### PR TITLE
Add an agent-ready queue for one-slice port PRs

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "sudo apt-get update && sudo apt-get install -y clang cmake ninja-build python3 && ./scripts/check.sh"
+}

--- a/.cursor/rules/agent-queue.mdc
+++ b/.cursor/rules/agent-queue.mdc
@@ -1,0 +1,14 @@
+---
+description: How to pick the next port slice without inventing a backlog
+alwaysApply: true
+---
+
+# Agent queue
+
+Canonical protocol: `AGENTS.md` (section "Agent queue").
+
+- Start unlabeled work only when the user names that issue.
+- Parent issues `#1`?`#17` are epics, not a session. Slice issues say `Parent: #N`.
+- On "éü" / "éüÇ‚Ç¡Çƒ" / "pick next": `gh issue list --label agent-ready --state open`. Zero Å® stop. Otherwise take **one**, comment, remove the label, open one PR, stop.
+- Do not implement a second issue in the same session.
+- `./scripts/check.sh` is the gate. Do not convert game sources to UTF-8. Do not vendor DirectX.

--- a/.cursor/skills/next-slice/SKILL.md
+++ b/.cursor/skills/next-slice/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: next-slice
+description: >-
+  Picks exactly one GitHub issue labeled agent-ready, implements that slice,
+  opens a PR, and stops. Use when the user says Ÿ, Ÿ‚â‚Á‚Ä, Ÿ‚Ìì‹Æ, pick next,
+  continue the port, or asks to start work without naming an issue.
+---
+
+# Next slice
+
+Follow `AGENTS.md` section "Agent queue". This skill is the entry point when the user does not name an issue.
+
+## Steps
+
+1. Run `gh issue list --label agent-ready --state open --json number,title,labels`.
+2. If the list is empty: stop. Tell the user the queue is empty. Optionally `gh issue list --search "Parent: in:body state:open"` and show up to three slice candidates **without starting them**.
+3. If several are ready: take the **lowest number**, unless its files clearly collide with an open PR (`gh pr list`). Skip colliding issues rather than starting them.
+4. `gh issue comment <n> --body "Starting this slice. Removing \`agent-ready\` so another agent does not take it."`
+5. `gh issue edit <n> --remove-label agent-ready`
+6. Implement only that issue's ‚â‚é‚±‚Æ / Š®—¹ğŒ.
+7. Run `./scripts/check.sh`.
+8. Open one PR that `Closes #<slice>` (not the parent epic).
+9. Stop. Do not look for the next issue.
+
+## Do not
+
+- Do not keep going after the PR exists.
+- Do not start `#1`?`#17` as if they were one PR.
+- Do not create a markdown TODO list as a second queue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Agent notes
+
+Cross-platform port of RailSim2. Game logic stays close to upstream; platform code is replaced behind `lib/` and `port/stub/`.
+
+Human-facing overview: [`README.md`](README.md). Strategies: [`docs/porting/upstream.md`](docs/porting/upstream.md). Build: [`docs/porting/dev-env.md`](docs/porting/dev-env.md).
+
+## Hard constraints
+
+1. Prefer stubs and `lib/` backends over rewriting gameplay.
+2. No MinGW and no vendored DirectX SDK. Compile firewall is `port/stub/` via `-isystem`.
+3. Sources stay CP932 / ASCII. No mass UTF-8 conversion of game sources. `scripts/encoding-guard.sh` is law.
+4. Progress is monotonic: only add lines to `port/native_sources.txt` (denominator 254).
+5. `./scripts/check.sh` is the local and CI gate.
+
+Scope is the active Milestone / Issue, not a frozen exclusion list.
+
+## Commands
+
+```bash
+mise install            # cmake, ninja, ccache (see .mise.toml)
+./scripts/check.sh      # encoding-guard -> cmake --preset check -> ctest -> progress JSON
+```
+
+Linux CI also installs `clang` from apt. Do not add SDL2 or other runtime deps to the `check` preset.
+
+## Agent queue
+
+Tracking remains GitHub Issues and Milestones. The queue is the `agent-ready` label.
+
+Parent issues `#1`?`#17` are epics. They are **not** a session of work. Only a slice issue (body starts with `Parent: #N`) may be labeled `agent-ready`.
+
+### When the user does not name an issue
+
+("éü" / "éüÇ‚Ç¡Çƒ" / "pick next" / "continue")
+
+1. `gh issue list --label agent-ready --state open`
+2. **Zero issues:** stop. Say the queue is empty. List at most three unlabeled slice issues that look next, and wait. Do **not** start an unlabeled issue, a parent epic, or an open PR's remaining work.
+3. **One or more:** take **one** issue (lowest number). Comment that you started it, then **remove** `agent-ready` so a second agent cannot take it.
+4. Implement that slice only. Open one PR that `Closes #N` the slice (not the parent, unless the slice *is* the last remaining work and the parent checklist is done).
+5. **Stop.** Do not pick a second issue in the same session. Do not "keep going."
+
+### When the user names an issue
+
+Follow that issue. If it is a parent epic, implement **one** unchecked slice-sized checklist item, then stop and say what remains. Do not finish an epic in one PR.
+
+### Parallelism
+
+Multiple `agent-ready` issues means they do not share files. If two ready issues would touch the same path, do the lower number and leave the other labeled.
+
+Open PRs are in-flight work. Do not start a second implementation of the same parent.
+
+## Slice size
+
+One PR is one of:
+
+- A docs/ADR/inventory that another issue can depend on
+- One backend or OS seam (for example `timeGetTime` Å® chrono), with tests if they exist
+- An allowlist expansion: add the smallest set of `port/native_sources.txt` entries that share one missing type or header, grow stubs as needed, keep `./scripts/check.sh` green
+
+A slice is too big if it spans two Milestones, rewrites game logic, or cannot be verified with `./scripts/check.sh` plus the issue's own äÆóπèåè.
+
+## Pull requests
+
+- Keep game-code diffs mechanical (path separators, encoding-safe strings). Put behavior in `lib/` or `port/`.
+- `./scripts/check.sh` must be green.
+- Do not chain a second issue after CI goes green.
+
+## Cursor Cloud specific instructions
+
+Cloud VMs are Linux. After install, `clang`, `cmake`, `ninja`, and `python3` must exist, then `./scripts/check.sh` must pass on the branch you started from.
+
+```bash
+sudo apt-get update && sudo apt-get install -y clang cmake ninja-build python3
+./scripts/check.sh
+```
+
+`gh` is the GitHub client. Do not invent a local markdown queue.

--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ See [docs/porting/dev-env.md](docs/porting/dev-env.md) for presets, the compile 
 
 ## Tracking
 
-Work is organized with GitHub Milestones and Issues only: https://github.com/lollipop-onl/railsim2-portable/milestones
+Work is organized with GitHub Milestones and Issues: https://github.com/lollipop-onl/railsim2-portable/milestones
+
+Agents may start **only** issues labeled `agent-ready`, one PR each. Protocol: [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
## Summary
- Encode build constraints and a one-PR-then-stop protocol in `AGENTS.md`, with a Cursor rule/skill so 「次やって」 picks only `agent-ready` issues.
- Point Cloud Agents at a Linux `check.sh` install via `.cursor/environment.json`.
- Seed the queue outside this PR: [#23](https://github.com/lollipop-onl/railsim2-portable/issues/23) is labeled `agent-ready`; [#24](https://github.com/lollipop-onl/railsim2-portable/issues/24) waits on M1 PRs #20–#22.

## Test plan
- [ ] `./scripts/check.sh` still green (docs/config only)
- [ ] After merge, a new chat that says 「次やって」 lists or starts only #23, not parent epics #1–#17
- [ ] `gh issue list --label agent-ready --state open` returns #23 only
- [ ] Do not start #24 until #20–#22 land


Made with [Cursor](https://cursor.com)