### PR TITLE
Replace timeGetTime with std::chrono::steady_clock for FPS sync

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -74,6 +74,12 @@ modified work but are not listed as "changed upstream files".
     CRailwayPluginSet.cpp, CConfigMode.cpp, Language.cpp, Capture.cpp,
     SystemCover.cpp
 
+2026-08-31 -- Replace timeGetTime with std::chrono::steady_clock (#33)
+
+  Modified upstream sources:
+    lib/main.cpp    -- CFrame::Init / Sync use a monotonic millisecond clock
+    lib/headers.h   -- mmsystem.h stays for WAVEFORMATEX / mmio
+
 Further changes must update this file (date + summary) and keep git
 history as the detailed record. Prefer leaving game logic untouched so
 diffs against upstream stay reviewable.

--- a/lib/headers.h
+++ b/lib/headers.h
@@ -3,7 +3,7 @@
 #include <io.h>
 #include <direct.h>
 #include <windows.h>
-#include <mmsystem.h>	//	timeGetTime()
+#include <mmsystem.h>	//	WAVEFORMATEX / mmio*
 #include <imm.h>			//	IMEŠÖ˜A
 #include <stdio.h>
 #include <math.h>

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -3,6 +3,15 @@
 #include "udx.h"
 #include "libraries.h"
 #include "sysvalue.h"
+#include <chrono>
+
+static DWORD Rs2SteadyMs(){
+	using clock = std::chrono::steady_clock;
+	static const clock::time_point origin = clock::now();
+	return (DWORD)std::chrono::duration_cast<std::chrono::milliseconds>(
+		clock::now() - origin).count();
+}
+
 
 /*
  *	コンパイル・オプション
@@ -156,7 +165,7 @@ void CFrame::Init(){
 
 	frame = 0;
 	cnt = 0;
-	start = timeGetTime();
+	start = Rs2SteadyMs();
 	old = start;
 	fps = MAXFPS;
 	framecnt = MAXFPS;
@@ -171,7 +180,7 @@ void CFrame::Sync(){
 	DWORD now;	//	現在時間
 	DWORD diff;	//	経過時間
 
-	now = timeGetTime();
+	now = Rs2SteadyMs();
 	diff = now-start;
 	frame++;
 


### PR DESCRIPTION
## Summary
- `CFrame::Init` / `Sync` now read milliseconds from `std::chrono::steady_clock` instead of `timeGetTime()`. DWORD diffs and wait math are unchanged.
- `<mmsystem.h>` stays in `lib/headers.h` because `WAVEFORMATEX` and `mmio*` (wave / AVI) still need it.

Closes #33

## Test plan
- [x] `./scripts/check.sh` green locally
- [ ] Confirm CI macOS + Linux matrix is green
- [ ] `rg timeGetTime` has no game call sites (stub in `port/stub/mmsystem.h` only)


Made with [Cursor](https://cursor.com)