### PR TITLE
Add Sample.rs2 load-save roundtrip ctest (#24)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,5 +64,20 @@ target_compile_definitions(railsim2 PRIVATE
   NOMINMAX
 )
 
+# Byte-compare harness only. Does not link railsim2_native / CSaveFile (#10).
+add_executable(rs2_roundtrip port/rs2_roundtrip.cpp)
+target_compile_features(rs2_roundtrip PRIVATE cxx_std_17)
+target_compile_options(rs2_roundtrip PRIVATE -Wall -Wextra)
+
+set(RS2_ROUNDTRIP_FIXTURE
+  "${CMAKE_SOURCE_DIR}/Distribution/en/RailSim2/Layout/Sample.rs2")
+set(RS2_ROUNDTRIP_OUTPUT
+  "${CMAKE_BINARY_DIR}/rs2_roundtrip_out.rs2")
+
 enable_testing()
 add_test(NAME rs2_smoke COMMAND "${CMAKE_COMMAND}" -E echo "ctest skeleton ok")
+add_test(NAME rs2_roundtrip_reports_diff COMMAND rs2_roundtrip --self-test-diff)
+add_test(NAME rs2_roundtrip COMMAND rs2_roundtrip
+  "${RS2_ROUNDTRIP_FIXTURE}"
+  "${RS2_ROUNDTRIP_OUTPUT}")
+set_tests_properties(rs2_roundtrip PROPERTIES SKIP_RETURN_CODE 77)

--- a/NOTICE
+++ b/NOTICE
@@ -55,6 +55,13 @@ modified work but are not listed as "changed upstream files".
     port/stub/* (D3D8 device methods, D3DX math, DIK_*, Win32 no-ops),
     docs/porting/dev-env.md, README.md
 
+2026-08-30 -- Sample.rs2 load-save roundtrip ctest (#24)
+
+  Build / docs (new):
+    port/rs2_roundtrip.cpp, docs/porting/rs2-roundtrip.md
+  Updated:
+    CMakeLists.txt, docs/porting/dev-env.md, docs/porting/upstream.md
+
 Further changes must update this file (date + summary) and keep git
 history as the detailed record. Prefer leaving game logic untouched so
 diffs against upstream stay reviewable.

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -32,7 +32,7 @@ brew bundle --file Brewfile
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
 | `cmake --preset check` | Configure AppleClang native target |
 | `cmake --build --preset check` | Compile allowlisted sources and link `railsim2` |
-| `ctest --preset check` | Run ctest skeleton (extended by #10) |
+| `ctest --preset check` | Smoke + `Sample.rs2` roundtrip harness (see [rs2-roundtrip.md](rs2-roundtrip.md)) |
 
 ## Compile firewall
 
@@ -73,5 +73,5 @@ GitHub Actions runs `./scripts/check.sh` on a **macOS + Linux matrix** (`macos-1
 
 ## Next milestones
 
-- **#10** attaches `.rs2` roundtrip tests to the ctest harness.
+- **#10** replaces the roundtrip passthrough with `CSaveFile` and drives byte-identity (`%p` / MD5 / float). The ctest harness itself is [#24](https://github.com/lollipop-onl/railsim2-portable/issues/24) ([rs2-roundtrip.md](rs2-roundtrip.md)).
 - Backend / window bring-up uses SDL2 only when a `native` preset is added (see `adr-backend.md`); keep `check` stub-only.

--- a/docs/porting/rs2-roundtrip.md
+++ b/docs/porting/rs2-roundtrip.md
@@ -1,0 +1,34 @@
+# Sample.rs2 load-save roundtrip harness
+
+- **Issue**: [#24](https://github.com/lollipop-onl/railsim2-portable/issues/24) (parent [#10](https://github.com/lollipop-onl/railsim2-portable/issues/10))
+- **Binary**: `rs2_roundtrip` (`port/rs2_roundtrip.cpp`), built by the `check` preset
+- **ctest**: `rs2_roundtrip` and `rs2_roundtrip_reports_diff`
+
+This is the mechanical gate for `#10`'s "load then save, byte diff zero" goal. It does **not** call `CSaveFile` yet (that still needs udx globals). `#10` should replace `rs2_layout_roundtrip()` with `CSaveFile::Load` + `CSaveFile::Save`. Do not "fix" `%p` width, MD5, or float format in the harness.
+
+## Fixture
+
+Default input is the in-repo English sample:
+
+`Distribution/en/RailSim2/Layout/Sample.rs2`
+
+No extra copy is vendored under `tests/` or into CI. GitHub Actions already checks out `Distribution/`. If that file is missing (sparse checkout, deleted tree), `rs2_roundtrip` prints `skip: no fixture at ...` and exits **77**. CMake sets `SKIP_RETURN_CODE 77`, so `./scripts/check.sh` stays green.
+
+Japanese `Distribution/jp/RailSim2/Layout/Sample.rs2` is CP932; pass it locally if you want that encoding in the compare.
+
+## Local
+
+```bash
+./scripts/check.sh
+# or, after cmake --build --preset check:
+ctest --preset check --output-on-failure -R rs2_roundtrip
+
+# explicit paths (any .rs2):
+./build/check/rs2_roundtrip Distribution/en/RailSim2/Layout/Sample.rs2 /tmp/out.rs2
+```
+
+`rs2_roundtrip_reports_diff` feeds two different buffers to the comparator and checks that the failure text is `roundtrip diff`, not a missing-harness error.
+
+## After `#10` wires `CSaveFile`
+
+A real save will likely differ (`%p` width on 64-bit, `LayoutInfo.Date` from `GetLocalTime`, float `%f`). That must fail as **roundtrip diff** with sizes and the first mismatch offset. Byte-identity is `#10`'s job, not this harness.

--- a/docs/porting/upstream.md
+++ b/docs/porting/upstream.md
@@ -49,3 +49,4 @@ There is no separate denylist of "do not touch" paths. Scope is defined by the s
 - Frozen udx / D3D8 game ABI: [`api-surface.md`](api-surface.md)
 - Backend ADR: [`adr-backend.md`](adr-backend.md)
 - X-File templates in `Distribution`: [`x-file-templates.md`](x-file-templates.md)
+- `.rs2` roundtrip ctest: [`rs2-roundtrip.md`](rs2-roundtrip.md)

--- a/port/rs2_roundtrip.cpp
+++ b/port/rs2_roundtrip.cpp
@@ -1,0 +1,131 @@
+// Layout load->save byte-compare harness for ctest (issue #24).
+//
+// Does not call CSaveFile: that object graph still needs udx globals and
+// is #10. The save path is rs2_layout_roundtrip() -- replace its body
+// with CSaveFile::Load + CSaveFile::Save. Until then this copies bytes so
+// the compare step always runs (a mismatch prints "roundtrip diff", never
+// "harness not connected").
+//
+// Exit codes:
+//   0  byte-identical, or --self-test-diff passed
+//   1  roundtrip diff
+//   2  bad usage
+//  77  skipped (fixture missing) -- ctest SKIP_RETURN_CODE
+//
+// Local: rs2_roundtrip Distribution/en/RailSim2/Layout/Sample.rs2 /tmp/out.rs2
+// CI:    the check preset points at that path; skip if Distribution is absent.
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace {
+
+const int kSkip = 77;
+
+bool read_file(const char *path, std::vector<unsigned char> *out, std::string *err) {
+	std::ifstream in(path, std::ios::binary);
+	if (!in) {
+		*err = std::string("cannot open ") + path;
+		return false;
+	}
+	out->assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+	return true;
+}
+
+bool write_file(const char *path, const std::vector<unsigned char> &data, std::string *err) {
+	std::ofstream out(path, std::ios::binary);
+	if (!out) {
+		*err = std::string("cannot write ") + path;
+		return false;
+	}
+	out.write(reinterpret_cast<const char *>(data.data()),
+		static_cast<std::streamsize>(data.size()));
+	if (!out) {
+		*err = std::string("write failed: ") + path;
+		return false;
+	}
+	return true;
+}
+
+// #10: replace with CSaveFile::Load(in_path) then CSaveFile::Save(out_path).
+// Do not "fix" %p width, MD5, or float format here -- those belong to #10.
+bool rs2_layout_roundtrip(const char *in_path, const char *out_path, std::string *err) {
+	std::vector<unsigned char> loaded;
+	if (!read_file(in_path, &loaded, err)) {
+		return false;
+	}
+	return write_file(out_path, loaded, err);
+}
+
+int report_diff(const std::vector<unsigned char> &loaded,
+	const std::vector<unsigned char> &saved) {
+	if (loaded == saved) {
+		std::fprintf(stdout, "roundtrip match: %zu bytes\n", loaded.size());
+		return 0;
+	}
+	const std::size_t n = loaded.size() < saved.size() ? loaded.size() : saved.size();
+	std::size_t off = 0;
+	for (; off < n; ++off) {
+		if (loaded[off] != saved[off]) {
+			break;
+		}
+	}
+	std::fprintf(stderr,
+		"roundtrip diff: loaded %zu bytes, saved %zu bytes, first mismatch at offset %zu\n",
+		loaded.size(), saved.size(), off);
+	return 1;
+}
+
+int self_test_diff() {
+	const std::vector<unsigned char> a{'a', 'b', 'c'};
+	const std::vector<unsigned char> b{'a', 'x', 'c'};
+	const int rc = report_diff(a, b);
+	if (rc != 1) {
+		std::fprintf(stderr, "self-test: expected roundtrip diff, got exit %d\n", rc);
+		return 1;
+	}
+	std::fprintf(stdout, "self-test: diff reporter ok\n");
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test-diff") == 0) {
+		return self_test_diff();
+	}
+	if (argc != 3) {
+		std::fprintf(stderr,
+			"usage: rs2_roundtrip <in.rs2> <out.rs2> | rs2_roundtrip --self-test-diff\n");
+		return 2;
+	}
+
+	const char *in_path = argv[1];
+	const char *out_path = argv[2];
+
+	std::ifstream probe(in_path, std::ios::binary);
+	if (!probe) {
+		std::fprintf(stderr, "skip: no fixture at %s\n", in_path);
+		return kSkip;
+	}
+	probe.close();
+
+	std::string err;
+	if (!rs2_layout_roundtrip(in_path, out_path, &err)) {
+		// Save/load of a present fixture must not look like a missing harness.
+		std::fprintf(stderr, "roundtrip diff: %s\n", err.c_str());
+		return 1;
+	}
+
+	std::vector<unsigned char> loaded;
+	std::vector<unsigned char> saved;
+	if (!read_file(in_path, &loaded, &err) || !read_file(out_path, &saved, &err)) {
+		std::fprintf(stderr, "roundtrip diff: %s\n", err.c_str());
+		return 1;
+	}
+	return report_diff(loaded, saved);
+}


### PR DESCRIPTION
## Summary
- Add `rs2_roundtrip` to the `check` preset: load then save `Distribution/en/RailSim2/Layout/Sample.rs2` and compare bytes.
- Missing fixture skips (exit 77) instead of failing CI. No extra copy of assets is vendored.
- Does not call `CSaveFile` (still needs udx globals; that is #10). The save path is a named seam so a later real save fails as `roundtrip diff`, not a missing harness.

## Test plan
- [x] `./scripts/check.sh` green locally (3 ctests: smoke, diff-reporter self-test, Sample.rs2 roundtrip)
- [x] Missing path exits 77 with `skip: no fixture`
- [x] `--self-test-diff` prints `roundtrip diff`
- [ ] CI macOS + Linux matrix

Closes #24

Made with [Cursor](https://cursor.com)