### PR TITLE
Load Distribution .x files with a closed text parser (#28)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,13 @@ add_test(NAME rs2_roundtrip COMMAND rs2_roundtrip
   "${RS2_ROUNDTRIP_FIXTURE}"
   "${RS2_ROUNDTRIP_OUTPUT}")
 set_tests_properties(rs2_roundtrip PROPERTIES SKIP_RETURN_CODE 77)
+
+# Closed text X-File parser (#28). Does not replace CMesh::Load (#6).
+add_executable(rs2_xfile_load port/xfile_load.cpp port/xfile.cpp)
+target_include_directories(rs2_xfile_load PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_xfile_load PRIVATE cxx_std_17)
+target_compile_options(rs2_xfile_load PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_xfile_self_test COMMAND rs2_xfile_load --self-test)
+add_test(NAME rs2_xfile_load COMMAND rs2_xfile_load "${CMAKE_SOURCE_DIR}/Distribution")
+set_tests_properties(rs2_xfile_load PROPERTIES SKIP_RETURN_CODE 77)

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -32,7 +32,7 @@ brew bundle --file Brewfile
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
 | `cmake --preset check` | Configure AppleClang native target |
 | `cmake --build --preset check` | Compile allowlisted sources and link `railsim2` |
-| `ctest --preset check` | Smoke + `Sample.rs2` roundtrip harness (see [rs2-roundtrip.md](rs2-roundtrip.md)) |
+| `ctest --preset check` | Smoke + `Sample.rs2` roundtrip + text `.x` load (see [rs2-roundtrip.md](rs2-roundtrip.md), [x-file-parser.md](x-file-parser.md)) |
 
 ## Compile firewall
 
@@ -74,4 +74,5 @@ GitHub Actions runs `./scripts/check.sh` on a **macOS + Linux matrix** (`macos-1
 ## Next milestones
 
 - **#10** replaces the roundtrip passthrough with `CSaveFile` and drives byte-identity (`%p` / MD5 / float). The ctest harness itself is [#24](https://github.com/lollipop-onl/railsim2-portable/issues/24) ([rs2-roundtrip.md](rs2-roundtrip.md)).
+- **#6** replaces `CXFile` / `D3DXLoadMeshFromX` with the closed parser in `port/xfile.cpp`. Loading Distribution `.x` into memory is [#28](https://github.com/lollipop-onl/railsim2-portable/issues/28) ([x-file-parser.md](x-file-parser.md)).
 - Backend / window bring-up uses SDL2 only when a `native` preset is added (see `adr-backend.md`); keep `check` stub-only.

--- a/docs/porting/upstream.md
+++ b/docs/porting/upstream.md
@@ -49,4 +49,5 @@ There is no separate denylist of "do not touch" paths. Scope is defined by the s
 - Frozen udx / D3D8 game ABI: [`api-surface.md`](api-surface.md)
 - Backend ADR: [`adr-backend.md`](adr-backend.md)
 - X-File templates in `Distribution`: [`x-file-templates.md`](x-file-templates.md)
+- Closed text `.x` parser: [`x-file-parser.md`](x-file-parser.md)
 - `.rs2` roundtrip ctest: [`rs2-roundtrip.md`](rs2-roundtrip.md)

--- a/docs/porting/x-file-parser.md
+++ b/docs/porting/x-file-parser.md
@@ -1,0 +1,32 @@
+# Closed text X-File parser
+
+- **Issue**: [#28](https://github.com/lollipop-onl/railsim2-portable/issues/28) (parent [#6](https://github.com/lollipop-onl/railsim2-portable/issues/6))
+- **Set**: [x-file-templates.md](x-file-templates.md)
+- **Sources**: `port/xfile.h`, `port/xfile.cpp`
+- **Binary**: `rs2_xfile_load` (`port/xfile_load.cpp`), built by the `check` preset
+- **ctest**: `rs2_xfile_self_test` and `rs2_xfile_load`
+
+This is the mechanical gate for `#6`'s "`.x` is an in-memory mesh" goal. It does **not** replace `CXFile` or `CMesh::Load` (those still call `D3DXLoadMeshFromX` / `Xof`). `#6` should feed `Rs2XMesh` into that path.
+
+Faces stay **n-gons** as written in the file. Triangulation belongs with the later `ID3DXMESH`-like object, not here.
+
+## Fixture
+
+Default scan root is `Distribution/` (178 files: 89 unique jp/en pairs). GitHub Actions already checks that tree out. If the directory is missing, `rs2_xfile_load` prints `skip: no fixture at ...` and exits **77**.
+
+## Local
+
+```bash
+./scripts/check.sh
+# or, after cmake --build --preset check:
+ctest --preset check --output-on-failure -R rs2_xfile
+
+./build/check/rs2_xfile_load --self-test
+./build/check/rs2_xfile_load Distribution
+```
+
+`rs2_xfile_self_test` parses an inline Arrow-like mesh and rejects `xof 0302bin`. The Distribution test also checks `Arrow.x` (normals, no UVs) and `Compass1.x` (no normals, no UVs).
+
+## After `#6` wires `CMesh::Load`
+
+Keep this ctest. Wiring should not change the parse result; it only copies `Rs2XMesh` into the existing material / texture lists.

--- a/docs/porting/x-file-templates.md
+++ b/docs/porting/x-file-templates.md
@@ -2,7 +2,7 @@
 
 - **Issue**: [#23](https://github.com/lollipop-onl/railsim2-portable/issues/23) (parent [#6](https://github.com/lollipop-onl/railsim2-portable/issues/6))
 - **Tree**: `Distribution/**/*.x` at this document's commit
-- **Parser**: not implemented here. `#6` should implement **this closed set**, not the full X-File spec.
+- **Parser**: `port/xfile.cpp` (issue [#28](https://github.com/lollipop-onl/railsim2-portable/issues/28)). `#6` still has to swap `CMesh::Load`. This document is the closed set.
 
 `CMesh::Load` currently calls `D3DXLoadMeshFromX` / `D3DXLoadMeshFromXof` after `CXFile::GetTopMesh` walks to `TID_D3DRMMesh`. A portable loader only has to feed that same mesh object. `CAnim::Load` reads a **custom text sidecar** (`fopen` / `fscanf`), not `AnimationSet`.
 

--- a/port/xfile.cpp
+++ b/port/xfile.cpp
@@ -1,0 +1,561 @@
+// Closed text X-File parser. See docs/porting/x-file-templates.md for the
+// instantiated set. Binary / compressed X and Frame / AnimationSet fail.
+
+#include "xfile.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+
+namespace {
+
+struct Parser {
+	const char *start;
+	const char *p;
+	const char *end;
+	std::string *err;
+
+	bool fail(const char *msg) {
+		if (err) {
+			std::ostringstream os;
+			os << msg << " at offset " << static_cast<std::size_t>(p - start);
+			*err = os.str();
+		}
+		return false;
+	}
+};
+
+void skip_ws_comments(Parser *s) {
+	for (;;) {
+		while (s->p < s->end && std::isspace(static_cast<unsigned char>(*s->p))) {
+			s->p++;
+		}
+		if (s->p + 1 < s->end && s->p[0] == '/' && s->p[1] == '/') {
+			s->p += 2;
+			while (s->p < s->end && *s->p != '\n') {
+				s->p++;
+			}
+			continue;
+		}
+		return;
+	}
+}
+
+bool at_end(Parser *s) {
+	skip_ws_comments(s);
+	return s->p >= s->end;
+}
+
+bool peek_char(Parser *s, char c) {
+	skip_ws_comments(s);
+	return s->p < s->end && *s->p == c;
+}
+
+bool take_char(Parser *s, char c) {
+	skip_ws_comments(s);
+	if (s->p < s->end && *s->p == c) {
+		s->p++;
+		return true;
+	}
+	return false;
+}
+
+bool is_ident_start(char c) {
+	return std::isalpha(static_cast<unsigned char>(c)) || c == '_';
+}
+
+bool is_ident_char(char c) {
+	return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
+
+bool take_ident(Parser *s, std::string *out) {
+	skip_ws_comments(s);
+	if (s->p >= s->end || !is_ident_start(*s->p)) {
+		return false;
+	}
+	const char *b = s->p;
+	s->p++;
+	while (s->p < s->end && is_ident_char(*s->p)) {
+		s->p++;
+	}
+	out->assign(b, s->p);
+	return true;
+}
+
+bool expect_char(Parser *s, char c, const char *msg) {
+	if (!take_char(s, c)) {
+		return s->fail(msg);
+	}
+	return true;
+}
+
+void skip_seps(Parser *s) {
+	skip_ws_comments(s);
+	while (s->p < s->end && (*s->p == ';' || *s->p == ',')) {
+		s->p++;
+		skip_ws_comments(s);
+	}
+}
+
+bool parse_number(Parser *s, double *out) {
+	skip_ws_comments(s);
+	if (s->p >= s->end) {
+		return s->fail( "expected number");
+	}
+	char *endp = nullptr;
+	const double v = std::strtod(s->p, &endp);
+	if (endp == s->p) {
+		return s->fail( "expected number");
+	}
+	s->p = endp;
+	*out = v;
+	skip_seps(s);
+	return true;
+}
+
+bool parse_int(Parser *s, int *out) {
+	double v = 0;
+	if (!parse_number(s, &v)) {
+		return false;
+	}
+	*out = static_cast<int>(v);
+	return true;
+}
+
+bool parse_float(Parser *s, float *out) {
+	double v = 0;
+	if (!parse_number(s, &v)) {
+		return false;
+	}
+	*out = static_cast<float>(v);
+	return true;
+}
+
+bool parse_string(Parser *s, std::string *out) {
+	skip_ws_comments(s);
+	if (!take_char(s, '"')) {
+		return s->fail( "expected string");
+	}
+	const char *b = s->p;
+	while (s->p < s->end && *s->p != '"') {
+		s->p++;
+	}
+	if (s->p >= s->end) {
+		return s->fail( "unterminated string");
+	}
+	out->assign(b, s->p);
+	s->p++;
+	skip_seps(s);
+	return true;
+}
+
+bool skip_balanced(Parser *s) {
+	if (!expect_char(s, '{', "expected '{'")) {
+		return false;
+	}
+	int depth = 1;
+	while (s->p < s->end && depth > 0) {
+		if (s->p[0] == '/' && s->p + 1 < s->end && s->p[1] == '/') {
+			s->p += 2;
+			while (s->p < s->end && *s->p != '\n') {
+				s->p++;
+			}
+			continue;
+		}
+		if (*s->p == '"') {
+			s->p++;
+			while (s->p < s->end && *s->p != '"') {
+				s->p++;
+			}
+			if (s->p < s->end) {
+				s->p++;
+			}
+			continue;
+		}
+		if (*s->p == '{') {
+			depth++;
+		} else if (*s->p == '}') {
+			depth--;
+		}
+		s->p++;
+	}
+	if (depth != 0) {
+		return s->fail( "unbalanced '{'");
+	}
+	return true;
+}
+
+bool skip_guid(Parser *s) {
+	skip_ws_comments(s);
+	if (!peek_char(s, '<')) {
+		return true;
+	}
+	s->p++;
+	while (s->p < s->end && *s->p != '>') {
+		s->p++;
+	}
+	if (s->p >= s->end) {
+		return s->fail( "unterminated GUID");
+	}
+	s->p++;
+	return true;
+}
+
+bool parse_vec3(Parser *s, Rs2XVec3 *v) {
+	return parse_float(s, &v->x) && parse_float(s, &v->y) && parse_float(s, &v->z);
+}
+
+bool parse_vec2(Parser *s, Rs2XVec2 *v) {
+	return parse_float(s, &v->u) && parse_float(s, &v->v);
+}
+
+bool parse_color_rgba(Parser *s, Rs2XColor *c) {
+	return parse_float(s, &c->r) && parse_float(s, &c->g) && parse_float(s, &c->b) &&
+		parse_float(s, &c->a);
+}
+
+bool parse_color_rgb(Parser *s, Rs2XColor *c) {
+	c->a = 1.0f;
+	return parse_float(s, &c->r) && parse_float(s, &c->g) && parse_float(s, &c->b);
+}
+
+bool parse_face(Parser *s, Rs2XFace *f) {
+	int n = 0;
+	if (!parse_int(s, &n) || n < 0) {
+		return s->fail( "bad face index count");
+	}
+	f->indices.resize(static_cast<std::size_t>(n));
+	for (int i = 0; i < n; i++) {
+		if (!parse_int(s, &f->indices[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool parse_optional_name(Parser *s, std::string *name) {
+	skip_ws_comments(s);
+	if (s->p < s->end && is_ident_start(*s->p)) {
+		return take_ident(s, name);
+	}
+	name->clear();
+	return true;
+}
+
+bool parse_texture_filename(Parser *s, std::string *tex) {
+	if (!expect_char(s, '{', "expected '{' after TextureFilename")) {
+		return false;
+	}
+	if (!parse_string(s, tex)) {
+		return false;
+	}
+	return expect_char(s, '}', "expected '}' after TextureFilename");
+}
+
+bool parse_material(Parser *s, Rs2XMaterial *m) {
+	if (!expect_char(s, '{', "expected '{' after Material")) {
+		return false;
+	}
+	if (!parse_color_rgba(s, &m->diffuse)) {
+		return false;
+	}
+	if (!parse_float(s, &m->power)) {
+		return false;
+	}
+	if (!parse_color_rgb(s, &m->specular)) {
+		return false;
+	}
+	if (!parse_color_rgb(s, &m->emissive)) {
+		return false;
+	}
+	m->texture.clear();
+	while (!peek_char(s, '}')) {
+		std::string kind;
+		if (!take_ident(s, &kind)) {
+			return s->fail( "expected Material child or '}'");
+		}
+		if (kind == "TextureFilename") {
+			if (!parse_texture_filename(s, &m->texture)) {
+				return false;
+			}
+		} else {
+			return s->fail( "unknown Material child");
+		}
+	}
+	return expect_char(s, '}', "expected '}' after Material");
+}
+
+bool parse_material_list(Parser *s, Rs2XMesh *mesh) {
+	if (!expect_char(s, '{', "expected '{' after MeshMaterialList")) {
+		return false;
+	}
+	int nmat = 0;
+	int nface = 0;
+	if (!parse_int(s, &nmat) || nmat < 0) {
+		return s->fail( "bad material count");
+	}
+	if (!parse_int(s, &nface) || nface < 0) {
+		return s->fail( "bad material face-index count");
+	}
+	mesh->face_materials.resize(static_cast<std::size_t>(nface));
+	for (int i = 0; i < nface; i++) {
+		if (!parse_int(s, &mesh->face_materials[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	mesh->materials.clear();
+	mesh->materials.reserve(static_cast<std::size_t>(nmat));
+	for (int i = 0; i < nmat; i++) {
+		std::string kind;
+		if (!take_ident(s, &kind) || kind != "Material") {
+			return s->fail( "expected Material");
+		}
+		std::string unused_name;
+		if (!parse_optional_name(s, &unused_name)) {
+			return false;
+		}
+		Rs2XMaterial mat{};
+		if (!parse_material(s, &mat)) {
+			return false;
+		}
+		mesh->materials.push_back(mat);
+	}
+	if (static_cast<int>(mesh->materials.size()) != nmat) {
+		return s->fail( "material count mismatch");
+	}
+	return expect_char(s, '}', "expected '}' after MeshMaterialList");
+}
+
+bool parse_normals(Parser *s, Rs2XMesh *mesh) {
+	if (!expect_char(s, '{', "expected '{' after MeshNormals")) {
+		return false;
+	}
+	int n = 0;
+	if (!parse_int(s, &n) || n < 0) {
+		return s->fail( "bad normal count");
+	}
+	mesh->normals.resize(static_cast<std::size_t>(n));
+	for (int i = 0; i < n; i++) {
+		if (!parse_vec3(s, &mesh->normals[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	int nf = 0;
+	if (!parse_int(s, &nf) || nf < 0) {
+		return s->fail( "bad normal-face count");
+	}
+	mesh->normal_faces.resize(static_cast<std::size_t>(nf));
+	for (int i = 0; i < nf; i++) {
+		if (!parse_face(s, &mesh->normal_faces[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	return expect_char(s, '}', "expected '}' after MeshNormals");
+}
+
+bool parse_texcoords(Parser *s, Rs2XMesh *mesh) {
+	if (!expect_char(s, '{', "expected '{' after MeshTextureCoords")) {
+		return false;
+	}
+	int n = 0;
+	if (!parse_int(s, &n) || n < 0) {
+		return s->fail( "bad uv count");
+	}
+	mesh->uvs.resize(static_cast<std::size_t>(n));
+	for (int i = 0; i < n; i++) {
+		if (!parse_vec2(s, &mesh->uvs[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	return expect_char(s, '}', "expected '}' after MeshTextureCoords");
+}
+
+bool parse_vertex_colors(Parser *s, Rs2XMesh *mesh) {
+	if (!expect_char(s, '{', "expected '{' after MeshVertexColors")) {
+		return false;
+	}
+	int n = 0;
+	if (!parse_int(s, &n) || n < 0) {
+		return s->fail( "bad vertex-color count");
+	}
+	mesh->vertex_colors.resize(static_cast<std::size_t>(n));
+	for (int i = 0; i < n; i++) {
+		Rs2XIndexedColor ic{};
+		if (!parse_int(s, &ic.index)) {
+			return false;
+		}
+		if (!parse_color_rgba(s, &ic.color)) {
+			return false;
+		}
+		mesh->vertex_colors[static_cast<std::size_t>(i)] = ic;
+	}
+	return expect_char(s, '}', "expected '}' after MeshVertexColors");
+}
+
+bool parse_mesh_body(Parser *s, Rs2XMesh *mesh) {
+	if (!expect_char(s, '{', "expected '{' after Mesh")) {
+		return false;
+	}
+	int nverts = 0;
+	if (!parse_int(s, &nverts) || nverts < 0) {
+		return s->fail( "bad vertex count");
+	}
+	mesh->positions.resize(static_cast<std::size_t>(nverts));
+	for (int i = 0; i < nverts; i++) {
+		if (!parse_vec3(s, &mesh->positions[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	int nfaces = 0;
+	if (!parse_int(s, &nfaces) || nfaces < 0) {
+		return s->fail( "bad face count");
+	}
+	mesh->faces.resize(static_cast<std::size_t>(nfaces));
+	for (int i = 0; i < nfaces; i++) {
+		if (!parse_face(s, &mesh->faces[static_cast<std::size_t>(i)])) {
+			return false;
+		}
+	}
+	while (!peek_char(s, '}')) {
+		std::string kind;
+		if (!take_ident(s, &kind)) {
+			return s->fail( "expected Mesh child or '}'");
+		}
+		std::string unused;
+		if (!parse_optional_name(s, &unused)) {
+			return false;
+		}
+		if (kind == "MeshMaterialList") {
+			if (!parse_material_list(s, mesh)) {
+				return false;
+			}
+		} else if (kind == "MeshNormals") {
+			if (!parse_normals(s, mesh)) {
+				return false;
+			}
+		} else if (kind == "MeshTextureCoords") {
+			if (!parse_texcoords(s, mesh)) {
+				return false;
+			}
+		} else if (kind == "MeshVertexColors") {
+			if (!parse_vertex_colors(s, mesh)) {
+				return false;
+			}
+		} else {
+			return s->fail( "unknown Mesh child (closed set)");
+		}
+	}
+	return expect_char(s, '}', "expected '}' after Mesh");
+}
+
+bool parse_header_magic(Parser *s) {
+	if (s->end - s->p < 16) {
+		return s->fail( "file shorter than X-File magic");
+	}
+	const std::string magic(s->p, 16);
+	if (magic != "xof 0302txt 0064" && magic != "xof 0302txt 0032") {
+		if (magic.size() >= 12 && magic.compare(0, 8, "xof 0302") == 0) {
+			return s->fail( "binary or compressed X-File is out of scope");
+		}
+		return s->fail( "not a text X-File (xof 0302txt)");
+	}
+	s->p += 16;
+	return true;
+}
+
+bool parse_top(Parser *s, Rs2XMesh *mesh) {
+	bool got_mesh = false;
+	while (!at_end(s)) {
+		std::string kind;
+		if (!take_ident(s, &kind)) {
+			return s->fail( "expected top-level identifier");
+		}
+		if (kind == "template") {
+			std::string tname;
+			if (!take_ident(s, &tname)) {
+				return s->fail( "expected template name");
+			}
+			if (!skip_guid(s)) {
+				return false;
+			}
+			if (!skip_balanced(s)) {
+				return false;
+			}
+			continue;
+		}
+		std::string inst;
+		if (!parse_optional_name(s, &inst)) {
+			return false;
+		}
+		if (kind == "Header") {
+			if (!skip_balanced(s)) {
+				return false;
+			}
+			continue;
+		}
+		if (kind == "Mesh") {
+			if (got_mesh) {
+				return s->fail( "multiple Mesh objects");
+			}
+			mesh->name = inst;
+			if (!parse_mesh_body(s, mesh)) {
+				return false;
+			}
+			got_mesh = true;
+			continue;
+		}
+		return s->fail( "unknown top-level object (closed set)");
+	}
+	if (!got_mesh) {
+		return s->fail( "no Mesh object");
+	}
+	if (mesh->positions.empty()) {
+		return s->fail( "Mesh has no vertices");
+	}
+	if (mesh->faces.empty()) {
+		return s->fail( "Mesh has no faces");
+	}
+	if (mesh->materials.empty()) {
+		return s->fail( "Mesh has no materials");
+	}
+	if (mesh->face_materials.size() != mesh->faces.size()) {
+		return s->fail( "material face-index count != nFaces");
+	}
+	return true;
+}
+
+}  // namespace
+
+bool rs2_xfile_parse(const std::string &bytes, Rs2XMesh *out, std::string *err) {
+	if (!out) {
+		if (err) {
+			*err = "null mesh output";
+		}
+		return false;
+	}
+	Parser s{};
+	s.start = bytes.data();
+	s.p = bytes.data();
+	s.end = bytes.data() + bytes.size();
+	s.err = err;
+	*out = Rs2XMesh{};
+	if (!parse_header_magic(&s)) {
+		return false;
+	}
+	return parse_top(&s, out);
+}
+
+bool rs2_xfile_parse_file(const char *path, Rs2XMesh *out, std::string *err) {
+	std::ifstream in(path, std::ios::binary);
+	if (!in) {
+		if (err) {
+			*err = std::string("cannot open ") + path;
+		}
+		return false;
+	}
+	const std::string bytes((std::istreambuf_iterator<char>(in)),
+		std::istreambuf_iterator<char>());
+	return rs2_xfile_parse(bytes, out, err);
+}

--- a/port/xfile.h
+++ b/port/xfile.h
@@ -1,0 +1,61 @@
+// Closed text X-File parser for Distribution assets (issue #28, parent #6).
+// Does not replace CXFile / CMesh::Load.
+
+#ifndef RS2_PORT_XFILE_H
+#define RS2_PORT_XFILE_H
+
+#include <string>
+#include <vector>
+
+struct Rs2XVec3 {
+	float x;
+	float y;
+	float z;
+};
+
+struct Rs2XVec2 {
+	float u;
+	float v;
+};
+
+struct Rs2XColor {
+	float r;
+	float g;
+	float b;
+	float a;
+};
+
+struct Rs2XFace {
+	std::vector<int> indices;
+};
+
+struct Rs2XMaterial {
+	Rs2XColor diffuse;
+	float power;
+	Rs2XColor specular;
+	Rs2XColor emissive;
+	std::string texture;
+};
+
+struct Rs2XIndexedColor {
+	int index;
+	Rs2XColor color;
+};
+
+struct Rs2XMesh {
+	std::string name;
+	std::vector<Rs2XVec3> positions;
+	std::vector<Rs2XFace> faces;
+	std::vector<int> face_materials;
+	std::vector<Rs2XMaterial> materials;
+	std::vector<Rs2XVec3> normals;
+	std::vector<Rs2XFace> normal_faces;
+	std::vector<Rs2XVec2> uvs;
+	std::vector<Rs2XIndexedColor> vertex_colors;
+};
+
+// Parse a whole file (including the 16-byte magic). On failure, *err is set.
+bool rs2_xfile_parse(const std::string &bytes, Rs2XMesh *out, std::string *err);
+bool rs2_xfile_parse_file(const char *path, Rs2XMesh *out, std::string *err);
+
+#endif

--- a/port/xfile_load.cpp
+++ b/port/xfile_load.cpp
@@ -1,0 +1,191 @@
+// Load Distribution .x files into Rs2XMesh (issue #28). Does not call CMesh.
+
+#include "xfile.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace {
+
+const int kSkip = 77;
+
+const char kSelfMesh[] =
+	"xof 0302txt 0064\n"
+	"// self-test mesh (issue #28)\n"
+	"Header {\n"
+	" 1;\n"
+	" 0;\n"
+	" 1;\n"
+	"}\n"
+	"Mesh ArrowLike {\n"
+	" 5;\n"
+	" -1.0;2.0;0.0;,\n"
+	" 0.0;2.0;0.5;,\n"
+	" 1.0;2.0;0.0;,\n"
+	" 0.0;2.0;-0.5;,\n"
+	" 0.0;0.0;0.0;;\n"
+	" 5;\n"
+	" 4;0,1,2,3;,\n"
+	" 3;4,3,2;,\n"
+	" 3;2,1,4;,\n"
+	" 3;1,0,4;,\n"
+	" 3;4,0,3;;\n"
+	" MeshMaterialList {\n"
+	"  1;\n"
+	"  5;\n"
+	"  0, 0, 0, 0, 0;;\n"
+	"  Material {\n"
+	"   0.0;0.0;1.0;0.5;;\n"
+	"   0.0;\n"
+	"   0.0;0.0;0.0;;\n"
+	"   0.0;0.0;0.0;;\n"
+	"  }\n"
+	" }\n"
+	" MeshNormals {\n"
+	"  1;\n"
+	"  0.0;1.0;0.0;;\n"
+	"  5;\n"
+	"  4;0,0,0,0;,\n"
+	"  3;0,0,0;,\n"
+	"  3;0,0,0;,\n"
+	"  3;0,0,0;,\n"
+	"  3;0,0,0;;\n"
+	" }\n"
+	"}\n";
+
+bool expect_mesh(const Rs2XMesh &m, const char *label) {
+	if (m.positions.size() != 5 || m.faces.size() != 5 || m.materials.size() != 1) {
+		std::fprintf(stderr, "self-test: %s: verts=%zu faces=%zu mats=%zu\n",
+			label, m.positions.size(), m.faces.size(), m.materials.size());
+		return false;
+	}
+	if (m.faces[0].indices.size() != 4) {
+		std::fprintf(stderr, "self-test: %s: first face is not a quad\n", label);
+		return false;
+	}
+	if (m.normals.empty() || m.uvs.size() != 0) {
+		std::fprintf(stderr, "self-test: %s: expected normals, no uvs\n", label);
+		return false;
+	}
+	if (m.name != "ArrowLike") {
+		std::fprintf(stderr, "self-test: %s: name '%s'\n", label, m.name.c_str());
+		return false;
+	}
+	return true;
+}
+
+int self_test() {
+	Rs2XMesh m;
+	std::string err;
+	if (!rs2_xfile_parse(kSelfMesh, &m, &err)) {
+		std::fprintf(stderr, "self-test: parse failed: %s\n", err.c_str());
+		return 1;
+	}
+	if (!expect_mesh(m, "inline")) {
+		return 1;
+	}
+
+	const std::string bad_magic = "xof 0302bin 0064\nMesh { 0; 0; }";
+	Rs2XMesh ignored;
+	if (rs2_xfile_parse(bad_magic, &ignored, &err)) {
+		std::fprintf(stderr, "self-test: binary magic should fail\n");
+		return 1;
+	}
+	if (err.find("binary") == std::string::npos &&
+		err.find("out of scope") == std::string::npos) {
+		std::fprintf(stderr, "self-test: expected binary/out-of-scope error, got '%s'\n",
+			err.c_str());
+		return 1;
+	}
+
+	std::fprintf(stdout, "self-test: xfile parser ok\n");
+	return 0;
+}
+
+void collect_x_files(const std::filesystem::path &root, std::vector<std::filesystem::path> *out) {
+	std::error_code ec;
+	if (!std::filesystem::exists(root, ec)) {
+		return;
+	}
+	for (const auto &ent : std::filesystem::recursive_directory_iterator(root, ec)) {
+		if (ec) {
+			break;
+		}
+		if (!ent.is_regular_file()) {
+			continue;
+		}
+		if (ent.path().extension() == ".x") {
+			out->push_back(ent.path());
+		}
+	}
+}
+
+int check_known_file(const std::filesystem::path &path, const Rs2XMesh &m) {
+	const std::string name = path.filename().string();
+	if (name == "Arrow.x") {
+		if (m.positions.size() != 5 || m.faces.size() != 5 || m.normals.empty() ||
+			!m.uvs.empty()) {
+			std::fprintf(stderr, "%s: expected 5 verts/faces, normals, no uvs\n",
+				path.c_str());
+			return 1;
+		}
+	}
+	if (name == "Compass1.x") {
+		if (m.positions.empty() || !m.normals.empty() || !m.uvs.empty()) {
+			std::fprintf(stderr, "%s: expected verts, no normals, no uvs\n", path.c_str());
+			return 1;
+		}
+	}
+	return 0;
+}
+
+int load_tree(const char *root) {
+	std::vector<std::filesystem::path> files;
+	collect_x_files(root, &files);
+	if (files.empty()) {
+		std::fprintf(stderr, "skip: no fixture at %s\n", root);
+		return kSkip;
+	}
+
+	int failed = 0;
+	for (const auto &path : files) {
+		Rs2XMesh mesh;
+		std::string err;
+		if (!rs2_xfile_parse_file(path.c_str(), &mesh, &err)) {
+			std::fprintf(stderr, "xfile load failed: %s: %s\n", path.c_str(), err.c_str());
+			failed++;
+			continue;
+		}
+		if (check_known_file(path, mesh) != 0) {
+			failed++;
+		}
+	}
+	if (failed != 0) {
+		std::fprintf(stderr, "xfile load: %d of %zu files failed\n", failed, files.size());
+		return 1;
+	}
+	if (files.size() != 178) {
+		std::fprintf(stderr, "xfile load: expected 178 files, got %zu under %s\n",
+			files.size(), root);
+		return 1;
+	}
+	std::fprintf(stdout, "xfile load: %zu meshes ok\n", files.size());
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test") == 0) {
+		return self_test();
+	}
+	if (argc != 2) {
+		std::fprintf(stderr,
+			"usage: rs2_xfile_load <Distribution-dir> | rs2_xfile_load --self-test\n");
+		return 2;
+	}
+	return load_tree(argv[1]);
+}


### PR DESCRIPTION
## Summary
- Add `port/xfile.cpp` to parse the closed `xof 0302txt` set from [#23](https://github.com/lollipop-onl/railsim2-portable/issues/23) into an in-memory `Rs2XMesh` (n-gon faces, optional normals/UVs/vertex colors).
- `rs2_xfile_load` on the `check` preset loads all 178 `Distribution/**/*.x` files. Missing tree skips (exit 77). `--self-test` covers an Arrow-like mesh and rejects binary magic.
- Does not replace `CXFile` / `CMesh::Load` (that is #6). Game sources are unchanged.

## Test plan
- [x] `./scripts/check.sh` green locally (5 ctests: smoke, roundtrip x2, xfile self-test, 178-file load)
- [x] `rs2_xfile_load --self-test` prints `self-test: xfile parser ok`
- [x] `rs2_xfile_load Distribution` prints `xfile load: 178 meshes ok`
- [x] `Arrow.x` has 5 verts/faces + normals; `Compass1.x` has no normals/UVs
- [ ] CI macOS + Linux matrix

Closes #28


Made with [Cursor](https://cursor.com)