### PR TITLE
Join g_BaseDir instead of chdir for the closed path I/O set

### DIFF
--- a/CConfigMode.cpp
+++ b/CConfigMode.cpp
@@ -243,8 +243,9 @@ bool CConfigMode::Load(){
 	g_SelectedStructID = "Ship";
 	g_SelectedSurfaceID = "Default";
 	g_SelectedEnvID = "Default";
-	if(chdir(g_BaseDir)) goto SET;
-	str = g_ConfigBuffer = LoadBinaryText("Config.txt");
+	char cfgpath[RS2_PATH_MAX];
+	if(!rs2_path_join(cfgpath, sizeof(cfgpath), g_BaseDir, "Config.txt")) goto SET;
+	str = g_ConfigBuffer = LoadBinaryText(cfgpath);
 	if(!g_ConfigBuffer) goto SET;
 	try{
 		if(!(str = Space(eee = str))) throw CSynErr(eee);
@@ -396,8 +397,9 @@ bool CConfigMode::Save(){
 	}
 	void SetCurrentPluginID();
 	SetCurrentPluginID();
-	if(chdir(g_BaseDir)) return false;
-	FILE *file = fopen("Config.txt", "wt");
+	char cfgpath[RS2_PATH_MAX];
+	if(!rs2_path_join(cfgpath, sizeof(cfgpath), g_BaseDir, "Config.txt")) return false;
+	FILE *file = fopen(cfgpath, "wt");
 	if(!file) return false;
 	fprintf(file, "/*\n *\tRailSim II Configuration Datafile\n */\n\n");
 	fprintf(file, "DatafileHeader{\n");

--- a/CFileMode.cpp
+++ b/CFileMode.cpp
@@ -78,9 +78,13 @@ bool CFileListView::ConfirmRename(
 	char *oldname = item->GetString(0);
 	newname = FixFileExt((char *)newname.c_str(), "rs2");
 	if(!_mbsicmp((PUCHAR)oldname, (PUCHAR)newname.c_str())) return false;
-	if(CheckSlash(newname.c_str()) || chdir(g_BaseDir) || chdir(LAYOUT_DIRNAME) ||
-		rename(oldname, newname.c_str())){
-		FILE *file = fopen(newname.c_str(), "rb");
+	char dir[RS2_PATH_MAX] = {}, from[RS2_PATH_MAX] = {}, to[RS2_PATH_MAX] = {};
+	if(CheckSlash(newname.c_str())
+		|| !rs2_path_join(dir, sizeof(dir), g_BaseDir, LAYOUT_DIRNAME)
+		|| !rs2_path_join(from, sizeof(from), dir, oldname)
+		|| !rs2_path_join(to, sizeof(to), dir, newname.c_str())
+		|| rs2_rename(from, to)){
+		FILE *file = fopen(to, "rb");
 		if(file){
 			EnqueueCommonDialog(new CSimpleDialog(
 				lang(FileAlreadyExists), (char *)newname.c_str()));
@@ -176,11 +180,9 @@ CFileMode::CFileMode(){
 	new CPopMenu("-", m_FileMenu);
 	new CPopMenu(lang(CreateSession), m_FileMenu);
 	new CPopMenu(lang(JoinSession), m_FileMenu);
-	chdir(g_BaseDir);
-	if(chdir(LAYOUT_DIRNAME)) mkdir(LAYOUT_DIRNAME);
-	chdir(g_BaseDir);
-	if(chdir(UNDO_DIRNAME)) mkdir(UNDO_DIRNAME);
-	chdir(g_BaseDir);
+	char dir[RS2_PATH_MAX];
+	if(rs2_path_join(dir, sizeof(dir), g_BaseDir, LAYOUT_DIRNAME)) rs2_mkdir(dir);
+	if(rs2_path_join(dir, sizeof(dir), g_BaseDir, UNDO_DIRNAME)) rs2_mkdir(dir);
 	ResetUndo();
 	m_NetworkMode = false;
 }
@@ -245,8 +247,9 @@ CPopMenu *CFileMode::Dispatch(
 			CFileDeleter(bool c, char *fname){ m_Confirm = c; m_FileName = fname; }
 			void Exec(){
 				if(m_Confirm){
-					if(chdir(g_BaseDir) || chdir(LAYOUT_DIRNAME)
-						|| remove(m_FileName.c_str())){
+					char delpath[RS2_PATH_MAX];
+					if(!rs2_path_join(delpath, sizeof(delpath), g_BaseDir, LAYOUT_DIRNAME, m_FileName.c_str())
+						|| rs2_remove(delpath)){
 						EnqueueCommonDialog(new CSimpleDialog(
 							lang(ErrorDuringDelete), (char *)m_FileName.c_str()));
 						g_Skin->Error();
@@ -657,28 +660,28 @@ SAVEAS:
  *	ファイルリスト作成
  */
 void CFileMode::ListFile(){
-	long filelist;
-	_finddata_t data;
 	m_FileListView.DeleteAllItems();
 	m_LayoutInfoList.clear();
-	if(chdir(g_BaseDir) || chdir(LAYOUT_DIRNAME)) return;
-	if((filelist = _findfirst("*.rs2", &data))>=0){
-		do{
-			FILE *file;
-			if(data.attrib&_A_SUBDIR) continue;
-			m_LayoutInfoList.push_back(CLayoutInfo(data.name));
-			CLayoutInfo *nfo = &*m_LayoutInfoList.rbegin();
-			if(file = fopen(data.name, "rb")){
-				if(!nfo->PreLoadSF(file)){
-					m_LayoutInfoList.pop_back();
-					continue;
-				}
-			}else{
+	char layoutdir[RS2_PATH_MAX];
+	if(!rs2_path_join(layoutdir, sizeof(layoutdir), g_BaseDir, LAYOUT_DIRNAME)
+		|| !rs2_is_dir(layoutdir)) return;
+	std::vector<std::string> names;
+	if(!rs2_list_dir(layoutdir, "*.rs2", false, &names)) return;
+	for(size_t i = 0; i<names.size(); i++){
+		char fpath[RS2_PATH_MAX];
+		FILE *file;
+		m_LayoutInfoList.push_back(CLayoutInfo((char *)names[i].c_str()));
+		CLayoutInfo *nfo = &*m_LayoutInfoList.rbegin();
+		if(rs2_path_join(fpath, sizeof(fpath), layoutdir, names[i].c_str()) &&
+			(file = fopen(fpath, "rb"))){
+			if(!nfo->PreLoadSF(file)){
 				m_LayoutInfoList.pop_back();
 				continue;
 			}
-		} while(!_findnext(filelist, &data));
-		_findclose(filelist);
+		}else{
+			m_LayoutInfoList.pop_back();
+			continue;
+		}
 	}
 	m_LayoutInfoList.sort();
 	ILayoutInfo ili = m_LayoutInfoList.begin();

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ if(RS2_NATIVE_SOURCES STREQUAL "")
   message(FATAL_ERROR "port/native_sources.txt has no compile targets")
 endif()
 
-add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES})
+add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
+  "${CMAKE_SOURCE_DIR}/port/path.cpp")
 
 target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub"
@@ -91,3 +92,13 @@ target_compile_options(rs2_xfile_load PRIVATE -Wall -Wextra)
 add_test(NAME rs2_xfile_self_test COMMAND rs2_xfile_load --self-test)
 add_test(NAME rs2_xfile_load COMMAND rs2_xfile_load "${CMAKE_SOURCE_DIR}/Distribution")
 set_tests_properties(rs2_xfile_load PROPERTIES SKIP_RETURN_CODE 77)
+
+# Closed-set path join / list / fullpath (#32). Does not rewrite plugin Load().
+add_executable(rs2_path_test port/path_test.cpp port/path.cpp)
+target_include_directories(rs2_path_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_path_test PRIVATE cxx_std_17)
+target_compile_options(rs2_path_test PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_path_self_test COMMAND rs2_path_test --self-test)
+add_test(NAME rs2_path_distribution COMMAND rs2_path_test "${CMAKE_SOURCE_DIR}/Distribution")
+set_tests_properties(rs2_path_distribution PROPERTIES SKIP_RETURN_CODE 77)

--- a/CPlugin.cpp
+++ b/CPlugin.cpp
@@ -47,7 +47,10 @@ int CPlugin::Compare(
  *	ディレクトリ移動
  */
 bool CPlugin::ChDir(){
-	return !chdir(g_BaseDir) && !chdir(DirName()) && !chdir(m_ID.c_str());
+	char path[RS2_PATH_MAX];
+	if(!rs2_path_join(path, sizeof(path), g_BaseDir, DirName(), m_ID.c_str()))
+		return false;
+	return rs2_chdir(path)==0;
 }
 
 /*
@@ -216,36 +219,37 @@ CPluginList::~CPluginList(){
  *	定義ファイルのロード
  */
 bool CPluginList::List(){
-	long filelist;
-	_finddata_t data;
 	CPlugin **adr = &m_List;
-	if(chdir(g_BaseDir) || chdir(DirName())) return false;
-	if((filelist = _findfirst("*", &data))>=0){
-		do{
-			FILE *file;
-			if(!(data.attrib&_A_SUBDIR)) continue;
-			if(chdir(g_BaseDir) || chdir(DirName()) || chdir(data.name)) continue;
-			CPlugin *newpi = NewEntry(data.name);
-			if(file = fopen(TextName2(), "rb")){
-				if(!newpi->PreLoad(file)){
-					delete newpi;
-					continue;
-				}
-			}else if(TextName() && (file = fopen(TextName(), "rt"))){
-				if(!newpi->PreLoadOldForm(file)){
-					delete newpi;
-					continue;
-				}
-			}else{
+	char typedir[RS2_PATH_MAX];
+	if(!rs2_path_join(typedir, sizeof(typedir), g_BaseDir, DirName()) || !rs2_is_dir(typedir))
+		return false;
+	std::vector<std::string> names;
+	if(!rs2_list_dir(typedir, "*", true, &names)) return false;
+	for(size_t i = 0; i<names.size(); i++){
+		char plugindir[RS2_PATH_MAX], defpath[RS2_PATH_MAX];
+		FILE *file;
+		if(!rs2_path_join(plugindir, sizeof(plugindir), typedir, names[i].c_str())) continue;
+		CPlugin *newpi = NewEntry((char *)names[i].c_str());
+		if(rs2_path_join(defpath, sizeof(defpath), plugindir, TextName2()) &&
+			(file = fopen(defpath, "rb"))){
+			if(!newpi->PreLoad(file)){
 				delete newpi;
 				continue;
 			}
-			newpi->m_State = 1;
-			*adr = newpi;
-			adr = &newpi->m_Next;
-			m_PluginNum++;
-		} while(!_findnext(filelist, &data));
-		_findclose(filelist);
+		}else if(TextName() && rs2_path_join(defpath, sizeof(defpath), plugindir, TextName()) &&
+			(file = fopen(defpath, "rt"))){
+			if(!newpi->PreLoadOldForm(file)){
+				delete newpi;
+				continue;
+			}
+		}else{
+			delete newpi;
+			continue;
+		}
+		newpi->m_State = 1;
+		*adr = newpi;
+		adr = &newpi->m_Next;
+		m_PluginNum++;
 	}
 	return true;
 }
@@ -260,17 +264,22 @@ bool CPluginList::LoadOne(
 ){
 	CPlugin **adr = &m_List;
 	while(*adr) adr = &(*adr)->m_Next;
-	if(chdir(g_BaseDir)) return false;
+	char path[RS2_PATH_MAX];
+	const char *openpath = defpath;
+	if(!rs2_path_is_absolute(defpath)){
+		if(!rs2_path_join(path, sizeof(path), g_BaseDir, defpath)) return false;
+		openpath = path;
+	}
 	FILE *file;
 	CPlugin *newpi = NewEntry(piid);
 	bool success = false;
 	if(oldform){
-		if(file = fopen(defpath, "rt")){
+		if(file = fopen(openpath, "rt")){
 			if(newpi->PreLoadOldForm(file)) success = true;
 			else fclose(file);
 		}
 	}else{
-		if(file = fopen(defpath, "rb")){
+		if(file = fopen(openpath, "rb")){
 			if(newpi->PreLoad(file)) success = true;
 			else fclose(file);
 		}

--- a/CRailwayPluginSet.cpp
+++ b/CRailwayPluginSet.cpp
@@ -179,7 +179,9 @@ void CRailwayPluginSet::Save(
  *	データファイル削除
  */
 bool CRailwayPluginSet::DeleteFromDisk(){
-	if(chdir(g_BaseDir) || chdir(DirName()) || remove(TextName2())){
+	char path[RS2_PATH_MAX];
+	if(!rs2_path_join(path, sizeof(path), g_BaseDir, DirName(), TextName2())
+		|| rs2_remove(path)){
 		EnqueueCommonDialog(new CSimpleDialog(
 			lang(ErrorDuringDelete), TextName2()));
 		g_Skin->Error();
@@ -195,8 +197,13 @@ bool CRailwayPluginSet::Rename(
 	string &newname	//	新規名
 ){
 	string fname2 = FlashIn("%s.txt", newname.c_str());
-	if(CheckSlash(fname2.c_str()) || chdir(g_BaseDir) || chdir(DirName()) ||
-		(remove(fname2.c_str()), rename(TextName2(), fname2.c_str()))){
+	char dir[RS2_PATH_MAX], from[RS2_PATH_MAX], to[RS2_PATH_MAX];
+	char *oldname = TextName2();
+	if(CheckSlash(fname2.c_str())
+		|| !rs2_path_join(dir, sizeof(dir), g_BaseDir, DirName())
+		|| !rs2_path_join(from, sizeof(from), dir, oldname)
+		|| !rs2_path_join(to, sizeof(to), dir, fname2.c_str())
+		|| (rs2_remove(to), rs2_rename(from, to))){
 		EnqueueCommonDialog(new CSimpleDialog(
 			lang(ErrorDuringRename), TextName2()));
 		g_Skin->Error();
@@ -229,28 +236,27 @@ void CRailwayPluginSet::Apply(){
  *	設定リスト読込
  */
 void LoadRailwayPluginSetList(){
-	long filelist;
-	_finddata_t data;
-	if(chdir(g_BaseDir) || chdir(RPS_DIRNAME)) return;
-	if((filelist = _findfirst("*.txt", &data))>=0){
-		do{
-			FILE *file;
-			if(data.attrib&_A_SUBDIR) continue;
-			string name = data.name;
-			name[name.size()-4] = 0;
-			g_RailwayPluginSetList.push_back(CRailwayPluginSet((char *)name.c_str(), false));
-			CRailwayPluginSet *rps = &*g_RailwayPluginSetList.rbegin();
-			if(file = fopen(data.name, "rb")){
-				if(!rps->PreLoadRPS(file)){
-					g_RailwayPluginSetList.pop_back();
-					continue;
-				}
-			}else{
+	char dir[RS2_PATH_MAX];
+	if(!rs2_path_join(dir, sizeof(dir), g_BaseDir, RPS_DIRNAME) || !rs2_is_dir(dir)) return;
+	std::vector<std::string> names;
+	if(!rs2_list_dir(dir, "*.txt", false, &names)) return;
+	for(size_t i = 0; i<names.size(); i++){
+		char fpath[RS2_PATH_MAX];
+		FILE *file;
+		string name = names[i];
+		name[name.size()-4] = 0;
+		g_RailwayPluginSetList.push_back(CRailwayPluginSet((char *)name.c_str(), false));
+		CRailwayPluginSet *rps = &*g_RailwayPluginSetList.rbegin();
+		if(rs2_path_join(fpath, sizeof(fpath), dir, names[i].c_str()) &&
+			(file = fopen(fpath, "rb"))){
+			if(!rps->PreLoadRPS(file)){
 				g_RailwayPluginSetList.pop_back();
 				continue;
 			}
-		} while(!_findnext(filelist, &data));
-		_findclose(filelist);
+		}else{
+			g_RailwayPluginSetList.pop_back();
+			continue;
+		}
 	}
 	g_RailwayPluginSetList.sort();
 }
@@ -290,8 +296,10 @@ void AddRailwayPluginSet(
 	}
 	char *fname = FlashIn("%s.txt", name.c_str());
 	FILE *file;
-	if(CheckSlash(fname) || chdir(g_BaseDir) || chdir(RPS_DIRNAME)
-		|| !(file = fopen(fname, "wt"))){
+	char rpspath[RS2_PATH_MAX];
+	if(CheckSlash(fname)
+		|| !rs2_path_join(rpspath, sizeof(rpspath), g_BaseDir, RPS_DIRNAME, fname)
+		|| !(file = fopen(rpspath, "wt"))){
 		EnqueueCommonDialog(new CSimpleDialog(
 			lang(CannotOpen_CheckFileName), fname));
 		return;

--- a/CSaveFile.cpp
+++ b/CSaveFile.cpp
@@ -660,7 +660,9 @@ bool CSaveFile::Load(
 ){
 	FILE *df;
 	if(!auxdata){
-		if(chdir(g_BaseDir) || chdir(dirname) || !(df = fopen(fname, "rb"))){
+		char loadpath[RS2_PATH_MAX];
+		if(!rs2_path_join(loadpath, sizeof(loadpath), g_BaseDir, dirname, fname)
+			|| !(df = fopen(loadpath, "rb"))){
 			if(warn){
 				EnqueueCommonDialog(new CSimpleDialog(lang(CannotOpenFile), (char *)fname));
 				g_Skin->Error();
@@ -840,8 +842,9 @@ bool CSaveFile::Load(
 		scene = scene->Next();
 	}
 	if(g_LackPlugin.size()){
-		chdir(g_BaseDir);
-		FILE *lacklog = fopen("LackPlugin.txt", "wt");
+		char lackpath[RS2_PATH_MAX];
+		rs2_path_join(lackpath, sizeof(lackpath), g_BaseDir, "LackPlugin.txt");
+		FILE *lacklog = fopen(lackpath, "wt");
 		if(lacklog){
 			set<string>::iterator is = g_LackPlugin.begin();
 			for(; is!=g_LackPlugin.end(); is++) fprintf(lacklog, "%s\n", is->c_str());
@@ -887,16 +890,17 @@ int CSaveFile::Save(
 	bool upname				//	ファイル名更新
 ){
 	FILE *df;
-	if(CheckSlash(fname) || chdir(g_BaseDir) || chdir(dirname)){
+	char savepath[RS2_PATH_MAX];
+	if(CheckSlash(fname) || !rs2_path_join(savepath, sizeof(savepath), g_BaseDir, dirname, fname)){
 		EnqueueCommonDialog(new CSimpleDialog(lang(CannotOpenFile), (char *)fname));
 		g_Skin->Error();
 		return 1;
 	}
-	if(!overwrite && (df = fopen(fname, "rb"))){
+	if(!overwrite && (df = fopen(savepath, "rb"))){
 		fclose(df);
 		return 2;
 	}
-	if(!(df = fopen(fname, "wt"))){
+	if(!(df = fopen(savepath, "wt"))){
 		EnqueueCommonDialog(new CSimpleDialog(lang(CannotOpenFile), (char *)fname));
 		g_Skin->Error();
 		return 1;

--- a/CTrainGroupTemplate.cpp
+++ b/CTrainGroupTemplate.cpp
@@ -240,7 +240,9 @@ void CTrainGroupTemplate::DeleteFromTree(){
  *	データファイル削除
  */
 bool CTrainGroupTemplate::DeleteFromDisk(){
-	if(chdir(g_BaseDir) || chdir(DirName()) || remove(TextName2())){
+	char path[RS2_PATH_MAX];
+	if(!rs2_path_join(path, sizeof(path), g_BaseDir, DirName(), TextName2())
+		|| rs2_remove(path)){
 		EnqueueCommonDialog(new CSimpleDialog(
 			lang(ErrorDuringDelete), TextName2()));
 		g_Skin->Error();
@@ -256,8 +258,13 @@ bool CTrainGroupTemplate::Rename(
 	string &newname	//	新規名
 ){
 	string fname2 = FlashIn("%s.txt", newname.c_str());
-	if(CheckSlash(fname2.c_str()) || chdir(g_BaseDir) || chdir(DirName()) ||
-		(remove(fname2.c_str()), rename(TextName2(), fname2.c_str()))){
+	char dir[RS2_PATH_MAX], from[RS2_PATH_MAX], to[RS2_PATH_MAX];
+	char *oldname = TextName2();
+	if(CheckSlash(fname2.c_str())
+		|| !rs2_path_join(dir, sizeof(dir), g_BaseDir, DirName())
+		|| !rs2_path_join(from, sizeof(from), dir, oldname)
+		|| !rs2_path_join(to, sizeof(to), dir, fname2.c_str())
+		|| (rs2_remove(to), rs2_rename(from, to))){
 		EnqueueCommonDialog(new CSimpleDialog(
 			lang(ErrorDuringRename), TextName2()));
 		g_Skin->Error();
@@ -304,28 +311,27 @@ void CTrainGroupTemplate::SetPreview(){
  *	テンプレートリスト読込
  */
 void LoadTrainGroupTemplateList(){
-	long filelist;
-	_finddata_t data;
-	if(chdir(g_BaseDir) || chdir(TGT_DIRNAME)) return;
-	if((filelist = _findfirst("*.txt", &data))>=0){
-		do{
-			FILE *file;
-			if(data.attrib&_A_SUBDIR) continue;
-			string name = data.name;
-			name[name.size()-4] = 0;
-			g_TrainGroupTemplateList.push_back(CTrainGroupTemplate((char *)name.c_str()));
-			CTrainGroupTemplate *tgt = &*g_TrainGroupTemplateList.rbegin();
-			if(file = fopen(data.name, "rb")){
-				if(!tgt->PreLoadTGT(file)){
-					g_TrainGroupTemplateList.pop_back();
-					continue;
-				}
-			}else{
+	char dir[RS2_PATH_MAX];
+	if(!rs2_path_join(dir, sizeof(dir), g_BaseDir, TGT_DIRNAME) || !rs2_is_dir(dir)) return;
+	std::vector<std::string> names;
+	if(!rs2_list_dir(dir, "*.txt", false, &names)) return;
+	for(size_t i = 0; i<names.size(); i++){
+		char fpath[RS2_PATH_MAX];
+		FILE *file;
+		string name = names[i];
+		name[name.size()-4] = 0;
+		g_TrainGroupTemplateList.push_back(CTrainGroupTemplate((char *)name.c_str()));
+		CTrainGroupTemplate *tgt = &*g_TrainGroupTemplateList.rbegin();
+		if(rs2_path_join(fpath, sizeof(fpath), dir, names[i].c_str()) &&
+			(file = fopen(fpath, "rb"))){
+			if(!tgt->PreLoadTGT(file)){
 				g_TrainGroupTemplateList.pop_back();
 				continue;
 			}
-		} while(!_findnext(filelist, &data));
-		_findclose(filelist);
+		}else{
+			g_TrainGroupTemplateList.pop_back();
+			continue;
+		}
 	}
 }
 
@@ -436,17 +442,19 @@ CMenuCommand *MakeGroupSaver(
  */
 void AddTrainGroupTemplate(){
 	FILE *file;
-	if(chdir(g_BaseDir) || chdir(TGT_DIRNAME)) return;
+	char dir[RS2_PATH_MAX], fpath[RS2_PATH_MAX];
+	if(!rs2_path_join(dir, sizeof(dir), g_BaseDir, TGT_DIRNAME) || !rs2_is_dir(dir)) return;
 	int i;
 	for(i = 1; i<1000; i++){
 		char *tname = i>1 ? FlashIn("%s (%d)", lang(NewTemplate), i) : lang(NewTemplate);
 		if(FindTrainGroupTemplate(tname)!=g_TrainGroupTemplateList.end()) continue;
 		char *fname = FlashIn("%s.txt", tname);
-		if(file = fopen(fname, "rb")){
+		if(!rs2_path_join(fpath, sizeof(fpath), dir, fname)) continue;
+		if(file = fopen(fpath, "rb")){
 			fclose(file);
 			continue;
 		}
-		if(!(file = fopen(fname, "wt"))) continue;
+		if(!(file = fopen(fpath, "wt"))) continue;
 		CPluginTree *tree = g_TrainEditMode->GetTree();
 		CTreeDirElement *insertpoint = tree->GetRoot();
 		g_TrainGroupTemplateList.push_back(CTrainGroupTemplate(tname));

--- a/Capture.cpp
+++ b/Capture.cpp
@@ -48,13 +48,11 @@ void InitCapture(){
 //	g_HidefCapture.Create(g_HidefBufferSize, g_HidefBufferSize);
 	g_ScreenShot.Clear(g_DispWidth, g_DispHeight);
 	g_HidefBufferSize = CheckArguments("-voodoo") ? 256 : 512;
-	chdir(g_BaseDir);
-	if(chdir("Picture")) mkdir("Picture");
-	chdir(g_BaseDir);
-	if(chdir("Video")) mkdir("Video");
+	char capdir[RS2_PATH_MAX];
+	if(rs2_path_join(capdir, sizeof(capdir), g_BaseDir, "Picture")) rs2_mkdir(capdir);
+	if(rs2_path_join(capdir, sizeof(capdir), g_BaseDir, "Video")) rs2_mkdir(capdir);
 	CountPicture();
 	CountVideoAVI();
-	chdir(g_BaseDir);
 }
 /*
  *	ŽB‰e‰ð•ú
@@ -153,7 +151,9 @@ void HidefCapture(CSceneryMode *scenerymode){
 	hidef_vert.BilinearStamp(&g_ScreenShot,
 		0, 0, sv3.width, sv3.height,
 		0, 0, hidef_vert.GetWidth(), hidef_vert.GetHeight());
-	g_ScreenShot.Save(FlashIn("%08d.bmp", g_PictureCount), 24);
+	char picpath[RS2_PATH_MAX];
+	if(rs2_path_join(picpath, sizeof(picpath), g_BaseDir, "Picture", FlashIn("%08d.bmp", g_PictureCount)))
+		g_ScreenShot.Save(picpath, 24);
 	CountPicture();
 	g_Skin->ScreenShot();
 	g_HidefCaptureFlag = false;
@@ -226,8 +226,6 @@ void VideoCapture(
 ){
 	if(GetKey(DIK_F12)==S_PUSH){
 		if(g_RSPV || !CheckCtrl()){
-			chdir(g_BaseDir);
-			chdir("Picture");
 			g_HidefQuality = g_VideoMode->GetPictureQuality();
 			if(g_HidefQuality>1 && scenerymode && !g_ConfigMode->GetStereo()){
 				HidefCapture(scenerymode);
@@ -235,7 +233,9 @@ void VideoCapture(
 				HDC windc = GetDC(svw.hWnd);
 				BitBlt(g_ScreenShot.GetHDC(), 0, 0, g_DispWidth, g_DispHeight, windc, 0, 0, SRCCOPY);
 				ReleaseDC(svw.hWnd, windc);
-				g_ScreenShot.Save(FlashIn("%08d.bmp", g_PictureCount), 24);
+				char picpath[RS2_PATH_MAX];
+				if(rs2_path_join(picpath, sizeof(picpath), g_BaseDir, "Picture", FlashIn("%08d.bmp", g_PictureCount)))
+					g_ScreenShot.Save(picpath, 24);
 				CountPicture();
 				g_Skin->ScreenShot();
 			}
@@ -273,10 +273,9 @@ void VideoCapture(
 			}
 			++g_VideoAVIFrame;
 		}else{
-			chdir(g_BaseDir);
-			chdir("Video");
-			char* frame_name = FlashIn("%08d.bmp", g_VideoFrame);
-				saving_img->Save(frame_name, 24);
+			char framepath[RS2_PATH_MAX];
+			if(rs2_path_join(framepath, sizeof(framepath), g_BaseDir, "Video", FlashIn("%08d.bmp", g_VideoFrame)))
+				saving_img->Save(framepath, 24);
 		}
 		g_VideoFrame++;
 	}
@@ -287,10 +286,11 @@ void VideoCapture(
  */
 void CountPicture(){
 	FILE *file;
-	chdir(g_BaseDir);
-	chdir("Picture");
+	char path[RS2_PATH_MAX];
 	while(true){
-		if(file = fopen(FlashIn("%08d.bmp", g_PictureCount), "rb")){
+		if(!rs2_path_join(path, sizeof(path), g_BaseDir, "Picture", FlashIn("%08d.bmp", g_PictureCount)))
+			break;
+		if(file = fopen(path, "rb")){
 			fclose(file);
 			g_PictureCount++;
 		}else{
@@ -304,10 +304,11 @@ void CountPicture(){
  */
 void CountVideoBMP(){
 	FILE *file;
-	chdir(g_BaseDir);
-	chdir("Video");
+	char path[RS2_PATH_MAX];
 	while(true){
-		if(file = fopen(FlashIn("%08d.bmp", g_VideoFrame), "rb")){
+		if(!rs2_path_join(path, sizeof(path), g_BaseDir, "Video", FlashIn("%08d.bmp", g_VideoFrame)))
+			break;
+		if(file = fopen(path, "rb")){
 			fclose(file);
 			g_VideoFrame++;
 		}else{
@@ -321,10 +322,11 @@ void CountVideoBMP(){
  */
 void CountVideoAVI(){
 	FILE *file;
-	chdir(g_BaseDir);
-	chdir("Video");
+	char path[RS2_PATH_MAX];
 	while(true){
-		if(file = fopen(FlashIn("%08d.avi", g_VideoCount), "rb")){
+		if(!rs2_path_join(path, sizeof(path), g_BaseDir, "Video", FlashIn("%08d.avi", g_VideoCount)))
+			break;
+		if(file = fopen(path, "rb")){
 			fclose(file);
 			g_VideoCount++;
 		}else{
@@ -351,9 +353,9 @@ void StartVideoCapture(){
 	g_VideoSound = false;//!!g_VideoMode->GetVideoSound();
 	if(g_VideoFormat==1){
 		g_VideoAVIFrame = 0;
-		chdir(g_BaseDir);
-		chdir("Video");
-		std::string avifile_name = FlashIn("%08d.avi", g_VideoCount);
+		char avipath[RS2_PATH_MAX];
+		std::string avifile_name = rs2_path_join(avipath, sizeof(avipath), g_BaseDir, "Video", FlashIn("%08d.avi", g_VideoCount))
+			? avipath : FlashIn("%08d.avi", g_VideoCount);
 		const int video_frame_per_sec = 30;
 
 #if 0

--- a/Language.cpp
+++ b/Language.cpp
@@ -19,8 +19,8 @@ namespace LanguageResource
  *	Œ¾Œê‰Šú‰»
  */
 bool InitLanguage(){
-	chdir(g_BaseDir);
-	char *buf = LoadBinaryText(LANG_FILE_NAME), *str = buf, *eee;
+	char langpath[RS2_PATH_MAX];
+	char *buf = LoadBinaryText(rs2_path_join(langpath, sizeof(langpath), g_BaseDir, LANG_FILE_NAME)), *str = buf, *eee;
 
 	//	â‘Î•K—v‚È‚à‚Ì
 	SyntaxError = "Syntax error";

--- a/NOTICE
+++ b/NOTICE
@@ -62,6 +62,18 @@ modified work but are not listed as "changed upstream files".
   Updated:
     CMakeLists.txt, docs/porting/dev-env.md, docs/porting/upstream.md
 
+2026-08-31 -- Join g_BaseDir instead of chdir for the closed path set (#32)
+
+  Build / docs (new):
+    port/path.h, port/path.cpp, port/path_test.cpp
+  Updated:
+    CMakeLists.txt, port/stub/direct.h, port/stub/windows.h,
+    stdafx.h, docs/porting/path-seams.md, docs/porting/dev-env.md
+  Modified upstream sources (cwd join, keep game logic):
+    CPlugin.cpp, CSaveFile.cpp, CFileMode.cpp, CTrainGroupTemplate.cpp,
+    CRailwayPluginSet.cpp, CConfigMode.cpp, Language.cpp, Capture.cpp,
+    SystemCover.cpp
+
 Further changes must update this file (date + summary) and keep git
 history as the detailed record. Prefer leaving game logic untouched so
 diffs against upstream stay reviewable.

--- a/SystemCover.cpp
+++ b/SystemCover.cpp
@@ -209,7 +209,7 @@ void CutPath(
 	char *path	//	パス格納先
 ){
 	char *ptr = path+strlen(path);
-	for(; ptr>path && *ptr!='\\'; ptr = CharPrev(path, ptr)) *ptr = 0;
+	for(; ptr>path && *ptr!='\\' && *ptr!='/'; ptr = CharPrev(path, ptr)) *ptr = 0;
 }
 
 /*
@@ -220,8 +220,8 @@ void CutFileName(
 	char *path	//	フルパス
 ){
 	char *ptr = path+strlen(path);
-	while(ptr>path && *ptr!='\\') ptr = CharPrev(path, ptr);
-	strcpy(name, *ptr=='\\' ? ptr+1 : ptr);
+	while(ptr>path && *ptr!='\\' && *ptr!='/') ptr = CharPrev(path, ptr);
+	strcpy(name, (*ptr=='\\' || *ptr=='/') ? ptr+1 : ptr);
 }
 
 /*
@@ -242,7 +242,7 @@ void MoveToFile(
 ){
 	char *tmp = FlashIn("%s", path);
 	CutPath(tmp);
-	chdir(tmp);
+	rs2_chdir(tmp);
 }
 
 /*

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -32,7 +32,7 @@ brew bundle --file Brewfile
 | `./scripts/progress.sh` | Prints `N/254` JSON from `port/native_sources.txt` |
 | `cmake --preset check` | Configure AppleClang native target |
 | `cmake --build --preset check` | Compile allowlisted sources and link `railsim2` |
-| `ctest --preset check` | Smoke + `Sample.rs2` roundtrip + text `.x` load (see [rs2-roundtrip.md](rs2-roundtrip.md), [x-file-parser.md](x-file-parser.md)) |
+| `ctest --preset check` | Smoke + `Sample.rs2` roundtrip + text `.x` load + path join (see [rs2-roundtrip.md](rs2-roundtrip.md), [x-file-parser.md](x-file-parser.md), [path-seams.md](path-seams.md)) |
 
 ## Compile firewall
 

--- a/docs/porting/path-seams.md
+++ b/docs/porting/path-seams.md
@@ -169,15 +169,9 @@ Closed options for the later `#10` slice:
 
 `#10` must not rewrite the script parser, `%p` width, MD5, or float format inside this inventory.
 
-## What later slices may touch
+## Implemented by #32
 
-**`#4` (one implementation slice, not this PR)** may:
-
-- Replace the closed `chdir` / `CPlugin::ChDir` / `MoveToFile` set with joining `g_BaseDir` + subdir + basename (or a small helper used from those sites).
-- Implement `_findfirst` / `_findnext` / `_findclose` for the **four** patterns above, or swap those four loops to `std::filesystem::directory_iterator`.
-- Make `_fullpath` actually resolve against cwd (or against an explicit base), because mesh texture loads depend on it.
-- Teach `CutPath` / `GetAppPath` about `/` (and stub `GetModuleFileName`) when `SystemCover.cpp` is compiled.
-- Keep game logic (plugin scripts, layout grammar, capture encoding) unchanged.
+`port/path.cpp` joins `g_BaseDir` + subdir + basename. Closed-set `chdir` sites use that join. `CPlugin::ChDir` / `MoveToFile` set a **virtual cwd** (`rs2_chdir`); `fopen` is wrapped to `rs2_fopen` so plugin `Load()` riders stay relative. The four `_findfirst` loops call `rs2_list_dir`. `_fullpath` resolves against the virtual cwd. `CutPath` / `CutFileName` treat `/` like `\`. `GetModuleFileNameA` lives in `port/path.cpp`.
 
 **`#4` must not**: rewrite every plugin `Load()`, implement `timeGetTime`, touch `lib/mutex.h`, or mass-convert sources to UTF-8.
 
@@ -185,22 +179,23 @@ Closed options for the later `#10` slice:
 
 WASM: treating `g_BaseDir` as the virtual-FS mount and joining instead of `chdir` is the point of `#4`. This document is the call set that join must cover.
 
-## Stub status (current `check` build)
+## Stub status (after #32)
 
 | Stub | Behavior | Effect |
 |------|----------|--------|
-| `_findfirst` / `_findnext` | always `-1` | no plugins, no layout list, no templates, no railway sets |
-| `_fullpath` | copy `rel` | cache keys stay relative; `MoveToFile` cannot `chdir` to a POSIX dirname |
+| `_findfirst` / `_findnext` | still `-1` (unused) | four loops use `rs2_list_dir` |
+| `_fullpath` | `rs2_fullpath` against virtual cwd | mesh / texture / wave cache keys are absolute |
 | `SetCurrentDirectory` | always `TRUE` | unused |
-| `GetModuleFileName` | missing | `GetAppPath` / `g_BaseDir` not native-ready yet |
+| `GetModuleFileNameA` | exe path (or `rs2_set_module_filename`) | `GetAppPath` / `g_BaseDir` can be filled |
 
 ## Verification
 
-Re-run from the repo root if sources move. Expected at this commit: 45 `chdir(` matching lines (62 live calls); `_findfirst(` 4; `_fullpath(` 3 in `lib/`; `_getcwd` / `_chdir` none in game code; `SetCurrentDirectory` only the unused `CHANGE_DIR` macro.
+Closed-set `chdir` / `_findfirst` should be gone from game `.cpp` except the commented dump in `CRailBuildMode.cpp`. `_fullpath` remains in `lib/` and goes through the stub.
 
 ```bash
 rg -n --glob '!build/**' --glob '!.git/**' --glob '!Distribution/**' --glob '!port/stub/**' \
-  --glob '!docs/**' '\bchdir\s*\(|\b_chdir\s*\(|SetCurrentDirectory|_findfirst|_findnext|_fullpath|_getcwd'
+  --glob '!docs/**' --glob '!port/path*' \
+  '\bchdir\s*\(|\b_chdir\s*\(|SetCurrentDirectory|_findfirst|_findnext|_fullpath|_getcwd'
 ```
 
-`./scripts/check.sh` is unchanged (docs only).
+`./scripts/check.sh` must stay green (`rs2_path_self_test` + `rs2_path_distribution`).

--- a/port/path.cpp
+++ b/port/path.cpp
@@ -1,0 +1,238 @@
+#define RS2_PATH_NO_FOPEN_WRAP
+#include "path.h"
+
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <system_error>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
+typedef unsigned long DWORD;
+typedef void *HMODULE;
+typedef char *LPSTR;
+
+namespace {
+
+void slash_to_fwd(std::string *s) {
+	for (char &c : *s) {
+		if (c == '\\') c = '/';
+	}
+}
+
+std::string &cwd_store() {
+	static std::string cwd;
+	if (cwd.empty()) {
+		std::error_code ec;
+		auto p = std::filesystem::current_path(ec);
+		cwd = ec ? std::string(".") : p.string();
+		slash_to_fwd(&cwd);
+	}
+	return cwd;
+}
+
+int icmp(const char *a, const char *b) {
+	while (*a && *b) {
+		unsigned char ca = (unsigned char)std::tolower((unsigned char)*a++);
+		unsigned char cb = (unsigned char)std::tolower((unsigned char)*b++);
+		if (ca != cb) return (int)ca - (int)cb;
+	}
+	return (int)(unsigned char)*a - (int)(unsigned char)*b;
+}
+
+bool glob_match(const char *name, const char *pattern) {
+	if (!pattern || !std::strcmp(pattern, "*")) return true;
+	if (pattern[0] == '*' && pattern[1] == '.') {
+		const char *ext = pattern + 1;
+		size_t nl = std::strlen(name);
+		size_t el = std::strlen(ext);
+		if (nl < el) return false;
+		return icmp(name + nl - el, ext) == 0;
+	}
+	return icmp(name, pattern) == 0;
+}
+
+std::string join_parts(const char *const *parts, int nparts) {
+	std::string acc;
+	for (int i = 0; i < nparts; i++) {
+		const char *p = parts[i];
+		if (!p || !*p) continue;
+		std::string s = p;
+		slash_to_fwd(&s);
+		if (rs2_path_is_absolute(s.c_str())) {
+			acc = s;
+			continue;
+		}
+		while (!acc.empty() && acc.back() == '/') acc.pop_back();
+		while (!s.empty() && s.front() == '/') s.erase(s.begin());
+		if (acc.empty()) acc = s;
+		else acc.append("/").append(s);
+	}
+	return acc;
+}
+
+std::string resolve_string(const char *path) {
+	if (!path || !*path) return cwd_store();
+	std::string p = path;
+	slash_to_fwd(&p);
+	if (rs2_path_is_absolute(p.c_str())) return p;
+	std::string cwd = cwd_store();
+	while (!cwd.empty() && cwd.back() == '/') cwd.pop_back();
+	if (cwd.empty()) return p;
+	return cwd + "/" + p;
+}
+
+std::string &module_path_store() {
+	static std::string path;
+	return path;
+}
+
+std::string detect_exe_path() {
+	if (!module_path_store().empty()) return module_path_store();
+#ifdef __APPLE__
+	char buf[RS2_PATH_MAX];
+	uint32_t size = sizeof(buf);
+	if (_NSGetExecutablePath(buf, &size) == 0) {
+		std::error_code ec;
+		auto p = std::filesystem::weakly_canonical(buf, ec);
+		return ec ? std::string(buf) : p.string();
+	}
+#else
+	std::error_code ec;
+	auto p = std::filesystem::read_symlink("/proc/self/exe", ec);
+	if (!ec) return p.string();
+#endif
+	return cwd_store();
+}
+
+}  // namespace
+
+bool rs2_path_is_absolute(const char *path) {
+	if (!path || !*path) return false;
+	if (path[0] == '/' || path[0] == '\\') return true;
+	if (((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
+	    path[1] == ':')
+		return true;
+	return false;
+}
+
+char *rs2_path_join(char *out, size_t n, const char *a, const char *b, const char *c,
+                    const char *d) {
+	if (!out || n == 0) return nullptr;
+	const char *parts[] = {a, b, c, d};
+	std::string acc = join_parts(parts, 4);
+	if (acc.size() >= n) {
+		out[0] = 0;
+		return nullptr;
+	}
+	std::memcpy(out, acc.c_str(), acc.size() + 1);
+	return out;
+}
+
+bool rs2_is_dir(const char *path) {
+	if (!path || !*path) return false;
+	std::error_code ec;
+	return std::filesystem::is_directory(resolve_string(path), ec);
+}
+
+int rs2_chdir(const char *path) {
+	if (!path) return -1;
+	std::string resolved = resolve_string(path);
+	std::error_code ec;
+	if (!std::filesystem::is_directory(resolved, ec)) return -1;
+	slash_to_fwd(&resolved);
+	cwd_store() = resolved;
+	return 0;
+}
+
+char *rs2_getcwd(char *buf, size_t n) {
+	if (!buf || n == 0) return nullptr;
+	const std::string &cwd = cwd_store();
+	if (cwd.size() >= n) return nullptr;
+	std::memcpy(buf, cwd.c_str(), cwd.size() + 1);
+	return buf;
+}
+
+FILE *rs2_fopen(const char *path, const char *mode) {
+	if (!path || !mode) return nullptr;
+	std::string full = resolve_string(path);
+	return std::fopen(full.c_str(), mode);
+}
+
+int rs2_mkdir(const char *path) {
+	if (!path || !*path) return -1;
+	std::string full = resolve_string(path);
+	std::error_code ec;
+	std::filesystem::create_directory(full, ec);
+	if (std::filesystem::is_directory(full, ec)) return 0;
+	return -1;
+}
+
+int rs2_rename(const char *from, const char *to) {
+	if (!from || !to) return -1;
+	std::error_code ec;
+	std::filesystem::rename(resolve_string(from), resolve_string(to), ec);
+	return ec ? -1 : 0;
+}
+
+int rs2_remove(const char *path) {
+	if (!path || !*path) return -1;
+	std::error_code ec;
+	bool ok = std::filesystem::remove(resolve_string(path), ec);
+	return (!ok || ec) ? -1 : 0;
+}
+
+char *rs2_fullpath(char *abs, const char *rel, size_t size) {
+	if (!rel || !abs || size == 0) return nullptr;
+	std::string r = resolve_string(rel);
+	std::error_code ec;
+	auto p = std::filesystem::weakly_canonical(std::filesystem::path(r), ec);
+	if (!ec) r = p.string();
+	slash_to_fwd(&r);
+	if (r.size() >= size) return nullptr;
+	std::memcpy(abs, r.c_str(), r.size() + 1);
+	return abs;
+}
+
+bool rs2_list_dir(const char *dir, const char *pattern, bool subdirs_only,
+                  std::vector<std::string> *out) {
+	if (!dir || !out) return false;
+	out->clear();
+	std::error_code ec;
+	std::filesystem::directory_iterator it(resolve_string(dir), ec);
+	if (ec) return false;
+	for (const auto &entry : it) {
+		std::string name = entry.path().filename().string();
+		if (name == "." || name == "..") continue;
+		bool is_dir = entry.is_directory(ec);
+		if (subdirs_only) {
+			if (!is_dir) continue;
+		} else if (is_dir) {
+			continue;
+		}
+		if (!glob_match(name.c_str(), pattern)) continue;
+		out->push_back(name);
+	}
+	return true;
+}
+
+void rs2_set_module_filename(const char *path) {
+	module_path_store() = path ? path : "";
+	slash_to_fwd(&module_path_store());
+}
+
+DWORD GetModuleFileNameA(HMODULE, LPSTR buf, DWORD size) {
+	if (!buf || !size) return 0;
+	std::string path = detect_exe_path();
+	slash_to_fwd(&path);
+	if (path.size() >= size) {
+		std::memcpy(buf, path.c_str(), size - 1);
+		buf[size - 1] = 0;
+		return size;
+	}
+	std::memcpy(buf, path.c_str(), path.size() + 1);
+	return (DWORD)path.size();
+}

--- a/port/path.h
+++ b/port/path.h
@@ -1,0 +1,38 @@
+// Join g_BaseDir + subdir + basename instead of chdir + relative I/O (#32).
+// Game logic stays in the closed set in docs/porting/path-seams.md.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#ifndef RS2_PATH_MAX
+#define RS2_PATH_MAX 1024
+#endif
+
+char *rs2_path_join(char *out, size_t n, const char *a, const char *b = nullptr,
+                     const char *c = nullptr, const char *d = nullptr);
+bool rs2_path_is_absolute(const char *path);
+bool rs2_is_dir(const char *path);
+
+int rs2_chdir(const char *path);
+char *rs2_getcwd(char *buf, size_t n);
+
+FILE *rs2_fopen(const char *path, const char *mode);
+int rs2_mkdir(const char *path);
+int rs2_rename(const char *from, const char *to);
+int rs2_remove(const char *path);
+char *rs2_fullpath(char *abs, const char *rel, size_t size);
+
+bool rs2_list_dir(const char *dir, const char *pattern, bool subdirs_only,
+                  std::vector<std::string> *out);
+
+void rs2_set_module_filename(const char *path);
+
+#ifdef RS2_PORTABLE_COMPILE_FIREWALL
+#ifndef RS2_PATH_NO_FOPEN_WRAP
+#define fopen rs2_fopen
+#endif
+#endif

--- a/port/path_test.cpp
+++ b/port/path_test.cpp
@@ -1,0 +1,163 @@
+// Path join / list / fullpath self-test (#32). Does not link CSaveFile.
+
+#include "path.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+const int kSkip = 77;
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+int self_test() {
+	char buf[RS2_PATH_MAX];
+	if (!expect(rs2_path_join(buf, sizeof(buf), "/base", "Layout", "Sample.rs2") &&
+	                std::strcmp(buf, "/base/Layout/Sample.rs2") == 0,
+	            "join three parts"))
+		return 1;
+	if (!expect(rs2_path_join(buf, sizeof(buf), "C:\\RailSim2\\", "Layout") &&
+	                std::strcmp(buf, "C:/RailSim2/Layout") == 0,
+	            "join converts backslash"))
+		return 1;
+	if (!expect(rs2_path_is_absolute("/tmp") && rs2_path_is_absolute("D:\\x") &&
+	                !rs2_path_is_absolute("Layout"),
+	            "is_absolute"))
+		return 1;
+
+	std::error_code ec;
+	auto tmp = std::filesystem::temp_directory_path(ec) / "rs2-path-test";
+	std::filesystem::remove_all(tmp, ec);
+	std::filesystem::create_directories(tmp / "Layout", ec);
+	std::filesystem::create_directories(tmp / "Rail" / "Default_JR_Narrow", ec);
+	{
+		std::ofstream f((tmp / "Layout" / "Sample.rs2").string());
+		f << "ok\n";
+	}
+	{
+		std::ofstream f((tmp / "Rail" / "Default_JR_Narrow" / "Rail2.txt").string());
+		f << "ok\n";
+	}
+
+	if (!expect(rs2_chdir(tmp.string().c_str()) == 0, "chdir tmp")) return 1;
+
+	char full[RS2_PATH_MAX];
+	if (!rs2_fullpath(full, "Layout/Sample.rs2", sizeof(full))) {
+		std::fprintf(stderr, "self-test: fullpath failed\n");
+		return 1;
+	}
+	if (!expect(std::strstr(full, "Layout/Sample.rs2") != nullptr, "fullpath suffix"))
+		return 1;
+
+	std::vector<std::string> names;
+	if (!rs2_path_join(buf, sizeof(buf), tmp.string().c_str(), "Layout")) return 1;
+	if (!expect(rs2_list_dir(buf, "*.rs2", false, &names) && names.size() == 1 &&
+	                names[0] == "Sample.rs2",
+	            "list *.rs2"))
+		return 1;
+
+	if (!rs2_path_join(buf, sizeof(buf), tmp.string().c_str(), "Rail")) return 1;
+	if (!expect(rs2_list_dir(buf, "*", true, &names) && names.size() == 1 &&
+	                names[0] == "Default_JR_Narrow",
+	            "list plugin subdirs"))
+		return 1;
+	for (const auto &n : names) {
+		if (n == "." || n == "..") {
+			std::fprintf(stderr, "self-test: listed %s\n", n.c_str());
+			return 1;
+		}
+	}
+
+	char sample[RS2_PATH_MAX];
+	if (!rs2_path_join(sample, sizeof(sample), tmp.string().c_str(), "Layout", "Sample.rs2"))
+		return 1;
+	FILE *f = rs2_fopen(sample, "rb");
+	if (!expect(f != nullptr, "fopen joined Sample.rs2")) return 1;
+	std::fclose(f);
+
+	if (!expect(rs2_chdir("Layout") == 0, "chdir relative Layout")) return 1;
+	f = rs2_fopen("Sample.rs2", "rb");
+	if (!expect(f != nullptr, "fopen relative after virtual cwd")) return 1;
+	std::fclose(f);
+
+	std::filesystem::remove_all(tmp, ec);
+	return 0;
+}
+
+int list_distribution(const char *root) {
+	namespace fs = std::filesystem;
+	std::error_code ec;
+	if (!fs::is_directory(root, ec)) {
+		std::fprintf(stderr, "skip: no fixture at %s\n", root);
+		return kSkip;
+	}
+
+	char base[RS2_PATH_MAX];
+	if (rs2_path_join(base, sizeof(base), root, "en", "RailSim2") && rs2_is_dir(base)) {
+		// keep base
+	} else if (rs2_path_join(base, sizeof(base), root, "RailSim2") && rs2_is_dir(base)) {
+		// keep base
+	} else {
+		std::fprintf(stderr, "skip: no RailSim2 under %s\n", root);
+		return kSkip;
+	}
+
+	char layout[RS2_PATH_MAX];
+	if (!rs2_path_join(layout, sizeof(layout), base, "Layout")) return 1;
+	std::vector<std::string> names;
+	if (!rs2_list_dir(layout, "*.rs2", false, &names)) {
+		std::fprintf(stderr, "list Layout failed: %s\n", layout);
+		return 1;
+	}
+	bool found_sample = false;
+	for (const auto &n : names) {
+		if (n == "Sample.rs2") found_sample = true;
+	}
+	if (!found_sample) {
+		std::fprintf(stderr, "Sample.rs2 missing under %s (%zu entries)\n", layout,
+		             names.size());
+		return 1;
+	}
+
+	char rail[RS2_PATH_MAX];
+	if (!rs2_path_join(rail, sizeof(rail), base, "Rail")) return 1;
+	if (!rs2_list_dir(rail, "*", true, &names) || names.empty()) {
+		std::fprintf(stderr, "Rail plugin dirs missing under %s\n", rail);
+		return 1;
+	}
+	for (const auto &n : names) {
+		if (n == "." || n == "..") return 1;
+	}
+
+	char sample[RS2_PATH_MAX];
+	if (!rs2_path_join(sample, sizeof(sample), base, "Layout", "Sample.rs2")) return 1;
+	FILE *f = rs2_fopen(sample, "rb");
+	if (!f) {
+		std::fprintf(stderr, "fopen failed: %s\n", sample);
+		return 1;
+	}
+	std::fclose(f);
+	std::printf("path: listed Layout and Rail under %s\n", base);
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	if (argc < 2) {
+		std::fprintf(stderr, "usage: rs2_path_test --self-test | <Distribution>\n");
+		return 2;
+	}
+	int st = self_test();
+	if (st) return st;
+	return list_distribution(argv[1]);
+}

--- a/port/stub/direct.h
+++ b/port/stub/direct.h
@@ -20,13 +20,10 @@ inline int mkdir(const char* path) { return ::mkdir(path, 0755); }
 #define _chdir chdir
 #endif
 
+#include "../path.h"
+
 #ifndef _fullpath
 inline char* _fullpath(char* abs, const char* rel, size_t size) {
-  if (!rel) return nullptr;
-  if (abs) {
-    std::snprintf(abs, size, "%s", rel);
-    return abs;
-  }
-  return nullptr;
+  return rs2_fullpath(abs, rel, size);
 }
 #endif

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -410,6 +410,17 @@ inline void LeaveCriticalSection(LPCRITICAL_SECTION) {}
 inline FARPROC GetProcAddress(HMODULE, LPCSTR) { return nullptr; }
 inline DWORD GetLastError() { return 0; }
 
+#ifndef _MAX_PATH
+#define _MAX_PATH 260
+#endif
+
+inline HMODULE GetModuleHandleA(LPCSTR) { return (HMODULE)1; }
+inline HMODULE GetModuleHandle(LPCSTR p) { return GetModuleHandleA(p); }
+DWORD GetModuleFileNameA(HMODULE, LPSTR, DWORD);
+inline DWORD GetModuleFileName(HMODULE m, LPSTR b, DWORD s) {
+  return GetModuleFileNameA(m, b, s);
+}
+
 #ifndef __argc
 inline int rs2_argc() { return 0; }
 inline char** rs2_argv() { return nullptr; }

--- a/stdafx.h
+++ b/stdafx.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <algorithm>
 #include "lib/udx.h"
+#include "port/path.h"
 
 typedef list<string>::iterator Istring;
 


### PR DESCRIPTION
## Summary
- Replace the closed `chdir` / `_findfirst` set from `docs/porting/path-seams.md` with `g_BaseDir` joins in `port/path.cpp`. Plugin `Load()` stays relative; `CPlugin::ChDir` is the seam (virtual cwd + `fopen` wrap).
- The four listing loops (`CPluginList::List`, `CFileMode::ListFile`, train-group templates, railway plugin sets) use `std::filesystem` via `rs2_list_dir`, skipping `.` / `..`.
- `_fullpath` resolves against that virtual cwd. `CutPath` / `CutFileName` treat `/`. `GetModuleFileNameA` is stubbed. `CSaveFile::Load` / `Save` signatures are unchanged.

Closes #32

## Test plan
- [x] `./scripts/check.sh` green locally (encoding-guard, native build, 7 ctests including `rs2_path_self_test` and `rs2_path_distribution`)
- [ ] Confirm CI macOS + Linux matrix is green
- [ ] Spot-check that no live `chdir` / `_findfirst` remains outside the commented dump in `CRailBuildMode.cpp`


Made with [Cursor](https://cursor.com)