### PR TITLE
Make CMutex single-instance lock a portable no-op

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -80,6 +80,11 @@ modified work but are not listed as "changed upstream files".
     lib/main.cpp    -- CFrame::Init / Sync use a monotonic millisecond clock
     lib/headers.h   -- mmsystem.h stays for WAVEFORMATEX / mmio
 
+2026-08-31 -- CMutex single-instance lock is a portable no-op (#37)
+
+  Modified upstream sources:
+    lib/mutex.h     -- BeginSingleBoot always succeeds; no CreateMutex
+
 Further changes must update this file (date + summary) and keep git
 history as the detailed record. Prefer leaving game logic untouched so
 diffs against upstream stay reviewable.

--- a/lib/mutex.h
+++ b/lib/mutex.h
@@ -1,9 +1,6 @@
 //	Copyright (c) 2002 Midikyou
 
-#define MUTEX_NAME "udx mutex"
-
 class CMutex{
-	HANDLE m_hMutex;
 public:
 
 	BOOL BeginSingleBoot();
@@ -11,23 +8,14 @@ public:
 };
 
 /*
- *	多重起動禁止
+ *	Single-instance lock (portable no-op).
+ *
+ *	Windows used a named mutex with timeout 0. That lock is not
+ *	reproduced here; multiple instances are allowed (issue #37).
  */
 inline BOOL CMutex::BeginSingleBoot(){
-	Debug("多重起動を禁止します.\n");
-
-	m_hMutex = CreateMutex(NULL, FALSE, MUTEX_NAME);
-	DWORD ret = WaitForSingleObject(m_hMutex, 0);
-
-	if(!(ret==WAIT_OBJECT_0 || ret==WAIT_ABANDONED))
-		return FALSE;
-	else
-		return TRUE;
+	return TRUE;
 }
 
-/*
- *	多重起動解禁
- */
 inline void CMutex::EndSingleBoot(){
-	ReleaseMutex(m_hMutex);
 }


### PR DESCRIPTION
## Summary
- Decide the Win32 named-mutex single-instance lock as a portable no-op: `CMutex::BeginSingleBoot` always succeeds, `EndSingleBoot` does nothing.
- Drop `CreateMutex` / `WaitForSingleObject` / `ReleaseMutex` from `lib/mutex.h`. `CApp` still calls the same methods. Wave streaming keeps the WaitForSingleObject stubs in `port/stub/windows.h`.

Closes #37

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, native build, 7 ctests)
- [ ] CI macOS + Linux matrix


Made with [Cursor](https://cursor.com)