### PR TITLE
CMake link skeleton and expanded compile allowlist (#3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ target_compile_options(railsim2_native PRIVATE
 
 target_compile_definitions(railsim2_native PRIVATE
   RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
 )
 
 # Link skeleton: POSIX main only. Allowlisted game objects compile into
@@ -60,6 +61,7 @@ add_executable(railsim2 port/native_entry.cpp)
 add_dependencies(railsim2 railsim2_native)
 target_compile_definitions(railsim2 PRIVATE
   RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
 )
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(RS2_NATIVE_SOURCES STREQUAL "")
   message(FATAL_ERROR "port/native_sources.txt has no compile targets")
 endif()
 
-add_library(railsim2_native OBJECT ${RS2_NATIVE_SOURCES})
+add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES})
 
 target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub"
@@ -49,6 +49,16 @@ target_compile_options(railsim2_native PRIVATE
 )
 
 target_compile_definitions(railsim2_native PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+)
+
+# Link skeleton: POSIX main only. Allowlisted game objects compile into
+# railsim2_native.a but are not linked yet — they still need udx globals
+# (sv3, g_frame, …) from lib/. SDL2 is not a check-preset dependency.
+# Win32 .rc is skipped; icons stay as files until a later loader.
+add_executable(railsim2 port/native_entry.cpp)
+add_dependencies(railsim2 railsim2_native)
+target_compile_definitions(railsim2 PRIVATE
   RS2_PORTABLE_COMPILE_FIREWALL=1
 )
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "check",
-      "displayName": "M0 compile firewall (AppleClang)",
+      "displayName": "Native compile + link skeleton (AppleClang)",
       "inherits": "check-base",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",

--- a/NOTICE
+++ b/NOTICE
@@ -46,6 +46,15 @@ modified work but are not listed as "changed upstream files".
     README.md, docs/porting/dev-env.md (attribution, platforms, upstream
     remote docs; fix mojibake in ASCII punctuation)
 
+2026-08-25 -- M1 CMake link skeleton (#3)
+
+  Build (new):
+    port/native_entry.cpp
+  Updated:
+    CMakeLists.txt, CMakePresets.json, port/native_sources.txt,
+    port/stub/* (D3D8 device methods, D3DX math, DIK_*, Win32 no-ops),
+    docs/porting/dev-env.md, README.md
+
 Further changes must update this file (date + summary) and keep git
 history as the detailed record. Prefer leaving game logic untouched so
 diffs against upstream stay reviewable.

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ This fork exists to run that work on additional platforms. It is not an official
 | Platform | Status |
 |----------|--------|
 | Windows (original DirectX 8) | Upstream / reference |
-| macOS | M0: compile-firewall only (object build via stubs) |
-| Linux | M0: same CI gate as macOS |
+| macOS | M1: compile allowlist + linked stub binary (`check` preset) |
+| Linux | M1: same CI gate as macOS |
 | Web (WebAssembly) | Later (optional milestone) |
 
-Native linking, runtime bring-up, and a playable binary are **not** M0 goals.
+Native linking, runtime bring-up, and a playable binary are **not** M0 goals. M1 links a stub `railsim2` executable; it does not start the game.
 
 ## Status
 
-M0 (Foundation): `./scripts/check.sh` green on macOS and Linux CI. Sources compile through `port/stub/` for an allowlisted subset (`port/native_sources.txt`). Full link and gameplay come in later milestones.
+M1 (Surface): `./scripts/check.sh` still green. `cmake --build --preset check` links `railsim2` (POSIX `main` in `port/native_entry.cpp`). Allowlist progress is `port/native_sources.txt` (see `scripts/progress.sh`). Gameplay is later milestones.
 
 ## Quick start
 

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -20,27 +20,31 @@ brew bundle --file Brewfile
 | Tool | Purpose |
 |------|---------|
 | cmake | Configure presets |
-| ninja | Object-only builds |
+| ninja | Native builds (objects + linked `railsim2` stub) |
 | ccache | Optional compile cache (wired later) |
 
 ## Commands
 
 | Command | What it does |
 |---------|----------------|
-| `./scripts/check.sh` | Full M0 gate: encoding guard -> configure -> build -> ctest -> progress JSON |
+| `./scripts/check.sh` | Gate: encoding guard -> configure -> build (link) -> ctest -> progress JSON |
 | `./scripts/encoding-guard.sh` | CP932 / BOM / SJIS-0x5C literal checks |
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
-| `cmake --preset check` | Configure AppleClang object library |
-| `cmake --build --preset check` | Compile allowlisted sources |
+| `cmake --preset check` | Configure AppleClang native target |
+| `cmake --build --preset check` | Compile allowlisted sources and link `railsim2` |
 | `ctest --preset check` | Run ctest skeleton (extended by #10) |
 
 ## Compile firewall
 
 Windows/DirectX headers are stubbed under `port/stub/` and injected with `-isystem port/stub` **before** system includes. Game code keeps `#include <d3d8.h>` etc.; only the include path changes.
 
-Native targets are listed in `port/native_sources.txt`. CMake reads this allowlist and builds an `OBJECT` library only -- no link step in M0.
+Native targets are listed in `port/native_sources.txt`. CMake compiles those into `railsim2_native.a` and links a stub `railsim2` from `port/native_entry.cpp` (`main` returns 0). Game objects are **not** linked into the executable yet; they still need udx globals from `lib/`. SDL2 is not required for the `check` preset.
 
 Progress denominator **254** = root-level `*.cpp` + `*.h` game files. Adding a line to the allowlist is monotonic progress.
+
+`stdafx.h` already parses through the stubs. Remaining root `.cpp` files fail mainly on **game header include-order** (`CTrain`, `CDragInterface`) and MSVC-only extra qualification -- not on missing D3D types. Do not rewrite those headers in M1.
+
+Win32 `.rc` is skipped on native. Icons stay as files until a later loader. Sources stay CP932 (M0 encoding-guard). `stdafx.h` already uses `lib/udx.h` with forward slashes.
 
 ## Compiler choice
 
@@ -69,5 +73,5 @@ GitHub Actions runs `./scripts/check.sh` on a **macOS + Linux matrix** (`macos-1
 
 ## Next milestones
 
-- **#3** grows this CMake skeleton into a linked native binary.
-- **#10** attaches `.rs2` roundtrip tests to the ctest harness created here.
+- **#10** attaches `.rs2` roundtrip tests to the ctest harness.
+- Backend / window bring-up uses SDL2 only when a `native` preset is added (see `adr-backend.md`); keep `check` stub-only.

--- a/port/native_entry.cpp
+++ b/port/native_entry.cpp
@@ -1,0 +1,5 @@
+// POSIX process entry. Upstream lib/main.cpp exposes WinMain only.
+// This file is always linked on the native target so the check preset
+// produces an executable (game startup is still WinMain / later M3).
+
+int main() { return 0; }

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -1,3 +1,32 @@
-# Native compile allowlist (M0). One entry per line; # comments allowed.
+# Native compile allowlist. One entry per line; # comments allowed.
 # Progress denominator is 254 root-level *.cpp + *.h files.
+# Remaining TUs fail on game include-order (CTrain / CDragInterface) or
+# extra qualification — not on missing D3D8 stubs. See docs/porting/dev-env.md.
+CCheckBox.cpp
+CCursor.cpp
+CCustomizer.cpp
+CEditCtrl.cpp
+CExpression.cpp
+CGroupBox.cpp
+CInterface.cpp
+CJobTimer.cpp
+CMiniButton.cpp
+CMultiStatic.cpp
+CPartsInst.cpp
+CPopMenu.cpp
+CPushButton.cpp
+CRadioButton.cpp
+CScrollBarV.cpp
+CSimpleDialog.cpp
+CStaticCtrl.cpp
+CStationEditMode.cpp
+CStringTexture.cpp
+CStructEditMode.cpp
+CTextureAnimation.cpp
+CVertexDump.cpp
 HighTimer.cpp
+Language.cpp
+Script.cpp
+WakeUp.cpp
+md5.cpp
+stdafx.cpp

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -143,6 +143,17 @@ typedef DWORD D3DTEXTURETRANSFORMFLAGS;
 #define D3DBLEND_INVDESTCOLOR 10
 
 #define D3DRS_ALPHATESTENABLE 15
+#define D3DRS_ZFUNC 23
+#define D3DRS_DIFFUSEMATERIALSOURCE 145
+#define D3DRS_AMBIENTMATERIALSOURCE 147
+#define D3DRS_STENCILWRITEMASK 58
+#define D3DRS_STENCILMASK 54
+#define D3DMCS_MATERIAL 0
+#define D3DMCS_COLOR1 1
+#define D3DLOCK_READONLY 0x00000010L
+#define D3DSTENCILOP_KEEP 1
+#define D3DSTENCILOP_REPLACE 3
+#define D3DCLEAR_STENCIL 0x00000004L
 #define D3DRS_ALPHAFUNC 16
 #define D3DRS_ALPHAREF 17
 
@@ -214,17 +225,34 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetTextureStageState(DWORD, D3DTEXTURESTAGESTATETYPE, DWORD) { return S_OK; }
   HRESULT SetTransform(D3DTRANSFORMSTATETYPE, const void*) { return S_OK; }
   HRESULT SetMaterial(const void*) { return S_OK; }
+  HRESULT SetLight(DWORD, const void*) { return S_OK; }
   HRESULT LightEnable(DWORD, BOOL) { return S_OK; }
   HRESULT Clear(DWORD, const void*, DWORD, D3DCOLOR, float, DWORD) { return S_OK; }
   HRESULT SetTexture(DWORD, IDirect3DTexture8*) { return S_OK; }
   HRESULT GetTexture(DWORD, IDirect3DBaseTexture8**) { return S_OK; }
   HRESULT DrawPrimitive(D3DPRIMITIVETYPE, UINT, UINT) { return S_OK; }
+  HRESULT DrawPrimitiveUP(D3DPRIMITIVETYPE, UINT, const void*, UINT) { return S_OK; }
   HRESULT DrawIndexedPrimitive(D3DPRIMITIVETYPE, UINT, UINT, UINT, UINT, const void*) { return S_OK; }
   HRESULT SetStreamSource(UINT, IDirect3DVertexBuffer8*, UINT) { return S_OK; }
   HRESULT SetVertexShader(DWORD) { return S_OK; }
   HRESULT BeginScene() { return S_OK; }
   HRESULT EndScene() { return S_OK; }
   HRESULT Present(const RECT*, const RECT*, HWND, void*) { return S_OK; }
+  HRESULT GetViewport(D3DVIEWPORT8*) { return S_OK; }
+  HRESULT SetViewport(const D3DVIEWPORT8*) { return S_OK; }
+  HRESULT CreateTexture(UINT, UINT, UINT, DWORD, D3DFORMAT, DWORD, IDirect3DTexture8**) { return S_OK; }
+  HRESULT CopyRects(IDirect3DSurface8*, const RECT*, UINT, IDirect3DSurface8*, const POINT*) { return S_OK; }
+  HRESULT GetDeviceCaps(void*) { return S_OK; }
+  HRESULT Reset(D3DPRESENT_PARAMETERS*) { return S_OK; }
+  HRESULT SetRenderTarget(IDirect3DSurface8*, IDirect3DSurface8*) { return S_OK; }
+  HRESULT GetRenderTarget(IDirect3DSurface8**) { return S_OK; }
+  HRESULT GetDepthStencilSurface(IDirect3DSurface8**) { return S_OK; }
+  HRESULT CreateVertexBuffer(UINT, DWORD, DWORD, DWORD, IDirect3DVertexBuffer8**) { return S_OK; }
+  HRESULT CreateImageSurface(UINT, UINT, D3DFORMAT, IDirect3DSurface8**) { return S_OK; }
+  HRESULT CreateDepthStencilSurface(UINT, UINT, D3DFORMAT, DWORD, IDirect3DSurface8**) { return S_OK; }
+  HRESULT TestCooperativeLevel() { return S_OK; }
+  HRESULT SetClipStatus(const void*) { return S_OK; }
+  DWORD GetAvailableTextureMem() { return 64u * 1024u * 1024u; }
 };
 
 struct IDirect3DBaseTexture8 : IUnknown {};
@@ -250,3 +278,14 @@ struct IDirect3D8 : IUnknown {
   HRESULT GetAdapterCount() { return 1; }
   HRESULT CheckDeviceFormat(UINT, DWORD, D3DFORMAT, DWORD, D3DRESOURCETYPE, D3DFORMAT) { return S_OK; }
 };
+
+#define D3D_SDK_VERSION 220
+#define D3DDEVTYPE_HAL 1
+#define D3DDEVTYPE_REF 2
+#define D3DCREATE_HARDWARE_VERTEXPROCESSING 0x00000040L
+#define D3DCREATE_SOFTWARE_VERTEXPROCESSING 0x00000020L
+
+inline IDirect3D8* Direct3DCreate8(UINT) {
+  static IDirect3D8 inst;
+  return &inst;
+}

--- a/port/stub/d3dx8.h
+++ b/port/stub/d3dx8.h
@@ -23,12 +23,47 @@ struct D3DXVECTOR2 {
   float x, y;
   D3DXVECTOR2() : x(0), y(0) {}
   D3DXVECTOR2(float X, float Y) : x(X), y(Y) {}
+  D3DXVECTOR2& operator+=(const D3DXVECTOR2& o) {
+    x += o.x;
+    y += o.y;
+    return *this;
+  }
+  D3DXVECTOR2& operator-=(const D3DXVECTOR2& o) {
+    x -= o.x;
+    y -= o.y;
+    return *this;
+  }
+  D3DXVECTOR2& operator*=(float s) {
+    x *= s;
+    y *= s;
+    return *this;
+  }
+  D3DXVECTOR2& operator/=(float s) { return *this *= (1.0f / s); }
 };
 
 struct D3DXVECTOR3 {
   float x, y, z;
   D3DXVECTOR3() : x(0), y(0), z(0) {}
   D3DXVECTOR3(float X, float Y, float Z) : x(X), y(Y), z(Z) {}
+  D3DXVECTOR3& operator+=(const D3DXVECTOR3& o) {
+    x += o.x;
+    y += o.y;
+    z += o.z;
+    return *this;
+  }
+  D3DXVECTOR3& operator-=(const D3DXVECTOR3& o) {
+    x -= o.x;
+    y -= o.y;
+    z -= o.z;
+    return *this;
+  }
+  D3DXVECTOR3& operator*=(float s) {
+    x *= s;
+    y *= s;
+    z *= s;
+    return *this;
+  }
+  D3DXVECTOR3& operator/=(float s) { return *this *= (1.0f / s); }
 };
 
 struct D3DXVECTOR4 {
@@ -81,6 +116,17 @@ struct D3DLIGHT8 {
   float Phi;
 };
 
+inline D3DXVECTOR2 operator+(const D3DXVECTOR2& a, const D3DXVECTOR2& b) {
+  return D3DXVECTOR2(a.x + b.x, a.y + b.y);
+}
+inline D3DXVECTOR2 operator-(const D3DXVECTOR2& a) { return D3DXVECTOR2(-a.x, -a.y); }
+inline D3DXVECTOR2 operator-(const D3DXVECTOR2& a, const D3DXVECTOR2& b) {
+  return D3DXVECTOR2(a.x - b.x, a.y - b.y);
+}
+inline D3DXVECTOR2 operator*(const D3DXVECTOR2& a, float s) { return D3DXVECTOR2(a.x * s, a.y * s); }
+inline D3DXVECTOR2 operator*(float s, const D3DXVECTOR2& a) { return a * s; }
+inline D3DXVECTOR2 operator/(const D3DXVECTOR2& a, float s) { return a * (1.0f / s); }
+
 inline D3DXVECTOR3 operator+(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
   return D3DXVECTOR3(a.x + b.x, a.y + b.y, a.z + b.z);
 }
@@ -90,6 +136,7 @@ inline D3DXVECTOR3 operator-(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
 }
 inline D3DXVECTOR3 operator*(const D3DXVECTOR3& a, float s) { return D3DXVECTOR3(a.x * s, a.y * s, a.z * s); }
 inline D3DXVECTOR3 operator*(float s, const D3DXVECTOR3& a) { return a * s; }
+inline D3DXVECTOR3 operator/(const D3DXVECTOR3& a, float s) { return a * (1.0f / s); }
 
 inline D3DXMATRIX operator*(const D3DXMATRIX& a, const D3DXMATRIX& b) {
   D3DXMATRIX r;
@@ -146,6 +193,29 @@ inline D3DXVECTOR3* D3DXVec3Cross(D3DXVECTOR3* out, const D3DXVECTOR3* a, const 
   return out;
 }
 
+inline D3DXVECTOR3* D3DXVec3TransformCoord(D3DXVECTOR3* out, const D3DXVECTOR3* v, const D3DXMATRIX* m) {
+  if (!out || !v || !m) return nullptr;
+  float x = v->x, y = v->y, z = v->z;
+  float w = m->_14 * x + m->_24 * y + m->_34 * z + m->_44;
+  if (w == 0.0f) w = 1.0f;
+  out->x = (m->_11 * x + m->_21 * y + m->_31 * z + m->_41) / w;
+  out->y = (m->_12 * x + m->_22 * y + m->_32 * z + m->_42) / w;
+  out->z = (m->_13 * x + m->_23 * y + m->_33 * z + m->_43) / w;
+  return out;
+}
+
+inline D3DXVECTOR3* D3DXVec3TransformNormal(D3DXVECTOR3* out, const D3DXVECTOR3* v, const D3DXMATRIX* m) {
+  if (!out || !v || !m) return nullptr;
+  float x = v->x, y = v->y, z = v->z;
+  out->x = m->_11 * x + m->_21 * y + m->_31 * z;
+  out->y = m->_12 * x + m->_22 * y + m->_32 * z;
+  out->z = m->_13 * x + m->_23 * y + m->_33 * z;
+  return out;
+}
+
+#define D3DXToRadian(deg) ((deg) * (D3DX_PI / 180.0f))
+#define D3DXToDegree(rad) ((rad) * (180.0f / D3DX_PI))
+
 inline D3DXMATRIX* D3DXMatrixRotationAxis(D3DXMATRIX* out, const D3DXVECTOR3* axis, float angle) {
   if (out) *out = D3DXMATRIX();
   (void)axis;
@@ -185,8 +255,11 @@ struct ID3DXMesh : IUnknown {
   HRESULT UnlockVertexBuffer() { return S_OK; }
   HRESULT LockIndexBuffer(DWORD, BYTE**) { return S_OK; }
   HRESULT UnlockIndexBuffer() { return S_OK; }
+  HRESULT LockAttributeBuffer(DWORD, DWORD**) { return S_OK; }
+  HRESULT UnlockAttributeBuffer() { return S_OK; }
   DWORD GetNumFaces() { return 0; }
   DWORD GetNumVertices() { return 0; }
+  DWORD GetFVF() { return 0; }
 };
 
 struct ID3DXSprite : IUnknown {
@@ -216,3 +289,79 @@ inline HRESULT D3DXCreateFontA(IDirect3DDevice8*, int, UINT, UINT, UINT, DWORD, 
                                LPD3DXFONT*) {
   return E_NOTIMPL;
 }
+
+inline HRESULT D3DXCreateFontIndirect(IDirect3DDevice8*, const void*, LPD3DXFONT*) { return E_NOTIMPL; }
+inline HRESULT D3DXCreateSprite(IDirect3DDevice8*, LPD3DXSPRITE*) { return E_NOTIMPL; }
+inline UINT D3DXGetFVFVertexSize(DWORD) { return 0; }
+
+inline D3DXMATRIX* D3DXMatrixIdentity(D3DXMATRIX* out) {
+  if (out) *out = D3DXMATRIX();
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixInverse(D3DXMATRIX* out, FLOAT*, const D3DXMATRIX* m) {
+  if (out && m) *out = *m;
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixLookAtLH(D3DXMATRIX* out, const D3DXVECTOR3*, const D3DXVECTOR3*, const D3DXVECTOR3*) {
+  return D3DXMatrixIdentity(out);
+}
+inline D3DXMATRIX* D3DXMatrixPerspectiveFovLH(D3DXMATRIX* out, FLOAT, FLOAT, FLOAT, FLOAT) {
+  return D3DXMatrixIdentity(out);
+}
+inline D3DXMATRIX* D3DXMatrixPerspectiveOffCenterLH(D3DXMATRIX* out, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT) {
+  return D3DXMatrixIdentity(out);
+}
+inline D3DXMATRIX* D3DXMatrixScaling(D3DXMATRIX* out, FLOAT x, FLOAT y, FLOAT z) {
+  if (out) *out = D3DXMATRIX(x, 0, 0, 0, 0, y, 0, 0, 0, 0, z, 0, 0, 0, 0, 1);
+  return out;
+}
+inline D3DXMATRIX* D3DXMatrixRotationYawPitchRoll(D3DXMATRIX* out, FLOAT, FLOAT, FLOAT) {
+  return D3DXMatrixIdentity(out);
+}
+inline D3DXMATRIX* D3DXMatrixRotationQuaternion(D3DXMATRIX* out, const D3DXQUATERNION*) {
+  return D3DXMatrixIdentity(out);
+}
+inline D3DXMATRIX* D3DXMatrixShadow(D3DXMATRIX* out, const D3DXVECTOR4*, const void*) {
+  return D3DXMatrixIdentity(out);
+}
+
+struct D3DXPLANE {
+  float a, b, c, d;
+};
+inline FLOAT D3DXPlaneDotCoord(const D3DXPLANE*, const D3DXVECTOR3*) { return 0; }
+inline D3DXPLANE* D3DXPlaneFromPointNormal(D3DXPLANE* out, const D3DXVECTOR3*, const D3DXVECTOR3*) { return out; }
+inline D3DXPLANE* D3DXPlaneFromPoints(D3DXPLANE* out, const D3DXVECTOR3*, const D3DXVECTOR3*, const D3DXVECTOR3*) {
+  return out;
+}
+inline D3DXQUATERNION* D3DXQuaternionSlerp(D3DXQUATERNION* out, const D3DXQUATERNION* a, const D3DXQUATERNION*, FLOAT) {
+  if (out && a) *out = *a;
+  return out;
+}
+
+struct D3DXMATERIAL {
+  D3DMATERIAL8 MatD3D;
+  char* pTextureFilename;
+};
+struct ID3DXBuffer : IUnknown {
+  LPVOID GetBufferPointer() { return nullptr; }
+  DWORD GetBufferSize() { return 0; }
+};
+typedef ID3DXBuffer* LPD3DXBUFFER;
+
+inline HRESULT D3DXLoadMeshFromX(LPCSTR, DWORD, IDirect3DDevice8*, LPD3DXBUFFER*, LPD3DXBUFFER*, DWORD*, LPD3DXBUFFER*,
+                                 LPD3DXMESH*) {
+  return E_NOTIMPL;
+}
+inline HRESULT D3DXLoadMeshFromXof(void*, DWORD, IDirect3DDevice8*, LPD3DXBUFFER*, LPD3DXBUFFER*, DWORD*, LPD3DXBUFFER*,
+                                   LPD3DXMESH*) {
+  return E_NOTIMPL;
+}
+inline HRESULT D3DXCreateBox(IDirect3DDevice8*, FLOAT, FLOAT, FLOAT, LPD3DXMESH*, LPD3DXBUFFER*) { return E_NOTIMPL; }
+inline HRESULT D3DXCreateSphere(IDirect3DDevice8*, FLOAT, UINT, UINT, LPD3DXMESH*, LPD3DXBUFFER*) { return E_NOTIMPL; }
+inline HRESULT D3DXCreateTeapot(IDirect3DDevice8*, LPD3DXMESH*, LPD3DXBUFFER*) { return E_NOTIMPL; }
+inline HRESULT D3DXComputeBoundingBox(D3DXVECTOR3*, DWORD, DWORD, D3DXVECTOR3*, D3DXVECTOR3*) { return S_OK; }
+inline HRESULT D3DXComputeBoundingSphere(D3DXVECTOR3*, DWORD, DWORD, D3DXVECTOR3*, FLOAT*) { return S_OK; }
+inline BOOL D3DXBoxBoundProbe(const D3DXVECTOR3*, const D3DXVECTOR3*, const D3DXVECTOR3*, const D3DXVECTOR3*) {
+  return FALSE;
+}
+inline BOOL D3DXSphereBoundProbe(const D3DXVECTOR3*, FLOAT, const D3DXVECTOR3*, const D3DXVECTOR3*) { return FALSE; }

--- a/port/stub/dinput.h
+++ b/port/stub/dinput.h
@@ -6,13 +6,50 @@
 #define DIRECTINPUT_VERSION 0x0800
 #endif
 
-#define DIK_LSHIFT 0x2A
-#define DIK_RSHIFT 0x36
-#define DIK_LCONTROL 0x1D
-#define DIK_RCONTROL 0x9D
-#define DIK_LALT 0x38
-#define DIK_RALT 0xB8
 #define DIK_ESCAPE 0x01
+#define DIK_1 0x02
+#define DIK_2 0x03
+#define DIK_3 0x04
+#define DIK_4 0x05
+#define DIK_0 0x0B
+#define DIK_BACK 0x0E
+#define DIK_TAB 0x0F
+#define DIK_RETURN 0x1C
+#define DIK_LCONTROL 0x1D
+#define DIK_S 0x1F
+#define DIK_F 0x21
+#define DIK_D 0x20
+#define DIK_Y 0x15
+#define DIK_N 0x31
+#define DIK_M 0x32
+#define DIK_Z 0x2C
+#define DIK_LSHIFT 0x2A
+#define DIK_SLASH 0x35
+#define DIK_RSHIFT 0x36
+#define DIK_LALT 0x38
+#define DIK_SPACE 0x39
+#define DIK_F1 0x3B
+#define DIK_F2 0x3C
+#define DIK_F4 0x3E
+#define DIK_F11 0x57
+#define DIK_F12 0x58
+#define DIK_HOME 0xC7
+#define DIK_UP 0xC8
+#define DIK_PRIOR 0xC9
+#define DIK_LEFT 0xCB
+#define DIK_RIGHT 0xCD
+#define DIK_END 0xCF
+#define DIK_DOWN 0xD0
+#define DIK_NEXT 0xD1
+#define DIK_DELETE 0xD3
+#define DIK_RCONTROL 0x9D
+#define DIK_RALT 0xB8
+#define DIK_NUMPAD0 0x52
+#define DIK_NUMPAD1 0x4F
+#define DIK_NUMPAD2 0x50
+#define DIK_NUMPAD3 0x51
+#define DIK_NUMPAD4 0x4B
+#define DIK_NUMPADENTER 0x9C
 
 struct DIDEVICEINSTANCE;
 struct DIDEVICEOBJECTINSTANCE;

--- a/port/stub/direct.h
+++ b/port/stub/direct.h
@@ -6,7 +6,10 @@
 #include "io.h"
 
 #ifndef _mkdir
-inline int _mkdir(const char* path) { return mkdir(path, 0755); }
+inline int _mkdir(const char* path) { return ::mkdir(path, 0755); }
+#endif
+#ifndef mkdir
+inline int mkdir(const char* path) { return ::mkdir(path, 0755); }
 #endif
 
 #ifndef _getcwd

--- a/port/stub/dplay8.h
+++ b/port/stub/dplay8.h
@@ -3,6 +3,7 @@
 #include "windows.h"
 
 typedef DWORD DPNID;
+#define DPNID_ALL_PLAYERS_GROUP ((DPNID)0)
 
 struct IDirectPlay8Peer;
 struct IDirectPlay8Address;

--- a/port/stub/dsound.h
+++ b/port/stub/dsound.h
@@ -34,6 +34,8 @@ struct IDirectSoundBuffer : IUnknown {
 
 struct IDirectSoundBuffer8 : IDirectSoundBuffer {};
 #define DSBVOLUME_MAX 0
+#define DSBVOLUME_MIN -10000
+#define DS3D_IMMEDIATE 1
 #define DS3D_IMMEDIATE 1
 #define DS3D_DEFERRED 2
 

--- a/port/stub/mbstring.h
+++ b/port/stub/mbstring.h
@@ -2,8 +2,12 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <strings.h>
 
 inline unsigned char* _mbsinc(const unsigned char* p) { return (unsigned char*)(p + 1); }
 inline size_t _mbslen(const unsigned char* p) { return std::strlen((const char*)p); }
 inline int _ismbblead(unsigned int c) { return (c >= 0x81 && c <= 0x9F) || (c >= 0xE0 && c <= 0xFC); }
 inline int _ismbbtrail(unsigned int c) { return (c >= 0x40 && c <= 0x7E) || (c >= 0x80 && c <= 0xFC); }
+inline int _mbsicmp(const unsigned char* a, const unsigned char* b) {
+  return strcasecmp(reinterpret_cast<const char*>(a), reinterpret_cast<const char*>(b));
+}

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdarg>
 #include <cstring>
 #include <string>
 #include <vector>

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -309,5 +309,113 @@ inline LPSTR CharNext(LPCSTR p) { return CharNextA(p); }
 inline LPSTR CharPrev(LPCSTR s, LPCSTR p) { return CharPrevA(s, p); }
 inline HRESULT CoCreateInstance(const GUID&, LPVOID, DWORD, const GUID&, LPVOID*) { return E_NOTIMPL; }
 
+typedef BYTE* PBYTE;
+typedef unsigned char* PUCHAR;
+typedef void* HMODULE;
+typedef int (*FARPROC)();
+typedef void* HBRUSH;
+typedef void* HPEN;
+typedef void* HRGN;
+
+typedef struct tagBITMAPINFOHEADER {
+  DWORD biSize;
+  LONG biWidth;
+  LONG biHeight;
+  WORD biPlanes;
+  WORD biBitCount;
+  DWORD biCompression;
+  DWORD biSizeImage;
+  LONG biXPelsPerMeter;
+  LONG biYPelsPerMeter;
+  DWORD biClrUsed;
+  DWORD biClrImportant;
+} BITMAPINFOHEADER;
+
+typedef struct tagBITMAPINFO {
+  BITMAPINFOHEADER bmiHeader;
+  PALETTEENTRY bmiColors[1];
+} BITMAPINFO, *LPBITMAPINFO, *PBITMAPINFO;
+
+typedef struct _RTL_CRITICAL_SECTION {
+  void* DebugInfo;
+  LONG LockCount;
+  LONG RecursionCount;
+  HANDLE OwningThread;
+  HANDLE LockSemaphore;
+  ULONG_PTR SpinCount;
+} CRITICAL_SECTION, *LPCRITICAL_SECTION;
+
+#ifndef ZeroMemory
+#define ZeroMemory(dest, size) memset((dest), 0, (size))
+#endif
+#ifndef strcmpi
+#define strcmpi strcasecmp
+#endif
+
+#define MB_APPLMODAL 0x00000000L
+#define MB_YESNO 0x00000004L
+#define MB_YESNOCANCEL 0x00000003L
+#define IDYES 6
+#define IDNO 7
+#define IDCANCEL 2
+
+#define DIB_RGB_COLORS 0
+#define HALFTONE 4
+#define COLORONCOLOR 3
+#define SHIFTJIS_CHARSET 128
+#define PROOF_QUALITY 2
+#define OUT_DEFAULT_PRECIS 0
+#define CLIP_DEFAULT_PRECIS 0
+#define VARIABLE_PITCH 2
+#define FF_MODERN 0x30
+#define FW_REGULAR 400
+#define DEFAULT_CHARSET 1
+#define ANSI_CHARSET 0
+
+#define SW_SHOW 5
+#define SW_HIDE 0
+
+inline void Sleep(DWORD) {}
+inline int ShowCursor(BOOL) { return 0; }
+inline BOOL ClientToScreen(HWND, LPPOINT) { return TRUE; }
+inline BOOL ScreenToClient(HWND, LPPOINT) { return TRUE; }
+inline BOOL ClipCursor(const RECT*) { return TRUE; }
+inline BOOL DeleteObject(HANDLE) { return TRUE; }
+inline HDC CreateCompatibleDC(HDC) { return nullptr; }
+inline BOOL DeleteDC(HDC) { return TRUE; }
+inline HANDLE SelectObject(HDC, HANDLE) { return nullptr; }
+inline HMODULE LoadLibraryA(LPCSTR) { return nullptr; }
+inline HMODULE LoadLibrary(LPCSTR p) { return LoadLibraryA(p); }
+inline BOOL FreeLibrary(HMODULE) { return TRUE; }
+inline void ExitProcess(UINT) {}
+inline HFONT CreateFontA(int, int, int, int, int, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, LPCSTR) {
+  return nullptr;
+}
+inline HFONT CreateFont(int h, int w, int e, int o, int wt, DWORD i, DWORD u, DWORD s, DWORD c, DWORD op, DWORD cl,
+                        DWORD q, DWORD p, LPCSTR f) {
+  return CreateFontA(h, w, e, o, wt, i, u, s, c, op, cl, q, p, f);
+}
+inline int SetStretchBltMode(HDC, int) { return 0; }
+inline BOOL StretchBlt(HDC, int, int, int, int, HDC, int, int, int, int, DWORD) { return FALSE; }
+inline BOOL BitBlt(HDC, int, int, int, int, HDC, int, int, DWORD) { return FALSE; }
+inline BOOL TransparentBlt(HDC, int, int, int, int, HDC, int, int, int, int, UINT) { return FALSE; }
+inline HBITMAP CreateDIBSection(HDC, const BITMAPINFO*, UINT, void**, HANDLE, DWORD) { return nullptr; }
+inline int GetObjectA(HANDLE, int, LPVOID) { return 0; }
+inline BOOL WaitMessage() { return TRUE; }
+inline DWORD GetTickCount() { return 0; }
+inline void InitializeCriticalSection(LPCRITICAL_SECTION) {}
+inline void DeleteCriticalSection(LPCRITICAL_SECTION) {}
+inline void EnterCriticalSection(LPCRITICAL_SECTION) {}
+inline void LeaveCriticalSection(LPCRITICAL_SECTION) {}
+inline FARPROC GetProcAddress(HMODULE, LPCSTR) { return nullptr; }
+inline DWORD GetLastError() { return 0; }
+
+#ifndef __argc
+inline int rs2_argc() { return 0; }
+inline char** rs2_argv() { return nullptr; }
+#define __argc rs2_argc()
+#define __argv rs2_argv()
+#endif
+
 #define CLSID_DirectPlay8Peer GUID{}
 #define IID_IDirectPlay8Peer GUID{}

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -20,11 +20,10 @@
 #include <cctype>
 #include <algorithm>
 
-#ifndef max
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b))
+// Win32 min/max macros break libstdc++ <limits> (`numeric_limits::min()`).
+// Portable builds always compile with NOMINMAX; use std::min / std::max.
+#ifndef NOMINMAX
+#define NOMINMAX
 #endif
 
 typedef int BOOL;


### PR DESCRIPTION
## Summary
- Grow the `check` preset from object-only to a linked stub: `railsim2_native.a` (allowlisted game TUs) plus `port/native_entry.cpp` (`main` returns 0).
- Expand D3D8/D3DX/DIK/Win32 stubs so **28/254** root sources compile. Remaining failures are game include-order (`CTrain`, `CDragInterface`) and MSVC extra qualification, not missing D3D types.
- Keep `./scripts/check.sh` green: game objects are archived, not linked into the exe (udx globals like `sv3` still live in `lib/`). SDL2 is not a `check` dependency. Win32 `.rc` is skipped.

## Test plan
- [ ] `./scripts/check.sh` green locally and on CI (macos-15, ubuntu-24.04)
- [ ] Progress JSON prints `"28/254"`
- [ ] `build/check/railsim2` exists and exits 0
- [ ] `stdafx.h` include path remains `lib/udx.h` (already slash-normalized in M0)
- [ ] Sources stay CP932 (encoding-guard)

Closes #3


Made with [Cursor](https://cursor.com)