### PR TITLE
License compliance and README (#13)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,51 @@
+RailSim II / railsim2-portable
+==============================
+
+Original work
+-------------
+
+  RailSim II
+  Copyright (C) 2003-2013 Intaanetto Teiryuujo (インターネット停留所)
+
+  Upstream source: https://github.com/aizentranza/railsim2
+  License: GNU Lesser General Public License version 2.1 (see LICENSE)
+
+This repository (railsim2-portable) is a modified work based on that upstream.
+
+Modifications (LGPL 2.1 section 2(b))
+------------------------------------
+
+Prominent change notices for files modified in this fork. Dates are
+commit dates (YYYY-MM-DD). New files added only by this fork (for example
+under port/, scripts/, docs/, and CMake scaffolding) are part of the
+modified work but are not listed as "changed upstream files".
+
+2026-08-24 -- M0 compile firewall and mechanical verification (#15 / #18)
+
+  Build / docs (new):
+    .github/workflows/check.yml, .mise.toml, Brewfile, CMakeLists.txt,
+    CMakePresets.json, README.md, docs/porting/dev-env.md,
+    port/native_sources.txt, port/stub/*, scripts/check.sh,
+    scripts/encoding-guard.sh, scripts/progress.sh
+
+  Modified upstream sources (minimal, portability only):
+    lib/debug.cpp       -- ASCII-safe debug string (SJIS 0x5C trail)
+    lib/editbox.cpp     -- backslash include paths -> /
+    lib/editbox.h       -- GetFEPCursorPos return type for Clang
+    lib/graphic.cpp     -- ASCII-safe debug string (SJIS 0x5C trail)
+    lib/mesh.cpp        -- backslash include paths -> /
+    lib/texture.h       -- backslash include paths -> /
+    lib/window.cpp      -- backslash include paths -> /
+    stdafx.h            -- backslash include path -> /
+
+2026-08-24 -- License compliance and README (#13)
+
+  New:
+    NOTICE, docs/porting/upstream.md
+  Updated:
+    README.md, docs/porting/dev-env.md (attribution, platforms, upstream
+    remote docs; fix mojibake in ASCII punctuation)
+
+Further changes must update this file (date + summary) and keep git
+history as the detailed record. Prefer leaving game logic untouched so
+diffs against upstream stay reviewable.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,72 @@
 # railsim2-portable
 
-Cross-platform port of [RailSim2](https://github.com/aizentranza/railsim2) (LGPL 2.1) ? a railway layout simulator originally for Windows / DirectX 8.
+Cross-platform port of [RailSim2](https://github.com/aizentranza/railsim2) (LGPL 2.1) -- a railway layout simulator originally for Windows / DirectX 8.
 
 This repository tracks the portable build. Game logic stays as close to upstream as possible; platform code is replaced behind the UDX / DirectX-compatible layer in `lib/`.
 
+## Credit
+
+RailSim II was created by **Intaanetto Teiryuujo** (インターネット停留所).
+
+- Copyright (C) 2003-2013 Intaanetto Teiryuujo
+- Upstream: [aizentranza/railsim2](https://github.com/aizentranza/railsim2)
+- License: GNU LGPL 2.1 (see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE))
+
+This fork exists to run that work on additional platforms. It is not an official release from the original author.
+
+## Platforms
+
+| Platform | Status |
+|----------|--------|
+| Windows (original DirectX 8) | Upstream / reference |
+| macOS | M0: compile-firewall only (object build via stubs) |
+| Linux | M0: same CI gate as macOS |
+| Web (WebAssembly) | Later (optional milestone) |
+
+Native linking, runtime bring-up, and a playable binary are **not** M0 goals.
+
 ## Status
 
-M0 (Foundation): compile-firewall checks on macOS. Native linking and runtime are not goals yet.
+M0 (Foundation): `./scripts/check.sh` green on macOS and Linux CI. Sources compile through `port/stub/` for an allowlisted subset (`port/native_sources.txt`). Full link and gameplay come in later milestones.
 
-## Quick start (macOS)
+## Quick start
 
 ```bash
-brew bundle --file Brewfile   # or: mise install
+mise install              # cmake, ninja, ccache from .mise.toml
+./scripts/check.sh        # encoding -> cmake -> build -> ctest -> progress JSON
+```
+
+Homebrew fallback on macOS:
+
+```bash
+brew bundle --file Brewfile
 ./scripts/check.sh
 ```
 
-`scripts/check.sh` configures the `check` CMake preset, builds object files through `port/stub/`, runs encoding guards, and prints JSON progress from `scripts/progress.sh`.
+Details: [docs/porting/dev-env.md](docs/porting/dev-env.md).
 
-## Upstream
+## Upstream remote
 
-- Original project: [aizentranza/railsim2](https://github.com/aizentranza/railsim2)
-- License: GNU LGPL 2.1 (see `LICENSE`)
+```bash
+git remote add upstream https://github.com/aizentranza/railsim2.git
+git fetch upstream
+```
 
-### Modification notice (LGPL 2.1 �2)
+Follow policy (when and how to take upstream changes): [docs/porting/upstream.md](docs/porting/upstream.md).
 
-This fork modifies the original RailSim2 sources for cross-platform portability. Modified files include build scaffolding under `port/`, `scripts/`, `CMakeLists.txt`, path-normalization edits, and encoding-safe string literal adjustments. Each modified file should carry a brief change note in commit history.
+## License and modification notice (LGPL 2.1 section 2)
+
+This project is a modified LGPL 2.1 work based on RailSim2.
+
+- Full license text: [`LICENSE`](LICENSE)
+- Copyright and change notices with dates: [`NOTICE`](NOTICE)
+- Git history remains the detailed record of each edit
+
+Modified upstream files so far are limited to path separators, encoding-safe debug strings, and a Clang-friendly declaration -- plus new port scaffolding under `port/`, `scripts/`, and CMake. Game logic is intentionally left alone so diffs against upstream stay small and reviewable.
 
 ## Development
 
-See [docs/porting/dev-env.md](docs/porting/dev-env.md) for commands, presets, and fallback compiler notes.
+See [docs/porting/dev-env.md](docs/porting/dev-env.md) for presets, the compile firewall, and CI notes.
 
 ## Tracking
 

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -27,7 +27,7 @@ brew bundle --file Brewfile
 
 | Command | What it does |
 |---------|----------------|
-| `./scripts/check.sh` | Full M0 gate: encoding guard ?? configure ?? build ?? ctest ?? progress JSON |
+| `./scripts/check.sh` | Full M0 gate: encoding guard -> configure -> build -> ctest -> progress JSON |
 | `./scripts/encoding-guard.sh` | CP932 / BOM / SJIS-0x5C literal checks |
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
 | `cmake --preset check` | Configure AppleClang object library |
@@ -38,7 +38,7 @@ brew bundle --file Brewfile
 
 Windows/DirectX headers are stubbed under `port/stub/` and injected with `-isystem port/stub` **before** system includes. Game code keeps `#include <d3d8.h>` etc.; only the include path changes.
 
-Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only ? no link step in M0.
+Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only -- no link step in M0.
 
 Progress denominator **254** = root-level `*.cpp` + `*.h` game files. Adding a line to the allowlist is monotonic progress.
 

--- a/docs/porting/upstream.md
+++ b/docs/porting/upstream.md
@@ -1,0 +1,48 @@
+# Upstream remote and follow policy
+
+## Remotes
+
+| Remote   | URL                                              | Role                                      |
+|----------|--------------------------------------------------|-------------------------------------------|
+| `origin` | `git@github.com:lollipop-onl/railsim2-portable.git` | This portable fork (default push/pull)  |
+| `upstream` | `https://github.com/aizentranza/railsim2.git`  | Original RailSim2 sources (lineage only)  |
+
+Add `upstream` once per clone (remotes are not committed):
+
+```bash
+git remote add upstream https://github.com/aizentranza/railsim2.git
+git fetch upstream
+```
+
+`upstream` is for attribution and historical comparison. The upstream project is not expected to receive further commits or tags, so there is no routine fetch / merge / tag-watch workflow.
+
+## Lineage
+
+Git history on this fork still contains the upstream drops:
+
+- `9c90bc9` Initial commit
+- `2662b8a` Version 2.12 source code
+- `2324375` Version 2.15 source code
+
+Port work starts after `2324375` (see `NOTICE` for modification dates).
+
+## Follow policy
+
+We do not track upstream for ongoing sync. The living rules are the **port strategies already decided for this fork**. When any of these change, update this section in the same change (do not leave stale strategy here).
+
+Current strategies:
+
+1. **Game logic stays close to upstream** -- prefer stubs / `lib/` backends over rewriting gameplay.
+2. **No MinGW and no vendored DirectX SDK** -- compile firewall via `port/stub/` instead.
+3. **Sources stay CP932 / ASCII** -- encoding-guard enforces; no mass UTF-8 conversion of game sources.
+4. **Progress is monotonic** via `port/native_sources.txt` (denominator 254).
+5. **Single gate** -- `./scripts/check.sh` is the local and CI truth for M0+.
+
+There is no separate denylist of "do not touch" paths. Scope is defined by the strategies above and by the active Milestone / Issue, not by a frozen exclusion list.
+
+## Related
+
+- License text: [`LICENSE`](../../LICENSE)
+- Change log for LGPL notices: [`NOTICE`](../../NOTICE)
+- Credit and overview: [`README.md`](../../README.md)
+- Dev environment: [`dev-env.md`](dev-env.md)


### PR DESCRIPTION
## Summary
- Expand README with original-author credit, platforms, build, and LGPL modification pointers
- Add `NOTICE` with dated change list for LGPL 2.1 §2(b)
- Document `upstream` remote and living port strategies in `docs/porting/upstream.md`
- GitHub repo description/topics already updated on the remote

## Test plan
- [ ] README / NOTICE / upstream.md render correctly on GitHub (UTF-8 Japanese credit)
- [ ] Third party can identify original project, license, and author from README alone
- [ ] No game sources or build scripts changed (docs-only PR)

Closes #13

Made with [Cursor](https://cursor.com)