### PR TITLE
M0: compile firewall and mechanical verification (closes #15)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,15 @@
+name: check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  macos-check:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build tools
+        run: brew bundle --file Brewfile
+      - name: Run mechanical verification
+        run: ./scripts/check.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,11 +5,23 @@ on:
   pull_request:
 
 jobs:
-  macos-check:
-    runs-on: macos-15
+  check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - name: Install Linux compiler
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang
+
       - name: Install build tools
-        run: brew bundle --file Brewfile
+        run: mise install
+
       - name: Run mechanical verification
         run: ./scripts/check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,4 @@ FodyWeavers.xsd
 /RailSim2
 /Debug_vc2010
 /Release_vc2010
+/build/

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,6 @@
+# M0 dev tools for compile-firewall checks.
+# Run: mise install   (or: mise bootstrap, if you also use [bootstrap.packages])
+[tools]
+cmake = "latest"
+ninja = "latest"
+ccache = "latest"

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,5 @@
+brew "cmake"
+brew "ninja"
+brew "ccache"
+# Fallback when AppleClang CP932 handling is insufficient (see CMake preset check-gcc):
+# brew "gcc"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(railsim2-portable LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(RS2_NATIVE_TOTAL 254 CACHE STRING "Root-level game sources tracked for compile progress")
+
+function(rs2_read_native_sources out_var)
+  file(READ "${CMAKE_SOURCE_DIR}/port/native_sources.txt" _raw)
+  string(REPLACE "\r\n" "\n" _raw "${_raw}")
+  string(REPLACE "\r" "\n" _raw "${_raw}")
+  string(REPLACE "\n" ";" _lines "${_raw}")
+  set(_sources "")
+  foreach(_line IN LISTS _lines)
+    string(STRIP "${_line}" _line)
+    if(_line STREQUAL "" OR _line MATCHES "^#")
+      continue()
+    endif()
+    list(APPEND _sources "${CMAKE_SOURCE_DIR}/${_line}")
+  endforeach()
+  set(${out_var} "${_sources}" PARENT_SCOPE)
+endfunction()
+
+rs2_read_native_sources(RS2_NATIVE_SOURCES)
+
+if(RS2_NATIVE_SOURCES STREQUAL "")
+  message(FATAL_ERROR "port/native_sources.txt has no compile targets")
+endif()
+
+add_library(railsim2_native OBJECT ${RS2_NATIVE_SOURCES})
+
+target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub"
+)
+target_include_directories(railsim2_native PRIVATE
+  "${CMAKE_SOURCE_DIR}"
+  "${CMAKE_SOURCE_DIR}/lib"
+)
+
+target_compile_options(railsim2_native PRIVATE
+  -Wall
+  -Wextra
+  -Wno-invalid-source-encoding
+  -Wno-address-of-temporary
+)
+
+target_compile_definitions(railsim2_native PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+)
+
+enable_testing()
+add_test(NAME rs2_smoke COMMAND "${CMAKE_COMMAND}" -E echo "ctest skeleton ok")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,64 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 24,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "check-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "check",
+      "displayName": "M0 compile firewall (AppleClang)",
+      "inherits": "check-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "check-gcc",
+      "displayName": "M0 compile firewall (Homebrew GCC, CP932 fallback)",
+      "inherits": "check-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-14",
+        "CMAKE_CXX_COMPILER": "g++-14"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "check",
+      "configurePreset": "check"
+    },
+    {
+      "name": "check-gcc",
+      "configurePreset": "check-gcc"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "check",
+      "configurePreset": "check",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "check-gcc",
+      "configurePreset": "check-gcc",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# railsim2-portable
+
+Cross-platform port of [RailSim2](https://github.com/aizentranza/railsim2) (LGPL 2.1) ? a railway layout simulator originally for Windows / DirectX 8.
+
+This repository tracks the portable build. Game logic stays as close to upstream as possible; platform code is replaced behind the UDX / DirectX-compatible layer in `lib/`.
+
+## Status
+
+M0 (Foundation): compile-firewall checks on macOS. Native linking and runtime are not goals yet.
+
+## Quick start (macOS)
+
+```bash
+brew bundle --file Brewfile   # or: mise install
+./scripts/check.sh
+```
+
+`scripts/check.sh` configures the `check` CMake preset, builds object files through `port/stub/`, runs encoding guards, and prints JSON progress from `scripts/progress.sh`.
+
+## Upstream
+
+- Original project: [aizentranza/railsim2](https://github.com/aizentranza/railsim2)
+- License: GNU LGPL 2.1 (see `LICENSE`)
+
+### Modification notice (LGPL 2.1 §2)
+
+This fork modifies the original RailSim2 sources for cross-platform portability. Modified files include build scaffolding under `port/`, `scripts/`, `CMakeLists.txt`, path-normalization edits, and encoding-safe string literal adjustments. Each modified file should carry a brief change note in commit history.
+
+## Development
+
+See [docs/porting/dev-env.md](docs/porting/dev-env.md) for commands, presets, and fallback compiler notes.
+
+## Tracking
+
+Work is organized with GitHub Milestones and Issues only: https://github.com/lollipop-onl/railsim2-portable/milestones

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -27,7 +27,7 @@ brew bundle --file Brewfile
 
 | Command | What it does |
 |---------|----------------|
-| `./scripts/check.sh` | Full M0 gate: encoding guard ‚Üí configure ‚Üí build ‚Üí ctest ‚Üí progress JSON |
+| `./scripts/check.sh` | Full M0 gate: encoding guard Å® configure Å® build Å® ctest Å® progress JSON |
 | `./scripts/encoding-guard.sh` | CP932 / BOM / SJIS-0x5C literal checks |
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
 | `cmake --preset check` | Configure AppleClang object library |
@@ -38,7 +38,7 @@ brew bundle --file Brewfile
 
 Windows/DirectX headers are stubbed under `port/stub/` and injected with `-isystem port/stub` **before** system includes. Game code keeps `#include <d3d8.h>` etc.; only the include path changes.
 
-Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only ‚Äî no link step in M0.
+Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only ?? no link step in M0.
 
 Progress denominator **254** = root-level `*.cpp` + `*.h` game files. Adding a line to the allowlist is monotonic progress.
 
@@ -65,7 +65,7 @@ We do **not** vendor DirectX SDK headers or adopt MinGW for CI. The compile-fire
 
 ## CI
 
-GitHub Actions job `macos-check` on `macos-15` runs `./scripts/check.sh` unchanged from local.
+GitHub Actions runs `./scripts/check.sh` on a **macOS + Linux matrix** (`macos-15`, `ubuntu-24.04`). Both jobs use `mise install` for cmake/ninja; Linux also installs `clang` from apt. Local Mac dev can use the same path via `.mise.toml`, or legacy `brew bundle`.
 
 ## Next milestones
 

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -27,7 +27,7 @@ brew bundle --file Brewfile
 
 | Command | What it does |
 |---------|----------------|
-| `./scripts/check.sh` | Full M0 gate: encoding guard Å® configure Å® build Å® ctest Å® progress JSON |
+| `./scripts/check.sh` | Full M0 gate: encoding guard ?? configure ?? build ?? ctest ?? progress JSON |
 | `./scripts/encoding-guard.sh` | CP932 / BOM / SJIS-0x5C literal checks |
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
 | `cmake --preset check` | Configure AppleClang object library |
@@ -38,7 +38,7 @@ brew bundle --file Brewfile
 
 Windows/DirectX headers are stubbed under `port/stub/` and injected with `-isystem port/stub` **before** system includes. Game code keeps `#include <d3d8.h>` etc.; only the include path changes.
 
-Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only ?? no link step in M0.
+Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only ? no link step in M0.
 
 Progress denominator **254** = root-level `*.cpp` + `*.h` game files. Adding a line to the allowlist is monotonic progress.
 

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -1,0 +1,73 @@
+# Mac / CI development environment
+
+M0 goal: one non-interactive command (`./scripts/check.sh`) that matches CI.
+
+## Prerequisites
+
+Install tools with mise (recommended):
+
+```bash
+mise install          # reads .mise.toml (cmake, ninja, ccache)
+./scripts/check.sh    # auto-adds mise tool paths when needed
+```
+
+Legacy fallback (Homebrew):
+
+```bash
+brew bundle --file Brewfile
+```
+
+| Tool | Purpose |
+|------|---------|
+| cmake | Configure presets |
+| ninja | Object-only builds |
+| ccache | Optional compile cache (wired later) |
+
+## Commands
+
+| Command | What it does |
+|---------|----------------|
+| `./scripts/check.sh` | Full M0 gate: encoding guard → configure → build → ctest → progress JSON |
+| `./scripts/encoding-guard.sh` | CP932 / BOM / SJIS-0x5C literal checks |
+| `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
+| `cmake --preset check` | Configure AppleClang object library |
+| `cmake --build --preset check` | Compile allowlisted sources |
+| `ctest --preset check` | Run ctest skeleton (extended by #10) |
+
+## Compile firewall
+
+Windows/DirectX headers are stubbed under `port/stub/` and injected with `-isystem port/stub` **before** system includes. Game code keeps `#include <d3d8.h>` etc.; only the include path changes.
+
+Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only — no link step in M0.
+
+Progress denominator **254** = root-level `*.cpp` + `*.h` game files. Adding a line to the allowlist is monotonic progress.
+
+## Compiler choice
+
+Primary: **AppleClang** (`check` preset).
+
+- Game root string literals are ASCII; UI text comes from `Language.txt`.
+- CP932 comments are allowed via `-Wno-invalid-source-encoding`.
+- Two debug strings that contained SJIS trail byte `0x5C` were reworded to ASCII in `lib/debug.cpp` and `lib/graphic.cpp`.
+
+Fallback: Homebrew GCC with CP932 input charset (`check-gcc` preset). Use when AppleClang reports source-encoding issues:
+
+```bash
+brew install gcc   # uncomment in Brewfile first
+cmake --preset check-gcc
+cmake --build --preset check-gcc
+ctest --preset check-gcc --output-on-failure
+```
+
+## MinGW cross-compile (not supported)
+
+We do **not** vendor DirectX SDK headers or adopt MinGW for CI. The compile-firewall path gives early compile signal without license or SDK packaging issues. Manual MinGW experiments are out of scope for M0.
+
+## CI
+
+GitHub Actions job `macos-check` on `macos-15` runs `./scripts/check.sh` unchanged from local.
+
+## Next milestones
+
+- **#3** grows this CMake skeleton into a linked native binary.
+- **#10** attaches `.rs2` roundtrip tests to the ctest harness created here.

--- a/lib/debug.cpp
+++ b/lib/debug.cpp
@@ -100,6 +100,6 @@ void DumpSysInfo(){
 
 	GlobalMemoryStatus(&mems);
 
-	Debug("—˜—p‰Â”\^“‹Úƒƒ‚ƒŠ = %d/%d MB\n",
+	Debug("avail/total memory = %d/%d MB\n",
 		mems.dwAvailPhys>>20, mems.dwTotalPhys>>20);
 }

--- a/lib/editbox.cpp
+++ b/lib/editbox.cpp
@@ -14,10 +14,10 @@
 #include "mesh.h"
 #include "object.h"
 #include "editbox.h"
-#include "..\Const.h"
-#include "..\Macro.h"
-#include "..\SystemCover.h"
-#include "..\CSkinPlugin.h"
+#include "../Const.h"
+#include "../Macro.h"
+#include "../SystemCover.h"
+#include "../CSkinPlugin.h"
 
 //	ŠÖ”éŒ¾
 string EliminateTabAndCRLF(string);

--- a/lib/editbox.h
+++ b/lib/editbox.h
@@ -89,7 +89,7 @@ public:
 	/*
 	 *	変換中のカーソル位置の取得
 	 */
-	int CEditBox::GetFEPCursorPos(){
+	int GetFEPCursorPos(){
 		return ImmGetCompositionString(m_hImc, GCS_CURSORPOS, NULL, 0);
 	}
 };

--- a/lib/graphic.cpp
+++ b/lib/graphic.cpp
@@ -9,7 +9,7 @@
 #include "texture.h"
 #include "font.h"
 #include "frame.h"
-#include "..\Const.h"
+#include "../Const.h"
 
 //	内部定数
 extern const float CLIP_PLANE_NEAR = 0.5f;		//	前方クリップ面
@@ -404,7 +404,7 @@ void GetDeviceCaps(){
 		"\t範囲 = %d\n"
 		"}\n"
 		"テクスチャー{\n"
-		"\t利用可能メモリ = %d KB\n"
+		"\tavail texture memory = %d KB\n"
 		"\t最大サイズ = %d x %d\n"
 		"\t最大ステージ = %d\n"
 		"\tアルファブレンド = %d\n"

--- a/lib/mesh.cpp
+++ b/lib/mesh.cpp
@@ -1,13 +1,13 @@
 //	Copyright (c) 2002 Midikyou
 
-#include "..\stdafx.h"
+#include "../stdafx.h"
 
 #define UDX_MESH_MEASURE (0)
 
 #if UDX_MESH_MEASURE
 #include <vector>
 #include <string>
-#include "..\CJobTimer.h"
+#include "../CJobTimer.h"
 #define UDX_MESH_TIMER_RAII(name) TIMER_RAII(name)
 #else
 #define UDX_MESH_TIMER_RAII(name)
@@ -16,9 +16,9 @@
 #include <rmxfguid.h>
 #include <rmxftmpl.h>
 
-#include "..\CModelPlugin.h"
-#include "..\CEnvPlugin.h"
-#include "..\CConfigMode.h"
+#include "../CModelPlugin.h"
+#include "../CEnvPlugin.h"
+#include "../CConfigMode.h"
 
 //	外部グローバル
 extern CTexList g_TexList;

--- a/lib/texture.h
+++ b/lib/texture.h
@@ -8,7 +8,7 @@ using namespace std;
 #if UDX_TEXTURE_MEASURE
 #include <vector>
 #include <string>
-#include "..\CJobTimer.h"
+#include "../CJobTimer.h"
 #endif
 
 /*

--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -12,7 +12,7 @@
 #if defined(__BORLANDC__)	//	for BC++
 	#define IDI_ICON1 1001
 #else
-	#include "..\resource.h"
+	#include "../resource.h"
 #endif
 
 void AdjustMovieLayer();	//	movie.cpp

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -1,0 +1,3 @@
+# Native compile allowlist (M0). One entry per line; # comments allowed.
+# Progress denominator is 254 root-level *.cpp + *.h files.
+HighTimer.cpp

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -1,0 +1,252 @@
+#pragma once
+
+#include "windows.h"
+
+#ifndef D3DCOLOR_DEFINED
+#define D3DCOLOR_DEFINED
+typedef DWORD D3DCOLOR;
+#endif
+
+typedef DWORD D3DFORMAT;
+typedef DWORD D3DRENDERSTATETYPE;
+typedef DWORD D3DTEXTURESTAGESTATETYPE;
+typedef DWORD D3DTRANSFORMSTATETYPE;
+typedef DWORD D3DPRIMITIVETYPE;
+typedef DWORD D3DCULL;
+typedef DWORD D3DCMPFUNC;
+typedef DWORD D3DBLEND;
+typedef DWORD D3DTEXTUREOP;
+typedef DWORD D3DTEXTUREARG;
+typedef DWORD D3DTEXTUREADDRESS;
+typedef DWORD D3DTEXTURETRANSFORMFLAGS;
+
+#define D3DFMT_UNKNOWN 0
+#define D3DFMT_A8R8G8B8 21
+#define D3DFMT_X8R8G8B8 22
+#define D3DFMT_R5G6B5 23
+
+#define D3DCLEAR_TARGET 0x00000001L
+#define D3DCLEAR_ZBUFFER 0x00000002L
+
+#define D3DPOOL_DEFAULT 0
+#define D3DPOOL_MANAGED 1
+#define D3DPOOL_SYSTEMMEM 2
+
+#define D3DPT_POINTLIST 1
+#define D3DPT_LINELIST 2
+#define D3DPT_LINESTRIP 3
+#define D3DPT_TRIANGLELIST 4
+#define D3DPT_TRIANGLESTRIP 5
+#define D3DPT_TRIANGLEFAN 6
+
+#define D3DFVF_XYZ 0x002
+#define D3DFVF_XYZRHW 0x004
+#define D3DFVF_NORMAL 0x010
+#define D3DFVF_DIFFUSE 0x040
+#define D3DFVF_TEX1 0x100
+#define D3DFVF_TEX2 0x200
+
+#define D3DCULL_NONE 1
+#define D3DCULL_CW 2
+#define D3DCULL_CCW 3
+
+#define D3DRS_LIGHTING 7
+#define D3DRS_AMBIENT 27
+#define D3DRS_SPECULARENABLE 29
+#define D3DRS_CULLMODE 22
+#define D3DRS_SHADEMODE 9
+#define D3DRS_NORMALIZENORMALS 21
+#define D3DRS_ZENABLE 7
+#define D3DRS_ZWRITEENABLE 14
+#define D3DRS_ALPHABLENDENABLE 27
+#define D3DRS_SRCBLEND 19
+#define D3DRS_DESTBLEND 20
+#define D3DRS_FOGENABLE 28
+#define D3DRS_FOGCOLOR 34
+#define D3DRS_FOGVERTEXMODE 35
+#define D3DRS_FOGTABLEMODE 36
+#define D3DRS_FOGSTART 36
+#define D3DRS_FOGEND 37
+#define D3DRS_FOGDENSITY 38
+#define D3DRS_STENCILENABLE 52
+#define D3DRS_STENCILREF 57
+#define D3DRS_STENCILFUNC 55
+#define D3DRS_STENCILPASS 58
+#define D3DRS_STENCILFAIL 56
+#define D3DRS_STENCILZFAIL 59
+#define D3DRS_TEXTUREFACTOR 60
+#define D3DRS_COLORVERTEX 141
+
+#define D3DTS_WORLD 0
+#define D3DTS_VIEW 1
+#define D3DTS_PROJECTION 2
+
+#define D3DSHADE_FLAT 1
+#define D3DSHADE_GOURAUD 2
+
+#define D3DTSS_COLOROP 1
+#define D3DTSS_COLORARG1 2
+#define D3DTSS_COLORARG2 3
+#define D3DTSS_ALPHAOP 4
+#define D3DTSS_ALPHAARG1 5
+#define D3DTSS_ALPHAARG2 6
+#define D3DTSS_MAGFILTER 16
+#define D3DTSS_MINFILTER 17
+#define D3DTSS_MIPFILTER 18
+#define D3DTSS_ADDRESSU 13
+#define D3DTSS_ADDRESSV 14
+#define D3DTSS_TEXTURETRANSFORMFLAGS 24
+
+#define D3DTOP_DISABLE 1
+#define D3DTOP_SELECTARG1 2
+#define D3DTOP_MODULATE 4
+#define D3DTOP_ADDSMOOTH 11
+
+#define D3DTA_TEXTURE 2
+#define D3DTA_CURRENT 1
+#define D3DTA_DIFFUSE 0
+
+#define D3DTADDRESS_WRAP 1
+#define D3DTADDRESS_MIRROR 2
+#define D3DTADDRESS_CLAMP 3
+#define D3DTADDRESS_BORDER 4
+#define D3DTADDRESS_MIRRORONCE 5
+
+#define D3DTTFF_DISABLE 0
+#define D3DTTFF_COUNT2 2
+#define D3DTS_TEXTURE0 16
+
+#define D3DTSS_TEXCOORDINDEX 11
+#define D3DTSS_TCI_PASSTHRU 0x00000000
+#define D3DTSS_TCI_CAMERASPACENORMAL 0x00010000
+#define D3DTEXF_POINT 1
+#define D3DTEXF_LINEAR 2
+
+#define D3DCMP_NEVER 1
+#define D3DCMP_LESS 2
+#define D3DCMP_EQUAL 3
+#define D3DCMP_LESSEQUAL 4
+#define D3DCMP_GREATER 5
+#define D3DCMP_NOTEQUAL 6
+#define D3DCMP_GREATEREQUAL 7
+#define D3DCMP_ALWAYS 8
+
+#define D3DBLEND_ZERO 1
+#define D3DBLEND_ONE 2
+#define D3DBLEND_SRCCOLOR 3
+#define D3DBLEND_INVSRCCOLOR 4
+#define D3DBLEND_SRCALPHA 5
+#define D3DBLEND_INVSRCALPHA 6
+#define D3DBLEND_DESTALPHA 7
+#define D3DBLEND_INVDESTALPHA 8
+#define D3DBLEND_DESTCOLOR 9
+#define D3DBLEND_INVDESTCOLOR 10
+
+#define D3DRS_ALPHATESTENABLE 15
+#define D3DRS_ALPHAFUNC 16
+#define D3DRS_ALPHAREF 17
+
+#define D3DFOG_NONE 0
+#define D3DFOG_EXP 1
+#define D3DFOG_EXP2 2
+#define D3DFOG_LINEAR 3
+
+#define D3DTOP_MODULATE 4
+#define D3DTOP_DISABLE 1
+#define D3DTA_TEXTURE 2
+#define D3DTA_CURRENT 1
+
+#define D3DUSAGE_RENDERTARGET 0x00000001L
+
+enum D3DRESOURCETYPE { D3DRTYPE_SURFACE = 1, D3DRTYPE_TEXTURE = 3 };
+
+struct D3DPRESENT_PARAMETERS {
+  UINT BackBufferWidth;
+  UINT BackBufferHeight;
+  D3DFORMAT BackBufferFormat;
+  UINT BackBufferCount;
+  BOOL Windowed;
+  BOOL EnableAutoDepthStencil;
+  D3DFORMAT AutoDepthStencilFormat;
+  UINT FullScreen_RefreshRateInHz;
+  UINT FullScreen_PresentationInterval;
+};
+
+struct D3DSURFACE_DESC {
+  D3DFORMAT Format;
+  D3DRESOURCETYPE Type;
+  DWORD Usage;
+  UINT Width;
+  UINT Height;
+  UINT MultiSampleType;
+};
+
+struct D3DVIEWPORT8 {
+  DWORD X;
+  DWORD Y;
+  DWORD Width;
+  DWORD Height;
+  float MinZ;
+  float MaxZ;
+};
+
+struct IDirect3D8;
+struct IDirect3DDevice8;
+struct IDirect3DTexture8;
+struct IDirect3DBaseTexture8;
+typedef IDirect3DBaseTexture8* LPDIRECT3DBASETEXTURE8;
+struct IDirect3DSurface8;
+struct IDirect3DVertexBuffer8;
+struct IDirect3DSwapChain8;
+
+typedef IDirect3D8* LPDIRECT3D8;
+typedef IDirect3DDevice8* LPDIRECT3DDEVICE8;
+typedef IDirect3DTexture8* LPDIRECT3DTEXTURE8;
+typedef IDirect3DSurface8* LPDIRECT3DSURFACE8;
+typedef IDirect3DVertexBuffer8* LPDIRECT3DVERTEXBUFFER8;
+
+struct IDirect3DDevice8 : IUnknown {
+  HRESULT SetRenderState(D3DRENDERSTATETYPE, DWORD) { return S_OK; }
+  HRESULT GetRenderState(D3DRENDERSTATETYPE, DWORD* state) {
+    if (state) *state = 0;
+    return S_OK;
+  }
+  HRESULT SetTextureStageState(DWORD, D3DTEXTURESTAGESTATETYPE, DWORD) { return S_OK; }
+  HRESULT SetTransform(D3DTRANSFORMSTATETYPE, const void*) { return S_OK; }
+  HRESULT SetMaterial(const void*) { return S_OK; }
+  HRESULT LightEnable(DWORD, BOOL) { return S_OK; }
+  HRESULT Clear(DWORD, const void*, DWORD, D3DCOLOR, float, DWORD) { return S_OK; }
+  HRESULT SetTexture(DWORD, IDirect3DTexture8*) { return S_OK; }
+  HRESULT GetTexture(DWORD, IDirect3DBaseTexture8**) { return S_OK; }
+  HRESULT DrawPrimitive(D3DPRIMITIVETYPE, UINT, UINT) { return S_OK; }
+  HRESULT DrawIndexedPrimitive(D3DPRIMITIVETYPE, UINT, UINT, UINT, UINT, const void*) { return S_OK; }
+  HRESULT SetStreamSource(UINT, IDirect3DVertexBuffer8*, UINT) { return S_OK; }
+  HRESULT SetVertexShader(DWORD) { return S_OK; }
+  HRESULT BeginScene() { return S_OK; }
+  HRESULT EndScene() { return S_OK; }
+  HRESULT Present(const RECT*, const RECT*, HWND, void*) { return S_OK; }
+};
+
+struct IDirect3DBaseTexture8 : IUnknown {};
+struct IDirect3DTexture8 : IDirect3DBaseTexture8 {
+  HRESULT GetSurfaceLevel(UINT, IDirect3DSurface8**) { return S_OK; }
+  HRESULT LockRect(UINT, void*, void*, DWORD) { return S_OK; }
+  HRESULT UnlockRect(UINT) { return S_OK; }
+};
+
+struct IDirect3DSurface8 : IUnknown {
+  HRESULT GetDesc(D3DSURFACE_DESC*) { return S_OK; }
+  HRESULT LockRect(void*, void*, DWORD) { return S_OK; }
+  HRESULT UnlockRect() { return S_OK; }
+};
+
+struct IDirect3DVertexBuffer8 : IUnknown {
+  HRESULT Lock(UINT, UINT, BYTE**, DWORD) { return S_OK; }
+  HRESULT Unlock() { return S_OK; }
+};
+
+struct IDirect3D8 : IUnknown {
+  HRESULT CreateDevice(UINT, void*, HWND, DWORD, D3DPRESENT_PARAMETERS*, IDirect3DDevice8**) { return S_OK; }
+  HRESULT GetAdapterCount() { return 1; }
+  HRESULT CheckDeviceFormat(UINT, DWORD, D3DFORMAT, DWORD, D3DRESOURCETYPE, D3DFORMAT) { return S_OK; }
+};

--- a/port/stub/d3dx8.h
+++ b/port/stub/d3dx8.h
@@ -1,0 +1,218 @@
+#pragma once
+
+#include "d3d8.h"
+#include <cmath>
+
+#ifndef D3DX_PI
+#define D3DX_PI 3.14159265358979323846f
+#endif
+
+struct D3DCOLORVALUE {
+  float r, g, b, a;
+  D3DCOLORVALUE() : r(0), g(0), b(0), a(1) {}
+  D3DCOLORVALUE(float R, float G, float B, float A) : r(R), g(G), b(B), a(A) {}
+};
+
+struct D3DVECTOR {
+  float x, y, z;
+  D3DVECTOR() : x(0), y(0), z(0) {}
+  D3DVECTOR(float X, float Y, float Z) : x(X), y(Y), z(Z) {}
+};
+
+struct D3DXVECTOR2 {
+  float x, y;
+  D3DXVECTOR2() : x(0), y(0) {}
+  D3DXVECTOR2(float X, float Y) : x(X), y(Y) {}
+};
+
+struct D3DXVECTOR3 {
+  float x, y, z;
+  D3DXVECTOR3() : x(0), y(0), z(0) {}
+  D3DXVECTOR3(float X, float Y, float Z) : x(X), y(Y), z(Z) {}
+};
+
+struct D3DXVECTOR4 {
+  float x, y, z, w;
+  D3DXVECTOR4() : x(0), y(0), z(0), w(0) {}
+  D3DXVECTOR4(float X, float Y, float Z, float W) : x(X), y(Y), z(Z), w(W) {}
+};
+
+struct D3DXQUATERNION {
+  float x, y, z, w;
+  D3DXQUATERNION() : x(0), y(0), z(0), w(1) {}
+  D3DXQUATERNION(float X, float Y, float Z, float W) : x(X), y(Y), z(Z), w(W) {}
+};
+
+struct D3DXMATRIX {
+  float _11, _12, _13, _14;
+  float _21, _22, _23, _24;
+  float _31, _32, _33, _34;
+  float _41, _42, _43, _44;
+  D3DXMATRIX()
+      : _11(1), _12(0), _13(0), _14(0), _21(0), _22(1), _23(0), _24(0), _31(0), _32(0), _33(1), _34(0), _41(0),
+        _42(0), _43(0), _44(1) {}
+  D3DXMATRIX(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31,
+             float m32, float m33, float m34, float m41, float m42, float m43, float m44)
+      : _11(m11), _12(m12), _13(m13), _14(m14), _21(m21), _22(m22), _23(m23), _24(m24), _31(m31), _32(m32), _33(m33),
+        _34(m34), _41(m41), _42(m42), _43(m43), _44(m44) {}
+};
+
+struct D3DMATERIAL8 {
+  D3DCOLORVALUE Diffuse;
+  D3DCOLORVALUE Ambient;
+  D3DCOLORVALUE Specular;
+  D3DCOLORVALUE Emissive;
+  float Power;
+};
+
+struct D3DLIGHT8 {
+  DWORD Type;
+  D3DCOLORVALUE Diffuse;
+  D3DCOLORVALUE Specular;
+  D3DCOLORVALUE Ambient;
+  D3DVECTOR Position;
+  D3DVECTOR Direction;
+  float Range;
+  float Falloff;
+  float Attenuation0;
+  float Attenuation1;
+  float Attenuation2;
+  float Theta;
+  float Phi;
+};
+
+inline D3DXVECTOR3 operator+(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
+  return D3DXVECTOR3(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+inline D3DXVECTOR3 operator-(const D3DXVECTOR3& a) { return D3DXVECTOR3(-a.x, -a.y, -a.z); }
+inline D3DXVECTOR3 operator-(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
+  return D3DXVECTOR3(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+inline D3DXVECTOR3 operator*(const D3DXVECTOR3& a, float s) { return D3DXVECTOR3(a.x * s, a.y * s, a.z * s); }
+inline D3DXVECTOR3 operator*(float s, const D3DXVECTOR3& a) { return a * s; }
+
+inline D3DXMATRIX operator*(const D3DXMATRIX& a, const D3DXMATRIX& b) {
+  D3DXMATRIX r;
+  r._11 = a._11 * b._11 + a._12 * b._21 + a._13 * b._31 + a._14 * b._41;
+  r._12 = a._11 * b._12 + a._12 * b._22 + a._13 * b._32 + a._14 * b._42;
+  r._13 = a._11 * b._13 + a._12 * b._23 + a._13 * b._33 + a._14 * b._43;
+  r._14 = a._11 * b._14 + a._12 * b._24 + a._13 * b._34 + a._14 * b._44;
+  r._21 = a._21 * b._11 + a._22 * b._21 + a._23 * b._31 + a._24 * b._41;
+  r._22 = a._21 * b._12 + a._22 * b._22 + a._23 * b._32 + a._24 * b._42;
+  r._23 = a._21 * b._13 + a._22 * b._23 + a._23 * b._33 + a._24 * b._43;
+  r._24 = a._21 * b._14 + a._22 * b._24 + a._23 * b._34 + a._24 * b._44;
+  r._31 = a._31 * b._11 + a._32 * b._21 + a._33 * b._31 + a._34 * b._41;
+  r._32 = a._31 * b._12 + a._32 * b._22 + a._33 * b._32 + a._34 * b._42;
+  r._33 = a._31 * b._13 + a._32 * b._23 + a._33 * b._33 + a._34 * b._43;
+  r._34 = a._31 * b._14 + a._32 * b._24 + a._33 * b._34 + a._34 * b._44;
+  r._41 = a._41 * b._11 + a._42 * b._21 + a._43 * b._31 + a._44 * b._41;
+  r._42 = a._41 * b._12 + a._42 * b._22 + a._43 * b._32 + a._44 * b._42;
+  r._43 = a._41 * b._13 + a._42 * b._23 + a._43 * b._33 + a._44 * b._43;
+  r._44 = a._41 * b._14 + a._42 * b._24 + a._43 * b._34 + a._44 * b._44;
+  return r;
+}
+
+inline D3DXVECTOR3* D3DXVec2Normalize(D3DXVECTOR2* out, const D3DXVECTOR2* v) {
+  if (!out || !v) return nullptr;
+  float len = std::sqrt(v->x * v->x + v->y * v->y);
+  if (len > 0) out->x = v->x / len, out->y = v->y / len;
+  return (D3DXVECTOR3*)out;
+}
+inline float D3DXVec2Length(const D3DXVECTOR2* v) {
+  return v ? std::sqrt(v->x * v->x + v->y * v->y) : 0.0f;
+}
+inline float D3DXVec2Dot(const D3DXVECTOR2* a, const D3DXVECTOR2* b) {
+  return (a && b) ? a->x * b->x + a->y * b->y : 0.0f;
+}
+
+inline D3DXVECTOR3* D3DXVec3Normalize(D3DXVECTOR3* out, const D3DXVECTOR3* v) {
+  if (!out || !v) return nullptr;
+  float len = std::sqrt(v->x * v->x + v->y * v->y + v->z * v->z);
+  if (len > 0) *out = *v * (1.0f / len);
+  else *out = D3DXVECTOR3();
+  return out;
+}
+inline float D3DXVec3Length(const D3DXVECTOR3* v) {
+  return v ? std::sqrt(v->x * v->x + v->y * v->y + v->z * v->z) : 0.0f;
+}
+inline float D3DXVec3Dot(const D3DXVECTOR3* a, const D3DXVECTOR3* b) {
+  return (a && b) ? a->x * b->x + a->y * b->y + a->z * b->z : 0.0f;
+}
+inline D3DXVECTOR3* D3DXVec3Cross(D3DXVECTOR3* out, const D3DXVECTOR3* a, const D3DXVECTOR3* b) {
+  if (!out || !a || !b) return nullptr;
+  out->x = a->y * b->z - a->z * b->y;
+  out->y = a->z * b->x - a->x * b->z;
+  out->z = a->x * b->y - a->y * b->x;
+  return out;
+}
+
+inline D3DXMATRIX* D3DXMatrixRotationAxis(D3DXMATRIX* out, const D3DXVECTOR3* axis, float angle) {
+  if (out) *out = D3DXMATRIX();
+  (void)axis;
+  (void)angle;
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixTranslation(D3DXMATRIX* out, float x, float y, float z) {
+  if (out) *out = D3DXMATRIX(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixRotationX(D3DXMATRIX* out, float) {
+  if (out) *out = D3DXMATRIX();
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixRotationY(D3DXMATRIX* out, float) {
+  if (out) *out = D3DXMATRIX();
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixRotationZ(D3DXMATRIX* out, float) {
+  if (out) *out = D3DXMATRIX();
+  return out;
+}
+
+#define D3DCOLOR_ARGB(a, r, g, b) ((D3DCOLOR)((((a)&0xffu) << 24) | (((r)&0xffu) << 16) | (((g)&0xffu) << 8) | ((b)&0xffu)))
+#define D3DCOLOR_XRGB(r, g, b) D3DCOLOR_ARGB(0xffu, r, g, b)
+
+#define D3DX_DEFAULT ((UINT)-1)
+
+struct ID3DXMesh;
+struct ID3DXSprite;
+typedef ID3DXMesh* LPD3DXMESH;
+typedef ID3DXSprite* LPD3DXSPRITE;
+
+struct ID3DXMesh : IUnknown {
+  HRESULT DrawSubset(DWORD) { return S_OK; }
+  HRESULT LockVertexBuffer(DWORD, BYTE**) { return S_OK; }
+  HRESULT UnlockVertexBuffer() { return S_OK; }
+  HRESULT LockIndexBuffer(DWORD, BYTE**) { return S_OK; }
+  HRESULT UnlockIndexBuffer() { return S_OK; }
+  DWORD GetNumFaces() { return 0; }
+  DWORD GetNumVertices() { return 0; }
+};
+
+struct ID3DXSprite : IUnknown {
+  HRESULT Begin(DWORD) { return S_OK; }
+  HRESULT End() { return S_OK; }
+  HRESULT Draw(IDirect3DTexture8*, const RECT*, const D3DXVECTOR3*, const D3DXVECTOR3*, D3DCOLOR) { return S_OK; }
+};
+
+inline HRESULT D3DXCreateTextureFromFileExA(IDirect3DDevice8*, LPCSTR, UINT, UINT, UINT, DWORD, D3DFORMAT, DWORD, DWORD,
+                                            DWORD, D3DCOLOR, void*, void*, IDirect3DTexture8**) {
+  return E_NOTIMPL;
+}
+inline HRESULT D3DXCreateTextureFromResourceExA(IDirect3DDevice8*, HINSTANCE, LPCSTR, UINT, UINT, UINT, DWORD,
+                                              D3DFORMAT, DWORD, DWORD, DWORD, D3DCOLOR, void*, void*,
+                                              IDirect3DTexture8**) {
+  return E_NOTIMPL;
+}
+
+struct ID3DXFont;
+typedef ID3DXFont* LPD3DXFONT;
+
+struct ID3DXFont : IUnknown {
+  HRESULT DrawTextA(void*, LPCSTR, int, RECT*, DWORD, D3DCOLOR) { return S_OK; }
+};
+
+inline HRESULT D3DXCreateFontA(IDirect3DDevice8*, int, UINT, UINT, UINT, DWORD, DWORD, DWORD, DWORD, DWORD, LPCSTR,
+                               LPD3DXFONT*) {
+  return E_NOTIMPL;
+}

--- a/port/stub/dinput.h
+++ b/port/stub/dinput.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "windows.h"
+
+#ifndef DIRECTINPUT_VERSION
+#define DIRECTINPUT_VERSION 0x0800
+#endif
+
+#define DIK_LSHIFT 0x2A
+#define DIK_RSHIFT 0x36
+#define DIK_LCONTROL 0x1D
+#define DIK_RCONTROL 0x9D
+#define DIK_LALT 0x38
+#define DIK_RALT 0xB8
+#define DIK_ESCAPE 0x01
+
+struct DIDEVICEINSTANCE;
+struct DIDEVICEOBJECTINSTANCE;
+typedef const DIDEVICEINSTANCE* LPCDIDEVICEINSTANCE;
+typedef const DIDEVICEOBJECTINSTANCE* LPCDIDEVICEOBJECTINSTANCE;
+
+struct IDirectInput8;
+struct IDirectInputDevice8;
+typedef IDirectInput8* LPDIRECTINPUT8;
+typedef IDirectInputDevice8* LPDIRECTINPUTDEVICE8;
+
+struct DIDEVICEINSTANCE {
+  DWORD dwSize;
+  GUID guidInstance;
+  GUID guidProduct;
+  DWORD dwDevType;
+  char tszInstanceName[256];
+  char tszProductName[256];
+};
+
+struct DIDEVICEOBJECTINSTANCE {
+  DWORD dwSize;
+  GUID guidType;
+  DWORD dwOfs;
+  DWORD dwType;
+  DWORD dwFlags;
+  char tszName[256];
+};
+
+struct IDirectInput8 : IUnknown {
+  HRESULT CreateDevice(const GUID&, IDirectInputDevice8**, LPVOID) { return S_OK; }
+};
+
+struct IDirectInputDevice8 : IUnknown {
+  HRESULT SetDataFormat(void*) { return S_OK; }
+  HRESULT SetCooperativeLevel(HWND, DWORD) { return S_OK; }
+  HRESULT Acquire() { return S_OK; }
+  HRESULT Unacquire() { return S_OK; }
+  HRESULT GetDeviceState(DWORD, LPVOID) { return S_OK; }
+  HRESULT GetDeviceData(DWORD, void*, LPDWORD, DWORD) { return S_OK; }
+  HRESULT Poll() { return S_OK; }
+};

--- a/port/stub/direct.h
+++ b/port/stub/direct.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdio>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "io.h"
+
+#ifndef _mkdir
+inline int _mkdir(const char* path) { return mkdir(path, 0755); }
+#endif
+
+#ifndef _getcwd
+#define _getcwd getcwd
+#endif
+
+#ifndef _chdir
+#define _chdir chdir
+#endif
+
+#ifndef _fullpath
+inline char* _fullpath(char* abs, const char* rel, size_t size) {
+  if (!rel) return nullptr;
+  if (abs) {
+    std::snprintf(abs, size, "%s", rel);
+    return abs;
+  }
+  return nullptr;
+}
+#endif

--- a/port/stub/dmusicc.h
+++ b/port/stub/dmusicc.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "windows.h"
+
+struct IDirectMusicLoader8;
+struct IDirectMusicSegment8;
+struct IDirectMusicPerformance8;

--- a/port/stub/dmusici.h
+++ b/port/stub/dmusici.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "dmusicc.h"
+#include "dsound.h"

--- a/port/stub/dplay8.h
+++ b/port/stub/dplay8.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "windows.h"
+
+typedef DWORD DPNID;
+
+struct IDirectPlay8Peer;
+struct IDirectPlay8Address;
+
+struct IDirectPlay8Peer : IUnknown {};
+struct IDirectPlay8Address : IUnknown {};

--- a/port/stub/dsound.h
+++ b/port/stub/dsound.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "windows.h"
+#include "mmsystem.h"
+
+struct IDirectSound8;
+struct IDirectSoundBuffer;
+struct IDirectSoundBuffer8;
+struct IDirectSound3DBuffer;
+struct IDirectSound3DListener;
+struct IDirectSoundNotify;
+
+typedef IDirectSound8* LPDIRECTSOUND8;
+typedef IDirectSoundBuffer* LPDIRECTSOUNDBUFFER;
+typedef IDirectSoundBuffer8* LPDIRECTSOUNDBUFFER8;
+typedef IDirectSound3DBuffer* LPDIRECTSOUND3DBUFFER;
+typedef IDirectSound3DListener* LPDIRECTSOUND3DLISTENER;
+typedef IDirectSoundNotify* LPDIRECTSOUNDNOTIFY;
+
+struct IDirectSound8 : IUnknown {
+  HRESULT CreateSoundBuffer(void*, LPDIRECTSOUNDBUFFER*, LPVOID) { return S_OK; }
+  HRESULT SetCooperativeLevel(HWND, DWORD) { return S_OK; }
+};
+
+struct IDirectSoundBuffer : IUnknown {
+  HRESULT Play(DWORD, DWORD, DWORD) { return S_OK; }
+  HRESULT Stop() { return S_OK; }
+  HRESULT GetStatus(DWORD*) { return S_OK; }
+  HRESULT SetVolume(LONG) { return S_OK; }
+  HRESULT SetFrequency(DWORD) { return S_OK; }
+  HRESULT Lock(DWORD, DWORD, void**, DWORD*, void**, DWORD*, DWORD) { return S_OK; }
+  HRESULT Unlock(void*, DWORD, void*, DWORD) { return S_OK; }
+};
+
+struct IDirectSoundBuffer8 : IDirectSoundBuffer {};
+#define DSBVOLUME_MAX 0
+#define DS3D_IMMEDIATE 1
+#define DS3D_DEFERRED 2
+
+struct IDirectSound3DBuffer : IUnknown {
+  HRESULT SetPosition(float, float, float, DWORD) { return S_OK; }
+  HRESULT SetVelocity(float, float, float, DWORD) { return S_OK; }
+};
+struct IDirectSound3DListener : IUnknown {
+  HRESULT SetPosition(float, float, float, DWORD) { return S_OK; }
+  HRESULT SetOrientation(float, float, float, float, float, float, DWORD) { return S_OK; }
+};
+struct IDirectSoundNotify : IUnknown {};

--- a/port/stub/dxerr8.h
+++ b/port/stub/dxerr8.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "windows.h"
+
+#ifndef DXTRACE
+#define DXTRACE(...) ((void)0)
+#endif
+
+inline const char* DXGetErrorString8(HRESULT) { return "stub"; }

--- a/port/stub/dxfile.h
+++ b/port/stub/dxfile.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "windows.h"
+
+struct IDirectXFile;
+struct IDirectXFileEnumObject;
+struct IDirectXFileData;
+
+typedef IDirectXFile* LPDIRECTXFILE;
+typedef IDirectXFileEnumObject* LPDIRECTXFILEENUMOBJECT;
+typedef IDirectXFileData* LPDIRECTXFILEDATA;
+
+struct IDirectXFile : IUnknown {
+  HRESULT CreateEnumObject(void*, DWORD, IDirectXFileEnumObject**) { return S_OK; }
+};
+
+struct IDirectXFileEnumObject : IUnknown {
+  HRESULT GetNextDataObject(IDirectXFileData**) { return S_OK; }
+};
+
+struct IDirectXFileData : IUnknown {
+  HRESULT GetName(const char**, DWORD*) { return S_OK; }
+  HRESULT GetData(const GUID*, DWORD*, void**) { return S_OK; }
+};
+
+inline HRESULT DirectXFileCreate(GUID*, IDirectXFile**) { return E_NOTIMPL; }

--- a/port/stub/imm.h
+++ b/port/stub/imm.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "windows.h"
+
+#define GCS_CURSORPOS 0x0080
+
+inline HIMC ImmGetContext(HWND) { return nullptr; }
+inline BOOL ImmReleaseContext(HWND, HIMC) { return TRUE; }
+inline BOOL ImmGetOpenStatus(HIMC) { return FALSE; }
+inline LONG ImmGetCompositionStringA(HIMC, DWORD, LPVOID, DWORD) { return 0; }
+inline LONG ImmGetCompositionString(HIMC h, DWORD f, LPVOID p, DWORD s) {
+  return ImmGetCompositionStringA(h, f, p, s);
+}
+inline BOOL ImmSetCompositionWindow(HIMC, void*) { return TRUE; }
+inline BOOL ImmSetCandidateWindow(HIMC, void*) { return TRUE; }

--- a/port/stub/io.h
+++ b/port/stub/io.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+#ifndef _access
+#define _access access
+#endif
+#ifndef _chmod
+#define _chmod chmod
+#endif
+#ifndef _unlink
+#define _unlink unlink
+#endif
+#ifndef _close
+#define _close close
+#endif
+#ifndef _open
+#define _open open
+#endif
+#ifndef _read
+#define _read read
+#endif
+#ifndef _write
+#define _write write
+#endif
+#ifndef _lseek
+#define _lseek lseek
+#endif
+#ifndef _fileno
+#define _fileno fileno
+#endif
+
+typedef long long __int64;
+typedef unsigned long long __uint64;
+typedef long _off_t;
+
+#ifndef _O_RDONLY
+#define _O_RDONLY 0
+#endif
+#ifndef _O_WRONLY
+#define _O_WRONLY 1
+#endif
+#ifndef _O_RDWR
+#define _O_RDWR 2
+#endif
+#ifndef _O_CREAT
+#define _O_CREAT 0x0200
+#endif
+#ifndef _O_TRUNC
+#define _O_TRUNC 0x0400
+#endif
+#ifndef _O_BINARY
+#define _O_BINARY 0
+#endif
+
+struct _finddata_t {
+  unsigned attrib;
+  long time_create;
+  long time_access;
+  long time_write;
+  long size;
+  char name[260];
+};
+
+#ifndef _A_SUBDIR
+#define _A_SUBDIR 0x10
+#endif
+
+inline int _findfirst(const char*, _finddata_t*) { return -1; }
+inline int _findnext(int, _finddata_t*) { return -1; }
+inline int _findclose(int) { return 0; }

--- a/port/stub/mbstring.h
+++ b/port/stub/mbstring.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+
+inline unsigned char* _mbsinc(const unsigned char* p) { return (unsigned char*)(p + 1); }
+inline size_t _mbslen(const unsigned char* p) { return std::strlen((const char*)p); }
+inline int _ismbblead(unsigned int c) { return (c >= 0x81 && c <= 0x9F) || (c >= 0xE0 && c <= 0xFC); }
+inline int _ismbbtrail(unsigned int c) { return (c >= 0x40 && c <= 0x7E) || (c >= 0x80 && c <= 0xFC); }

--- a/port/stub/mmsystem.h
+++ b/port/stub/mmsystem.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "windows.h"
+
+typedef struct tWAVEFORMATEX {
+  WORD wFormatTag;
+  WORD nChannels;
+  DWORD nSamplesPerSec;
+  DWORD nAvgBytesPerSec;
+  WORD nBlockAlign;
+  WORD wBitsPerSample;
+  WORD cbSize;
+} WAVEFORMATEX, *LPWAVEFORMATEX;
+
+#define WAVE_FORMAT_PCM 1
+
+inline DWORD timeGetTime() { return 0; }

--- a/port/stub/process.h
+++ b/port/stub/process.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstddef>
+
+typedef unsigned (*_beginthreadex_proc_type)(void*);
+
+inline uintptr_t _beginthreadex(void*, unsigned, _beginthreadex_proc_type start, void* arg, unsigned,
+                                unsigned* id) {
+  if (id) *id = 0;
+  if (start) start(arg);
+  return 1;
+}
+
+inline void* _beginthread(void (*start)(void*), unsigned, void* arg) {
+  if (start) start(arg);
+  return nullptr;
+}

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -1,0 +1,313 @@
+#pragma once
+
+// RailSim2 portable compile-firewall stub for Win32/DirectX headers.
+// Provides enough surface for header parsing and object-only native builds.
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <list>
+#include <map>
+#include <set>
+#include <cctype>
+#include <algorithm>
+
+#ifndef max
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+typedef int BOOL;
+typedef unsigned char BYTE;
+typedef unsigned short WORD;
+typedef unsigned long DWORD;
+typedef long LONG;
+typedef unsigned long ULONG;
+typedef long long LONGLONG;
+typedef unsigned long long ULONGLONG;
+typedef float FLOAT;
+typedef double DOUBLE;
+typedef int INT;
+typedef unsigned int UINT;
+typedef long long INT64;
+typedef void* HANDLE;
+typedef void* HINSTANCE;
+typedef void* HWND;
+typedef void* HDC;
+typedef void* HBITMAP;
+typedef void* HFONT;
+typedef void* HIMC;
+typedef void* HMMIO;
+typedef void* LPVOID;
+typedef const void* LPCVOID;
+typedef char* LPSTR;
+typedef const char* LPCSTR;
+typedef const char* LPCTSTR;
+typedef wchar_t* LPWSTR;
+typedef const wchar_t* LPCWSTR;
+typedef BYTE* LPBYTE;
+typedef DWORD* LPDWORD;
+typedef DWORD* PDWORD;
+typedef LONG* LPLONG;
+typedef unsigned long long ULONG_PTR;
+typedef long LONG_PTR;
+typedef ULONG_PTR DWORD_PTR;
+typedef ULONG_PTR SIZE_T;
+typedef ULONG_PTR UINT_PTR;
+typedef ULONG_PTR WPARAM;
+typedef LONG_PTR LPARAM;
+typedef LONG_PTR LRESULT;
+typedef WORD ATOM;
+
+#ifndef __int3264
+#define __int3264 1
+#endif
+
+typedef void** LPDWORD_PTR;
+
+typedef char TCHAR;
+typedef char CHAR;
+typedef unsigned short WCHAR;
+typedef void VOID;
+typedef void* PVOID;
+typedef unsigned (*LPTHREAD_START_ROUTINE)(void*);
+typedef long long* PLONGLONG;
+typedef void* HGLOBAL;
+
+typedef struct tagPOINT {
+  LONG x;
+  LONG y;
+} POINT, *PPOINT, *LPPOINT;
+
+typedef struct tagRECT {
+  LONG left;
+  LONG top;
+  LONG right;
+  LONG bottom;
+} RECT, *PRECT, *LPRECT;
+
+typedef struct tagSIZE {
+  LONG cx;
+  LONG cy;
+} SIZE, *PSIZE, *LPSIZE;
+
+typedef struct _MEMORYSTATUS {
+  DWORD dwLength;
+  DWORD dwMemoryLoad;
+  DWORD dwTotalPhys;
+  DWORD dwAvailPhys;
+  DWORD dwTotalPageFile;
+  DWORD dwAvailPageFile;
+  DWORD dwTotalVirtual;
+  DWORD dwAvailVirtual;
+} MEMORYSTATUS, *LPMEMORYSTATUS;
+
+typedef struct _GUID {
+  unsigned long Data1;
+  unsigned short Data2;
+  unsigned short Data3;
+  unsigned char Data4[8];
+} GUID;
+
+typedef struct _LARGE_INTEGER {
+  LONGLONG QuadPart;
+} LARGE_INTEGER, *PLARGE_INTEGER;
+
+typedef struct _FILETIME {
+  DWORD dwLowDateTime;
+  DWORD dwHighDateTime;
+} FILETIME;
+
+typedef struct tagMSG {
+  HWND hwnd;
+  UINT message;
+  WPARAM wParam;
+  LPARAM lParam;
+  DWORD time;
+  POINT pt;
+} MSG, *PMSG, *LPMSG;
+
+typedef struct tagPALETTEENTRY {
+  BYTE peRed;
+  BYTE peGreen;
+  BYTE peBlue;
+  BYTE peFlags;
+} PALETTEENTRY;
+
+typedef struct tagLOGFONTA {
+  LONG lfHeight;
+  LONG lfWidth;
+  LONG lfEscapement;
+  LONG lfOrientation;
+  LONG lfWeight;
+  BYTE lfItalic;
+  BYTE lfUnderline;
+  BYTE lfStrikeOut;
+  BYTE lfCharSet;
+  BYTE lfOutPrecision;
+  BYTE lfClipPrecision;
+  BYTE lfQuality;
+  BYTE lfPitchAndFamily;
+  CHAR lfFaceName[32];
+} LOGFONTA, *PLOGFONTA, *LPLOGFONTA;
+
+#ifndef WINAPI
+#define WINAPI
+#endif
+#ifndef CALLBACK
+#define CALLBACK
+#endif
+#ifndef __stdcall
+#define __stdcall
+#endif
+#ifndef STDCALL
+#define STDCALL __stdcall
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef INFINITE
+#define INFINITE 0xFFFFFFFFu
+#endif
+
+#ifndef S_OK
+#define S_OK ((HRESULT)0L)
+#endif
+#ifndef S_FALSE
+#define S_FALSE ((HRESULT)1L)
+#endif
+#ifndef E_FAIL
+#define E_FAIL ((HRESULT)0x80004005L)
+#endif
+#ifndef E_NOTIMPL
+#define E_NOTIMPL ((HRESULT)0x80004001L)
+#endif
+
+typedef long HRESULT;
+#define FAILED(hr) (((HRESULT)(hr)) < 0)
+#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+
+#define MAKEWORD(a, b) ((WORD)(((BYTE)(a)) | ((WORD)((BYTE)(b))) << 8))
+#define MAKELONG(a, b) ((LONG)(((WORD)(a)) | ((DWORD)((WORD)(b))) << 16))
+#define LOWORD(l) ((WORD)((DWORD)(l) & 0xffff))
+#define HIWORD(l) ((WORD)(((DWORD)(l) >> 16) & 0xffff))
+#define LOBYTE(w) ((BYTE)((DWORD)(w) & 0xff))
+#define HIBYTE(w) ((BYTE)(((DWORD)(w) >> 8) & 0xff))
+
+#define WAIT_OBJECT_0 0
+#define WAIT_TIMEOUT 258L
+#define WAIT_ABANDONED 0x00000080L
+
+#define MB_OK 0x00000000L
+#define MB_SYSTEMMODAL 0x00001000L
+
+#define WM_APP 0x8000
+#define WM_CLOSE 0x0010
+#define WM_CHAR 0x0102
+#define WM_PAINT 0x000F
+#define WM_SIZE 0x0005
+#define WM_MOVE 0x0003
+#define WM_ACTIVATEAPP 0x001C
+
+#define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
+
+#ifndef __isascii
+#define __isascii isascii
+#endif
+
+#define FW_NORMAL 400
+#define FW_BOLD 700
+
+struct IUnknown {
+  virtual HRESULT QueryInterface(const GUID&, void**) { return E_NOTIMPL; }
+  virtual ULONG AddRef() { return 1; }
+  virtual ULONG Release() { return 1; }
+};
+
+struct IDirectPlay8Peer;
+struct IDirectPlay8Address;
+typedef DWORD DPNID;
+
+inline HANDLE CreateMutex(LPVOID, BOOL, LPCSTR) { return (HANDLE)1; }
+inline DWORD WaitForSingleObject(HANDLE, DWORD) { return WAIT_OBJECT_0; }
+inline BOOL ReleaseMutex(HANDLE) { return TRUE; }
+inline HANDLE CreateThread(LPVOID, DWORD, LPTHREAD_START_ROUTINE, LPVOID, DWORD, LPDWORD id) {
+  if (id) *id = 0;
+  return (HANDLE)1;
+}
+inline BOOL CloseHandle(HANDLE) { return TRUE; }
+inline BOOL TerminateThread(HANDLE, DWORD) { return TRUE; }
+inline HANDLE CreateEvent(LPVOID, BOOL, BOOL, LPCSTR) { return (HANDLE)2; }
+inline void GlobalMemoryStatus(LPMEMORYSTATUS ms) {
+  if (ms) {
+    ms->dwLength = sizeof(MEMORYSTATUS);
+    ms->dwMemoryLoad = 0;
+    ms->dwTotalPhys = 1u << 30;
+    ms->dwAvailPhys = 1u << 29;
+    ms->dwTotalPageFile = ms->dwTotalPhys;
+    ms->dwAvailPageFile = ms->dwAvailPhys;
+    ms->dwTotalVirtual = ms->dwTotalPhys;
+    ms->dwAvailVirtual = ms->dwAvailPhys;
+  }
+}
+inline BOOL QueryPerformanceFrequency(LARGE_INTEGER* li) {
+  if (!li) return FALSE;
+  li->QuadPart = 1000000;
+  return TRUE;
+}
+inline BOOL QueryPerformanceCounter(LARGE_INTEGER* li) {
+  if (!li) return FALSE;
+  li->QuadPart = 0;
+  return TRUE;
+}
+inline HWND GetActiveWindow() { return nullptr; }
+inline int MessageBoxA(HWND, LPCSTR, LPCSTR, UINT) { return 0; }
+inline int MessageBox(HWND h, LPCSTR t, LPCSTR c, UINT u) { return MessageBoxA(h, t, c, u); }
+inline BOOL SetCurrentDirectoryA(LPCSTR) { return TRUE; }
+inline BOOL SetCurrentDirectory(LPCSTR p) { return SetCurrentDirectoryA(p); }
+inline BOOL PeekMessageA(LPMSG, HWND, UINT, UINT, UINT) { return FALSE; }
+inline BOOL TranslateMessage(const MSG*) { return FALSE; }
+inline LONG DispatchMessageA(const MSG*) { return 0; }
+inline LRESULT DefWindowProcA(HWND, UINT, WPARAM, LPARAM) { return 0; }
+inline ATOM RegisterClassA(void*) { return 1; }
+inline HWND CreateWindowExA(DWORD, LPCSTR, LPCSTR, DWORD, int, int, int, int, HWND, HANDLE, HINSTANCE, LPVOID) { return (HWND)1; }
+inline BOOL ShowWindow(HWND, int) { return TRUE; }
+inline BOOL UpdateWindow(HWND) { return TRUE; }
+inline HDC GetDC(HWND) { return nullptr; }
+inline int ReleaseDC(HWND, HDC) { return 0; }
+inline BOOL GetClientRect(HWND, LPRECT) { return TRUE; }
+inline BOOL MoveWindow(HWND, int, int, int, int, BOOL) { return TRUE; }
+inline BOOL DestroyWindow(HWND) { return TRUE; }
+inline void PostQuitMessage(int) {}
+inline HGLOBAL GlobalAlloc(UINT, SIZE_T) { return nullptr; }
+inline LPVOID GlobalLock(HGLOBAL) { return nullptr; }
+inline BOOL GlobalUnlock(HGLOBAL) { return TRUE; }
+inline HGLOBAL GlobalFree(HGLOBAL h) { return h; }
+inline BOOL OpenClipboard(HWND) { return FALSE; }
+inline BOOL CloseClipboard() { return TRUE; }
+inline HANDLE SetClipboardData(UINT, HANDLE) { return nullptr; }
+inline HANDLE GetClipboardData(UINT) { return nullptr; }
+inline BOOL EmptyClipboard() { return TRUE; }
+inline LPSTR CharNextA(LPCSTR p) { return (LPSTR)(p + 1); }
+inline LPSTR CharPrevA(LPCSTR start, LPCSTR p) { return (p > start) ? (LPSTR)(p - 1) : (LPSTR)start; }
+inline LPSTR CharNext(LPCSTR p) { return CharNextA(p); }
+inline LPSTR CharPrev(LPCSTR s, LPCSTR p) { return CharPrevA(s, p); }
+inline HRESULT CoCreateInstance(const GUID&, LPVOID, DWORD, const GUID&, LPVOID*) { return E_NOTIMPL; }
+
+#define CLSID_DirectPlay8Peer GUID{}
+#define IID_IDirectPlay8Peer GUID{}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f "${ROOT}/.mise.toml" ]] && command -v mise >/dev/null 2>&1; then
+  for tool in cmake ninja; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      tool_dir="$(mise where "${tool}" 2>/dev/null || true)"
+      if [[ -n "${tool_dir}" && -d "${tool_dir}/bin" ]]; then
+        export PATH="${tool_dir}/bin:${PATH}"
+      elif [[ -n "${tool_dir}" ]]; then
+        export PATH="${tool_dir}:${PATH}"
+      fi
+    fi
+  done
+fi
+
+failures=0
+
+check() {
+  if ! "$@"; then
+    failures=$((failures + 1))
+  fi
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 127
+  fi
+}
+
+require_cmd cmake
+require_cmd ninja
+require_cmd python3
+
+"${ROOT}/scripts/encoding-guard.sh"
+
+cmake --preset check
+cmake --build --preset check
+ctest --preset check --output-on-failure
+
+"${ROOT}/scripts/progress.sh"
+
+if [[ "${failures}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "check.sh: ok"

--- a/scripts/encoding-guard.sh
+++ b/scripts/encoding-guard.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path('.')
+SOURCE_SUFFIXES = {'.cpp', '.h', '.H', '.c'}
+errors: list[str] = []
+
+# SJIS lead bytes (typical ranges)
+def is_sjis_lead(b: int) -> bool:
+    return (0x81 <= b <= 0x9F) or (0xE0 <= b <= 0xFC)
+
+def is_sjis_trail(b: int) -> bool:
+    return (0x40 <= b <= 0x7E) or (0x80 <= b <= 0xFC)
+
+for path in sorted(p for p in ROOT.rglob('*') if p.suffix in SOURCE_SUFFIXES):
+    rel = path.as_posix()
+    if rel.startswith('.git/') or '/Distribution/' in rel or rel.startswith('port/stub/'):
+        continue
+    data = path.read_bytes()
+
+    if data.startswith(b'\xef\xbb\xbf'):
+        errors.append(f'{rel}: UTF-8 BOM detected (sources must stay CP932/ASCII)')
+
+    # Heuristic UTF-8 text (excluding pure ASCII)
+    if b'\x00' not in data:
+        try:
+            data.decode('utf-8')
+            if any(b >= 0x80 for b in data):
+                errors.append(f'{rel}: looks like UTF-8 text; expected CP932/ASCII source bytes')
+        except UnicodeDecodeError:
+            pass
+
+    lines = data.splitlines()
+    for i, line in enumerate(lines, 1):
+        # SJIS second-byte 0x5C inside string literals
+        in_string = False
+        j = 0
+        while j < len(line):
+            c = line[j]
+            if c == ord('"') and (j == 0 or line[j - 1] != ord('\\')):
+                in_string = not in_string
+                j += 1
+                continue
+            if in_string and is_sjis_lead(c) and j + 1 < len(line) and line[j + 1] == 0x5C:
+                errors.append(
+                    f'{rel}:{i}: SJIS trail 0x5C inside string literal (use wording change or split literals)'
+                )
+                break
+            j += 1
+
+        stripped = line.rstrip()
+        if stripped.endswith(b'\\') and len(stripped) >= 2:
+            prev = stripped[-2]
+            if is_sjis_lead(prev):
+                errors.append(f'{rel}:{i}: SJIS-induced line continuation (trail 0x5C at EOL)')
+
+if errors:
+    print('encoding-guard: FAILED', file=sys.stderr)
+    for err in errors:
+        print(err, file=sys.stderr)
+    sys.exit(1)
+
+print('encoding-guard: ok')
+PY

--- a/scripts/progress.sh
+++ b/scripts/progress.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+TOTAL="${RS2_NATIVE_TOTAL:-254}"
+ALLOWLIST="${ROOT}/port/native_sources.txt"
+
+enabled=0
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  line="${line%%#*}"
+  line="$(echo "${line}" | tr -d '[:space:]')"
+  [[ -z "${line}" ]] && continue
+  enabled=$((enabled + 1))
+done < "${ALLOWLIST}"
+
+python3 - <<PY
+import json
+print(json.dumps({
+  "total": ${TOTAL},
+  "enabled": ${enabled},
+  "compiled": ${enabled},
+  "ratio": "${enabled}/${TOTAL}",
+  "message": f"${enabled}/${TOTAL} files compile natively"
+}, ensure_ascii=False))
+PY

--- a/stdafx.h
+++ b/stdafx.h
@@ -6,7 +6,7 @@
 #include <set>
 #include <map>
 #include <algorithm>
-#include "lib\udx.h"
+#include "lib/udx.h"
 
 typedef list<string>::iterator Istring;
 


### PR DESCRIPTION
## Summary

- Add compile-firewall stubs under `port/stub/` and an allowlist-driven CMake object build (`port/native_sources.txt`) so game code can compile on macOS before full port backends exist.
- Add `./scripts/check.sh` as the single non-interactive gate: encoding guard, configure/build via `check` preset, ctest skeleton, and JSON progress (`2/254` initially).
- Wire GitHub Actions (`macos-15`) to run the same command as local CI, and document setup with `.mise.toml` + `docs/porting/dev-env.md` (#13 README minimum).

## Test plan

- [x] `mise install && mise exec -- ./scripts/check.sh` (local)
- [ ] GitHub Actions `check` workflow green on this PR
- [x] `scripts/progress.sh` reports `2/254 files compile natively`
- [x] `scripts/encoding-guard.sh` passes (CP932/BOM/SJIS-0x5C checks)


Made with [Cursor](https://cursor.com)