### PR TITLE
Wire rs2_roundtrip through CSaveFile::Load/Save (#36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,6 @@ FodyWeavers.xsd
 /Debug_vc2010
 /Release_vc2010
 /build/
+
+# Roundtrip harness output under Layout (#36)
+Distribution/**/Layout/rs2_roundtrip_out.rs2

--- a/CDragContainer.h
+++ b/CDragContainer.h
@@ -1,6 +1,8 @@
 #ifndef CDRAGCONTAINER_H_INCLUDED
 #define CDRAGCONTAINER_H_INCLUDED
 
+class CDragInterface;
+
 const int DRAG_THD = FONT_HEIGHT/2;
 
 //	”½•œŽq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,15 +65,41 @@ target_compile_definitions(railsim2 PRIVATE
   NOMINMAX
 )
 
-# Byte-compare harness only. Does not link railsim2_native / CSaveFile (#10).
-add_executable(rs2_roundtrip port/rs2_roundtrip.cpp)
+# Sample.rs2 Load/Save via CSaveFile (#36). Stubs fill the object graph;
+# byte-identity remains parent #10. Does not link the full railsim2_native.a.
+add_executable(rs2_roundtrip
+  port/rs2_roundtrip.cpp
+  port/rs2_roundtrip_stubs.cpp
+  port/path.cpp
+  CSaveFile.cpp
+  Script.cpp
+  md5.cpp
+)
+target_include_directories(rs2_roundtrip SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub"
+)
+target_include_directories(rs2_roundtrip PRIVATE
+  "${CMAKE_SOURCE_DIR}"
+  "${CMAKE_SOURCE_DIR}/lib"
+  "${CMAKE_SOURCE_DIR}/port"
+)
 target_compile_features(rs2_roundtrip PRIVATE cxx_std_17)
-target_compile_options(rs2_roundtrip PRIVATE -Wall -Wextra)
+target_compile_options(rs2_roundtrip PRIVATE
+  -Wall
+  -Wextra
+  -Wno-invalid-source-encoding
+  -Wno-address-of-temporary
+)
+target_compile_definitions(rs2_roundtrip PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
+)
 
 set(RS2_ROUNDTRIP_FIXTURE
   "${CMAKE_SOURCE_DIR}/Distribution/en/RailSim2/Layout/Sample.rs2")
+# Save requires a basename under Layout (CheckSlash); compare uses this path.
 set(RS2_ROUNDTRIP_OUTPUT
-  "${CMAKE_BINARY_DIR}/rs2_roundtrip_out.rs2")
+  "${CMAKE_SOURCE_DIR}/Distribution/en/RailSim2/Layout/rs2_roundtrip_out.rs2")
 
 enable_testing()
 add_test(NAME rs2_smoke COMMAND "${CMAKE_COMMAND}" -E echo "ctest skeleton ok")
@@ -81,7 +107,11 @@ add_test(NAME rs2_roundtrip_reports_diff COMMAND rs2_roundtrip --self-test-diff)
 add_test(NAME rs2_roundtrip COMMAND rs2_roundtrip
   "${RS2_ROUNDTRIP_FIXTURE}"
   "${RS2_ROUNDTRIP_OUTPUT}")
-set_tests_properties(rs2_roundtrip PROPERTIES SKIP_RETURN_CODE 77)
+# Fixture missing -> 77 skip. Expected Load/Save mismatch -> 1 (WILL_FAIL).
+set_tests_properties(rs2_roundtrip PROPERTIES
+  SKIP_RETURN_CODE 77
+  WILL_FAIL TRUE
+)
 
 # Closed text X-File parser (#28). Does not replace CMesh::Load (#6).
 add_executable(rs2_xfile_load port/xfile_load.cpp port/xfile.cpp)

--- a/CRailLink.h
+++ b/CRailLink.h
@@ -50,7 +50,7 @@ public:
 	CRailConnector *m_Link;	//	ƒŠƒ“ƒN
 public:
 	CRailConnectorLink(){ m_Side = m_Point = 0; m_Link = NULL; }
-	CRailConnectorLink::CRailConnectorLink(int side, int point, CRailConnector *link){
+	CRailConnectorLink(int side, int point, CRailConnector *link){
 		m_Side = side; m_Point = point; m_Link = link;
 	}
 	void Connect(CRailWayLink &);
@@ -77,7 +77,7 @@ public:
 	CRailWay *m_Link;	//	ƒŠƒ“ƒN
 public:
 	CRailWayLink(){ m_Side = 0; m_Link = NULL; }
-	CRailWayLink::CRailWayLink(int side, CRailWay *link){ m_Side = side; m_Link = link; }
+	CRailWayLink(int side, CRailWay *link){ m_Side = side; m_Link = link; }
 	float GetCant();
 	VEC3 GetPos();
 	VEC3 GetOppositePos();

--- a/CRailWay.h
+++ b/CRailWay.h
@@ -18,6 +18,7 @@ class CLinePlugin;
 class CPolePlugin;
 class CDetectInfo;
 class CRailWayParentLink;
+class CTrainGroup;
 
 /*
  *	橋脚位置データ

--- a/CTrainSetBuffer.h
+++ b/CTrainSetBuffer.h
@@ -3,6 +3,8 @@
 
 class CRailWay;
 class CAxleObject;
+class CTrain;
+class CTrainGroup;
 
 /*
  *	車軸姿勢バッファ

--- a/docs/porting/rs2-roundtrip.md
+++ b/docs/porting/rs2-roundtrip.md
@@ -4,7 +4,7 @@
 - **Binary**: `rs2_roundtrip` (`port/rs2_roundtrip.cpp`), built by the `check` preset
 - **ctest**: `rs2_roundtrip` and `rs2_roundtrip_reports_diff`
 
-This is the mechanical gate for `#10`'s "load then save, byte diff zero" goal. It does **not** call `CSaveFile` yet (that still needs udx globals). `#10` should replace `rs2_layout_roundtrip()` with `CSaveFile::Load` + `CSaveFile::Save`. Do not "fix" `%p` width, MD5, or float format in the harness.
+This is the mechanical gate for `#10`'s "load then save, byte diff zero" goal. `#36` wires `rs2_layout_roundtrip()` through `CSaveFile::Load` + `CSaveFile::Save` (path-seams option 1: `g_BaseDir` + Layout basenames). Object-graph `Read`/`Save` are still stubbed, so the ctest is marked `WILL_FAIL` until byte-identity work in `#10`. Do not "fix" `%p` width, MD5, or float format in the harness.
 
 ## Fixture
 
@@ -24,11 +24,11 @@ Japanese `Distribution/jp/RailSim2/Layout/Sample.rs2` is CP932; pass it locally 
 ctest --preset check --output-on-failure -R rs2_roundtrip
 
 # explicit paths (any .rs2):
-./build/check/rs2_roundtrip Distribution/en/RailSim2/Layout/Sample.rs2 /tmp/out.rs2
+./build/check/rs2_roundtrip Distribution/en/RailSim2/Layout/Sample.rs2 Distribution/en/RailSim2/Layout/rs2_roundtrip_out.rs2
 ```
 
 `rs2_roundtrip_reports_diff` feeds two different buffers to the comparator and checks that the failure text is `roundtrip diff`, not a missing-harness error.
 
-## After `#10` wires `CSaveFile`
+## After `#36` (current)
 
-A real save will likely differ (`%p` width on 64-bit, `LayoutInfo.Date` from `GetLocalTime`, float `%f`). That must fail as **roundtrip diff** with sizes and the first mismatch offset. Byte-identity is `#10`'s job, not this harness.
+`rs2_roundtrip` links `CSaveFile.cpp` plus `port/rs2_roundtrip_stubs.cpp`. A real byte-identical save still needs the object graph and `%p` / MD5 / float work under `#10`. Until then the test is expected to exit 1 with **roundtrip diff** (ctest `WILL_FAIL`); missing fixture still exits 77 and skips.

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -16,6 +16,7 @@ CPartsInst.cpp
 CPopMenu.cpp
 CPushButton.cpp
 CRadioButton.cpp
+CSaveFile.cpp
 CScrollBarV.cpp
 CSimpleDialog.cpp
 CStaticCtrl.cpp

--- a/port/rs2_roundtrip.cpp
+++ b/port/rs2_roundtrip.cpp
@@ -1,10 +1,9 @@
-// Layout load->save byte-compare harness for ctest (issue #24).
+#define RS2_PATH_NO_FOPEN_WRAP 1
+// Layout load->save byte-compare harness (issues #24 / #36).
 //
-// Does not call CSaveFile: that object graph still needs udx globals and
-// is #10. The save path is rs2_layout_roundtrip() -- replace its body
-// with CSaveFile::Load + CSaveFile::Save. Until then this copies bytes so
-// the compare step always runs (a mismatch prints "roundtrip diff", never
-// "harness not connected").
+// Calls CSaveFile::Load + CSaveFile::Save (path-seams option 1).
+// Object-graph Read/Save still stubbed (#36); a failed Load/Save or a
+// byte mismatch prints "roundtrip diff". Do not "fix" %p / MD5 / float.
 //
 // Exit codes:
 //   0  byte-identical, or --self-test-diff passed
@@ -12,8 +11,13 @@
 //   2  bad usage
 //  77  skipped (fixture missing) -- ctest SKIP_RETURN_CODE
 //
-// Local: rs2_roundtrip Distribution/en/RailSim2/Layout/Sample.rs2 /tmp/out.rs2
-// CI:    the check preset points at that path; skip if Distribution is absent.
+// Local: rs2_roundtrip Distribution/en/RailSim2/Layout/Sample.rs2 \
+//          Distribution/en/RailSim2/Layout/rs2_roundtrip_out.rs2
+
+#include "stdafx.h"
+#include "CSaveFile.h"
+#include "SystemCover.h"
+#include "port/path.h"
 
 #include <cstdio>
 #include <cstring>
@@ -21,6 +25,9 @@
 #include <iterator>
 #include <string>
 #include <vector>
+
+extern char g_BaseDir[1024];
+void rs2_roundtrip_init_stubs();
 
 namespace {
 
@@ -36,29 +43,66 @@ bool read_file(const char *path, std::vector<unsigned char> *out, std::string *e
 	return true;
 }
 
-bool write_file(const char *path, const std::vector<unsigned char> &data, std::string *err) {
-	std::ofstream out(path, std::ios::binary);
-	if (!out) {
-		*err = std::string("cannot write ") + path;
+// Basename of path (accepts / and \).
+const char *path_basename(const char *path) {
+	const char *base = path;
+	for (const char *p = path; *p; ++p) {
+		if (*p == '/' || *p == '\\') base = p + 1;
+	}
+	return base;
+}
+
+// in_path = .../RailSim2/Layout/Sample.rs2 -> set g_BaseDir to .../RailSim2
+bool set_base_dir_from_layout_file(const char *in_path, std::string *err) {
+	std::string path(in_path);
+	for (char &c : path) {
+		if (c == '\\') c = '/';
+	}
+	const std::string marker = "/Layout/";
+	const std::size_t pos = path.rfind(marker);
+	if (pos == std::string::npos) {
+		*err = std::string("expected .../Layout/<file> path, got ") + in_path;
 		return false;
 	}
-	out.write(reinterpret_cast<const char *>(data.data()),
-		static_cast<std::streamsize>(data.size()));
-	if (!out) {
-		*err = std::string("write failed: ") + path;
+	const std::string base = path.substr(0, pos);
+	if (base.size() >= 1024) {
+		*err = "g_BaseDir too long";
 		return false;
 	}
+	std::memcpy(g_BaseDir, base.c_str(), base.size() + 1);
 	return true;
 }
 
-// #10: replace with CSaveFile::Load(in_path) then CSaveFile::Save(out_path).
-// Do not "fix" %p width, MD5, or float format here -- those belong to #10.
+// Option 1: g_BaseDir + Load(basename, "Layout") + Save(basename, "Layout").
+// Never pass an absolute path to Save (CheckSlash rejects it).
 bool rs2_layout_roundtrip(const char *in_path, const char *out_path, std::string *err) {
-	std::vector<unsigned char> loaded;
-	if (!read_file(in_path, &loaded, err)) {
+	rs2_roundtrip_init_stubs();
+	if (!set_base_dir_from_layout_file(in_path, err)) {
 		return false;
 	}
-	return write_file(out_path, loaded, err);
+
+	const char *in_base = path_basename(in_path);
+	const char *out_base = path_basename(out_path);
+	if (!in_base || !*in_base || !out_base || !*out_base) {
+		*err = "missing input/output basename";
+		return false;
+	}
+	if (CheckSlash(in_base) || CheckSlash(out_base)) {
+		*err = "basename must not contain a slash";
+		return false;
+	}
+
+	CSaveFile save(false);
+	if (!save.Load(in_base, "Layout", false, true, nullptr, nullptr, false, nullptr)) {
+		*err = "CSaveFile::Load failed";
+		return false;
+	}
+	const int rc = save.Save(out_base, "Layout", true, false);
+	if (rc != 0) {
+		*err = std::string("CSaveFile::Save failed rc=") + std::to_string(rc);
+		return false;
+	}
+	return true;
 }
 
 int report_diff(const std::vector<unsigned char> &loaded,
@@ -116,14 +160,21 @@ int main(int argc, char **argv) {
 
 	std::string err;
 	if (!rs2_layout_roundtrip(in_path, out_path, &err)) {
-		// Save/load of a present fixture must not look like a missing harness.
 		std::fprintf(stderr, "roundtrip diff: %s\n", err.c_str());
+		return 1;
+	}
+
+	// Compare by absolute paths outside CSaveFile. Save wrote under Layout/.
+	char saved_abs[RS2_PATH_MAX];
+	if (!rs2_path_join(saved_abs, sizeof(saved_abs), g_BaseDir, "Layout",
+			path_basename(out_path))) {
+		std::fprintf(stderr, "roundtrip diff: cannot join saved path\n");
 		return 1;
 	}
 
 	std::vector<unsigned char> loaded;
 	std::vector<unsigned char> saved;
-	if (!read_file(in_path, &loaded, &err) || !read_file(out_path, &saved, &err)) {
+	if (!read_file(in_path, &loaded, &err) || !read_file(saved_abs, &saved, &err)) {
 		std::fprintf(stderr, "roundtrip diff: %s\n", err.c_str());
 		return 1;
 	}

--- a/port/rs2_roundtrip_stubs.cpp
+++ b/port/rs2_roundtrip_stubs.cpp
@@ -1,0 +1,528 @@
+// Link stubs for rs2_roundtrip -> CSaveFile::Load/Save (#36).
+// Real object graphs (CTrainGroup::Read, CScene::Read, ...) stay out of this
+// slice; Load is expected to fail into CSynErr and report roundtrip diff.
+// Do not use these stubs outside the roundtrip harness.
+
+#include "stdafx.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <new>
+#include <string>
+
+#include "CSaveFile.h"
+#include "CConfigMode.h"
+#include "CSimulationMode.h"
+#include "CSkinPlugin.h"
+#include "CRailWay.h"
+#include "CTrainGroup.h"
+#include "CScene.h"
+#include "CSimpleDialog.h"
+#include "CParticle.h"
+#include "CListView.h"
+#include "CModelInst.h"
+#include "CWindowDivInfo.h"
+#include "CDiaInst.h"
+#include "CTrainSetBuffer.h"
+#include "md5.h"
+#include "Language.h"
+#include "SystemCover.h"
+#include "port/path.h"
+#include "CRailPlugin.h"
+#include "CTiePlugin.h"
+#include "CGirderPlugin.h"
+#include "CPierPlugin.h"
+#include "CLinePlugin.h"
+#include "CModelSwitch.h"
+#include "CLensFlare.h"
+#include "CNamedObject.h"
+
+namespace {
+
+alignas(CSimulationMode) unsigned char g_sim_storage[sizeof(CSimulationMode)];
+alignas(CConfigMode) unsigned char g_cfg_storage[sizeof(CConfigMode)];
+alignas(CSkinPlugin) unsigned char g_skin_storage[sizeof(CSkinPlugin)];
+
+char g_flash_buf[8][1024];
+int g_flash_sel = 0;
+
+}  // namespace
+
+// --- constants / globals expected by CSaveFile ---
+
+const float RAILSIM_VERSION = 2.15f;
+const char *LAYOUT_DIRNAME = "Layout";
+char *YESNO[] = {(char *)"No", (char *)"Yes"};
+
+char g_BaseDir[1024];
+CSaveFile *g_SaveFile = nullptr;
+CSimulationMode *g_SimulationMode =
+	reinterpret_cast<CSimulationMode *>(g_sim_storage);
+CConfigMode *g_ConfigMode = reinterpret_cast<CConfigMode *>(g_cfg_storage);
+CSkinPlugin *g_Skin = reinterpret_cast<CSkinPlugin *>(g_skin_storage);
+CTrain *g_CabinViewTrain = nullptr;
+CSurfacePlugin *g_DefaultSurface = nullptr;
+CEnvPlugin *g_DefaultEnv = nullptr;
+map<std::string, CTrainGroup *> g_RailBlockMap;
+int g_NetworkDummyMapAddress = 1;
+bool g_NetworkInitialized = false;
+int g_NetworkSyncLimitReceived = 0;
+int g_NetworkSyncLimitSent = 0;
+int g_DispWidth = 640;
+int g_DispHeight = 480;
+int g_RSPV = 0;
+CCursor g_Cursor;
+CStringTexture *g_StrTex = nullptr;
+CWindowCtrl *g_ModalDialog = nullptr;
+VEC3 g_WindDir;
+VEC3 g_WindDirNorm;
+CFrame g_frame;
+SYSVALUE_3D sv3;
+char *g_DiaDefaultString[2] = {(char *)"", (char *)""};
+CModelSwitch g_SystemSwitch[1];
+CRailPluginList *g_RailPluginList = nullptr;
+CTiePluginList *g_TiePluginList = nullptr;
+CGirderPluginList *g_GirderPluginList = nullptr;
+CPierPluginList *g_PierPluginList = nullptr;
+CLinePluginList *g_LinePluginList = nullptr;
+
+namespace LanguageResource {
+string SyntaxError = "SyntaxError";
+string CommentEndNotFound = "CommentEndNotFound";
+string StringLiteralExceedLineBreak = "StringLiteralExceedLineBreak";
+string CannotOpenFile = "CannotOpenFile";
+string InvalidVersion = "InvalidVersion";
+string UnsupportedVersion = "UnsupportedVersion";
+string InvalidDatafileType = "InvalidDatafileType";
+string LackedPluginMessage = "LackedPluginMessage";
+string LackedPluginListSaved = "LackedPluginListSaved";
+string LackedPluginListFailed = "LackedPluginListFailed";
+string InitialConsist = "InitialConsist";
+string InitialScene = "InitialScene";
+string NewConsist = "NewConsist";
+string NewScene = "NewScene";
+string NotSet = "NotSet";
+string Set = "Set";
+string Yes = "Yes";
+string No = "No";
+string Cancel = "Cancel";
+}  // namespace LanguageResource
+
+string g_LanguageName = "stub";
+
+void rs2_roundtrip_init_stubs() {
+	std::memset(g_sim_storage, 0, sizeof(g_sim_storage));
+	std::memset(g_cfg_storage, 0, sizeof(g_cfg_storage));
+	std::memset(g_skin_storage, 0, sizeof(g_skin_storage));
+	g_SimulationMode = reinterpret_cast<CSimulationMode *>(g_sim_storage);
+	g_ConfigMode = reinterpret_cast<CConfigMode *>(g_cfg_storage);
+	g_Skin = reinterpret_cast<CSkinPlugin *>(g_skin_storage);
+	g_RailBlockMap.clear();
+	g_BaseDir[0] = 0;
+}
+
+// --- SystemCover / script helpers ---
+
+char *FlashIn(char *format, ...) {
+	g_flash_sel = (g_flash_sel + 1) % 8;
+	va_list vl;
+	va_start(vl, format);
+	std::vsnprintf(g_flash_buf[g_flash_sel], sizeof(g_flash_buf[0]), format, vl);
+	va_end(vl);
+	return g_flash_buf[g_flash_sel];
+}
+
+void ErrorDialog(char *format, ...) {
+	char buf[2048];
+	va_list vl;
+	va_start(vl, format);
+	std::vsnprintf(buf, sizeof(buf), format, vl);
+	va_end(vl);
+	std::fprintf(stderr, "ErrorDialog: %s\n", buf);
+}
+
+bool CheckSlash(const char *chk) {
+	for (; *chk; chk = CharNext(chk)) {
+		if (*chk == '\\' || *chk == '/') return true;
+	}
+	return false;
+}
+
+string ExpandDoubleQuote(const string &str) {
+	string ret = str;
+	for (size_t i = 0; i < ret.size();) {
+		if (ret[i] == '\"') {
+			ret[i] = '\'';
+			ret.insert(i, 1, '\'');
+			i += 2;
+		} else {
+			i++;
+		}
+	}
+	return ret;
+}
+
+string RestoreDoubleQuote(const string &str) {
+	string ret = str;
+	for (size_t i = 0; i + 1 < ret.size();) {
+		if (ret[i] == '\'' && ret[i + 1] == '\'') {
+			ret[i] = '\"';
+			ret.erase(i + 1, 1);
+		} else {
+			i++;
+		}
+	}
+	return ret;
+}
+
+char *LoadBinaryText(FILE *file, int maxbyte) {
+	if (!file) return nullptr;
+	if (std::fseek(file, 0, SEEK_END) != 0) {
+		std::fclose(file);
+		return nullptr;
+	}
+	long size = std::ftell(file);
+	if (size < 0) {
+		std::fclose(file);
+		return nullptr;
+	}
+	if (0 <= maxbyte && maxbyte < size) size = maxbyte;
+	if (std::fseek(file, 0, SEEK_SET) != 0) {
+		std::fclose(file);
+		return nullptr;
+	}
+	char *buf = new char[static_cast<size_t>(size) + 1];
+	if (std::fread(buf, 1, static_cast<size_t>(size), file) !=
+		static_cast<size_t>(size)) {
+		std::fclose(file);
+		delete[] buf;
+		return nullptr;
+	}
+	buf[size] = 0;
+	std::fclose(file);
+	return buf;
+}
+
+char *LoadBinaryText(char *fname, int maxbyte) {
+	return LoadBinaryText(fopen(fname, "rb"), maxbyte);
+}
+
+void EnqueueCommonDialog(CWindowCtrl *) {}
+void ClearRailBlockUser(CTrainGroup *) { g_RailBlockMap.clear(); }
+void ClearStaticSwitchTable() {}
+void CheckLayoutDigest(const unsigned char *) {}
+void InitRailMap() {}
+void InitShadow() {}
+void RenderShadow() {}
+void UpdateSyncLimit() {}
+void SyncTrainControls(int) {}
+void ExceedNetworkSyncLimit(int) {}
+void GetAppPath(char *out) {
+	if (out) out[0] = 0;
+}
+int GetKey(int) { return 0; }
+int GetButton(int) { return 0; }
+void Draw2DRect(int, int, int, int, unsigned long) {}
+void TexMap2DRect(int, int, int, int, unsigned long) {}
+void TexMap2DRect90(int, int, int, int, unsigned long) {}
+void TexMap3DRect(VEC3, VEC3, VEC3, VEC3, unsigned long) {}
+void CalcTextRect(int *, int *, const char *, void *) {}
+BOOL CheckArguments(LPCSTR) { return TRUE; }
+
+// --- Radio / config / skin ---
+
+void CRadioButton::ClearGroupCheck() { m_Check = 0; }
+
+int CRadioButton::GetNumber() {
+	if (!m_Prev || !m_Next) return m_Check ? 0 : -1;
+	CRadioButton *ptr = this;
+	int i = 0;
+	do {
+		if (ptr->m_Check) return i;
+		i++;
+		ptr = ptr->m_Next;
+	} while (ptr != this);
+	return -1;
+}
+
+void CConfigMode::FreeWindowDiv() {}
+
+void CSkinPlugin::Error() {}
+void CSkinPlugin::MouseUp() {}
+void CSkinPlugin::MouseDown() {}
+
+int CSimulationMode::GetTimeScale() { return 1; }
+int CSimulationMode::GetSimSpeed() { return 1; }
+
+CWindowInfo::CWindowInfo() {
+	m_Scene = nullptr;
+	m_Div = nullptr;
+	m_PosX = m_PosY = m_Width = m_Height = 0;
+}
+CWindowInfo::~CWindowInfo() {}
+void CWindowInfo::OnDeleteScene(CScene *) {}
+char *CWindowInfo::Read(char *str) { return str; }
+void CWindowInfo::Save(FILE *, string) {}
+
+// --- Object graph stubs: construct, then fail Read immediately ---
+
+CRailWay **CRailWay::ms_Root = nullptr;
+float CRailWay::ms_MinDist = -1.0f;
+CRailWayLink CRailWay::ms_Detect;
+
+CRailWay::CRailWay() {
+	m_OldAdr = nullptr;
+	m_Selected = 0;
+	m_PierPos = m_PolePos = m_SegLen = 0;
+	m_BuildLine = m_WarpDummy = m_MultiTrackDummy = false;
+	m_DummyTrackNum = 0;
+	m_DummyTrackInterval = 0;
+	m_SpeedLimit = -1;
+	m_Parent = nullptr;
+	m_Platform = nullptr;
+	m_Scene = nullptr;
+	m_RailPlugin = nullptr;
+	m_TiePlugin = nullptr;
+	m_GirderPlugin = nullptr;
+	m_PierPlugin = nullptr;
+	m_LinePlugin = nullptr;
+	m_PolePlugin = nullptr;
+	m_Next = nullptr;
+}
+CRailWay::~CRailWay() {}
+CRailWay *CRailWay::Delete() {
+	delete this;
+	return nullptr;
+}
+char *CRailWay::ReadWarp(char *) {
+	delete this;
+	return nullptr;
+}
+void CRailWay::SaveWarp(FILE *) {}
+void CRailWay::RestoreAddress() {}
+void CRailWay::RenderWarp() {}
+void CRailWay::ScanInputWarp(int, VEC3 &, VEC3 &) {}
+void CRailWay::CheckWarpEndScene(CScene *) {}
+
+CDiaElement::CDiaElement() {
+	m_Action = m_TimeType = m_Hour = m_Minute = m_Second = 0;
+	m_Offset = 0;
+}
+CGroupEndLocator::CGroupEndLocator() {
+	m_Side = m_Type = 0;
+	m_Offset = 0;
+	m_SetRail = nullptr;
+	m_Group = nullptr;
+}
+CGroupEndLocator::CGroupEndLocator(int, float, CRailWay *, CTrainGroup *) {
+	m_Side = m_Type = 0;
+	m_Offset = 0;
+	m_SetRail = nullptr;
+	m_Group = nullptr;
+}
+
+CTrainGroup::CTrainGroup(char *name) {
+	m_OldAdr = nullptr;
+	m_ControlState = m_Serial = m_State = m_DoorWait = 0;
+	m_Length = m_MaxVelocity = m_MaxAcceleration = m_MaxDeceleration = 0;
+	m_DoorClosingTime = m_TargetSpeed = m_EffectTargetSpeed = 0;
+	m_CurrentSpeed = m_OldSpeed = m_StopTarget = m_PreviewOffset = 0;
+	m_SpeedLimit = 0;
+	m_DepartureTime = 0;
+	m_OpenDoor[0] = m_OpenDoor[1] = false;
+	m_Reverse = m_Enabled = m_NotifyFlag = false;
+	m_SplitPos = 0;
+	m_ListElement = nullptr;
+	m_Platform = nullptr;
+	m_TrainList = nullptr;
+	m_SelectTrain = nullptr;
+	m_Next = nullptr;
+	if (name) m_Name = name;
+}
+CTrainGroup::~CTrainGroup() {}
+char *CTrainGroup::Read(char *, CTrainGroup ***) {
+	delete this;
+	return nullptr;
+}
+void CTrainGroup::Save(FILE *) {}
+void CTrainGroup::RestoreAddress() {}
+void CTrainGroup::RestoreSet() {}
+int CTrainGroup::GetTrainNum() { return 0; }
+void CTrainGroup::Render() {}
+void CTrainGroup::Simulate() {}
+void CTrainGroup::ScanInput(int, VEC3 &, VEC3 &) {}
+
+int CModelInst::ms_DetectMode = 0;
+int CModelInst::ms_DetectTemp = 0;
+float CModelInst::ms_MinDist = -1.0f;
+VEC3 CModelInst::ms_DetectRect1;
+VEC3 CModelInst::ms_DetectRect2;
+BOX8 CModelInst::ms_FocusBox;
+CModelInst *CModelInst::ms_CurrentInst = nullptr;
+CDetectInfo CModelInst::ms_DetectInfo;
+
+CModelInst::CModelInst() {
+	m_Selected = 0;
+	m_Pos = m_Right = m_Up = m_Dir = V3ZERO;
+	m_ModelPlugin = nullptr;
+}
+CModelInst::CModelInst(CModelPlugin *p) : CModelInst() { (void)p; }
+CModelInst::~CModelInst() {}
+void CModelInst::ResetDetect(int, VEC3, VEC3) {}
+
+CStruct **CStruct::ms_Root = nullptr;
+CStruct::CStruct() : CModelInst() {
+	m_Scene = nullptr;
+	m_StructPlugin = nullptr;
+	m_Next = nullptr;
+}
+CStruct::CStruct(CStructPlugin *) : CStruct() {}
+CStruct::CStruct(CStructPlugin *, VEC3, VEC3, VEC3, bool) : CStruct() {}
+CStruct::~CStruct() {}
+
+CScene::CScene() : CStruct() {
+	m_Serial = 0;
+	m_ListElement = nullptr;
+	m_RailConnector = nullptr;
+	m_RailWay = nullptr;
+	m_Pier = nullptr;
+	m_Line = nullptr;
+	m_Pole = nullptr;
+	m_Station = nullptr;
+	m_Struct = nullptr;
+	m_SurfacePlugin = nullptr;
+	m_EnvPlugin = nullptr;
+	m_IsDumpReady = false;
+	m_Next = nullptr;
+}
+CScene::CScene(CSurfacePlugin *, CEnvPlugin *, char *name) : CScene() {
+	if (name) m_Name = name;
+}
+CScene::~CScene() {}
+void CScene::Delete() { delete this; }
+void CScene::DeleteGroup(CTrainGroup *) {}
+void CScene::Enter(bool) {}
+void CScene::RestoreAddress() {}
+char *CScene::Read(char *, CScene ***) {
+	delete this;
+	return nullptr;
+}
+void CScene::Save(FILE *) {}
+void CScene::RenderAfter() {}
+void CScene::RenderScene() {}
+void CScene::SimulateScene() {}
+void CScene::ScanInputLine(int, VEC3, VEC3) {}
+void CScene::ScanInputPier(int, VEC3, VEC3) {}
+void CScene::ScanInputPole(int, VEC3, VEC3) {}
+void CScene::ScanInputRailWay(int, VEC3, VEC3, bool) {}
+void CScene::ScanInputStation(int, VEC3, VEC3, bool) {}
+void CScene::ScanInputStruct(int, VEC3, VEC3, bool) {}
+
+void CParticle::InitRenderList() {}
+void CParticle::RenderAll() {}
+void CParticle::SimulateAll() {}
+void CHeadlight::InitRenderList() {}
+void CHeadlight::RenderAll() {}
+void CNamedObject::InitAfterRenderList() {}
+void CNamedObject::AfterRenderAll() {}
+void CProfilePluginList::ClearDumpAll() {}
+
+CListElement *CListView::InsertItem(int, char *) { return nullptr; }
+void CListView::EnsureVisible(int) {}
+void CListView::DeleteAllItems() {}
+int CListView::GetSelectionMark() { return -1; }
+void CListView::SetSelectionMark(int, int) {}
+
+CSimpleDialog::CSimpleDialog(char *, char *) {}
+CYesNoDialog::CYesNoDialog(char *, char *, bool) {}
+CYesNoDialog::~CYesNoDialog() {}
+CInputDialog::CInputDialog(char *, char *, char *, int) {}
+CMultiInputDialog::CMultiInputDialog(char *, int, char **, char **, int *) {}
+CMultiInputDialog::~CMultiInputDialog() {}
+
+CInterface *CInterface::ms_Focus = nullptr;
+CInterface *CInterface::ms_Drop = nullptr;
+CInterface *CInterface::ms_TabHead = nullptr;
+CInterface::CInterface() {
+	m_PosX = m_PosY = m_Width = m_Height = 0;
+	m_Enabled = true;
+	m_Visible = true;
+	m_Parent = m_Brother = m_Child = m_Owner = nullptr;
+	m_TabPrev = m_TabNext = nullptr;
+}
+CInterface::~CInterface() {}
+void CInterface::Init(int, int, int, int, char *, CInterface *) {}
+void CInterface::LinkTab(bool) {}
+void CInterface::GetAbsPos(int *x, int *y) { if (x) *x = 0; if (y) *y = 0; }
+bool CInterface::IsInside(int, int) { return false; }
+void CInterface::GiveFocus(bool) {}
+bool CInterface::ScanInput() { return false; }
+void CInterface::Render() {}
+void CInterface::DrawFocusFrame() {}
+void CInterface::ProcessKey() {}
+void CInterface::SetChild(CInterface *) {}
+void CInterface::SetBrother(CInterface *) {}
+void CInterface::RemoveChild(CInterface *) {}
+CInterface *CInterface::FindTabItem() { return nullptr; }
+bool CInterface::IsVisible() { return m_Visible; }
+
+bool CEditBox::ms_Active = false;
+
+CWindowCtrl::CWindowCtrl() {}
+CWindowCtrl::~CWindowCtrl() {}
+void CWindowCtrl::Init(int, int, int, int, char *, CInterface *, bool) {}
+void CWindowCtrl::Render() {}
+void CWindowCtrl::SetSize(int, int) {}
+bool CWindowCtrl::ScanInput() { return false; }
+
+CEditBox::CEditBox() {}
+CEditBox::~CEditBox() {}
+void CEditBox::Create(int, int, int, int, string, int) {}
+void CEditBox::Render() {}
+void CEditBox::Release(int) {}
+int CEditBox::ScanInput() { return 0; }
+
+CTexture::CTexture() {}
+CTexture::~CTexture() {}
+BOOL CTexture::Create(int, int) { return FALSE; }
+BOOL CTexture::DrawInText(int, int, LPCSTR, HFONT, unsigned long, unsigned long, int, int) { return FALSE; }
+
+void CGameMode::WakeUp() {}
+
+// Extra vtable / member stubs pulled by dialog and model headers.
+
+CModelSwitch::CModelSwitch() {}
+CDiaElementBase::CDiaElementBase() {}
+CSoundState::~CSoundState() {}
+CObject::~CObject() {}
+
+bool CYesNoDialog::ScanInputWindow() { return false; }
+bool CMultiInputDialog::ScanInputWindow() { return false; }
+bool CInputDialog::ScanInputWindow() { return false; }
+
+bool CStruct::IsSelectVisible() { return false; }
+void CStruct::SimulateModelInst() {}
+CModelInst *CStruct::Control() { return this; }
+CPartsInst *CStruct::FindParts(CNamedObject *) { return nullptr; }
+void CStruct::PrintInfo() {}
+
+// Force vtables for controls used as dialog members.
+void CPushButton::Init(int, int, int, int, char *, CInterface *) {}
+bool CPushButton::ScanInput() { return false; }
+void CPushButton::Render() {}
+void CStaticCtrl::Init(int, int, int, int, char *, CInterface *, int, int) {}
+void CStaticCtrl::Render() {}
+
+void CEditCtrl::Init(int, int, int, int, char *, CInterface *, int) {}
+void CEditCtrl::GiveFocus(bool) {}
+void CEditCtrl::FinishInput() {}
+
+CWave::~CWave() {}
+void CEditCtrl::Render() {}
+bool CEditCtrl::ScanInput() { return false; }
+
+// Emit CDiaElement vtable by defining a key virtual if needed.
+string CDiaElement::GetListCaption() { return string(); }
+char *CDiaElement::Read(char *str) { return str; }
+void CDiaElement::Save(FILE *, char *) {}

--- a/port/stub/d3dx8.h
+++ b/port/stub/d3dx8.h
@@ -126,6 +126,10 @@ inline D3DXVECTOR2 operator-(const D3DXVECTOR2& a, const D3DXVECTOR2& b) {
 inline D3DXVECTOR2 operator*(const D3DXVECTOR2& a, float s) { return D3DXVECTOR2(a.x * s, a.y * s); }
 inline D3DXVECTOR2 operator*(float s, const D3DXVECTOR2& a) { return a * s; }
 inline D3DXVECTOR2 operator/(const D3DXVECTOR2& a, float s) { return a * (1.0f / s); }
+inline bool operator==(const D3DXVECTOR2& a, const D3DXVECTOR2& b) {
+  return a.x == b.x && a.y == b.y;
+}
+inline bool operator!=(const D3DXVECTOR2& a, const D3DXVECTOR2& b) { return !(a == b); }
 
 inline D3DXVECTOR3 operator+(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
   return D3DXVECTOR3(a.x + b.x, a.y + b.y, a.z + b.z);
@@ -137,6 +141,10 @@ inline D3DXVECTOR3 operator-(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
 inline D3DXVECTOR3 operator*(const D3DXVECTOR3& a, float s) { return D3DXVECTOR3(a.x * s, a.y * s, a.z * s); }
 inline D3DXVECTOR3 operator*(float s, const D3DXVECTOR3& a) { return a * s; }
 inline D3DXVECTOR3 operator/(const D3DXVECTOR3& a, float s) { return a * (1.0f / s); }
+inline bool operator==(const D3DXVECTOR3& a, const D3DXVECTOR3& b) {
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+inline bool operator!=(const D3DXVECTOR3& a, const D3DXVECTOR3& b) { return !(a == b); }
 
 inline D3DXMATRIX operator*(const D3DXMATRIX& a, const D3DXMATRIX& b) {
   D3DXMATRIX r;

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstdarg>
 #include <cstring>
+#include <ctime>
 #include <string>
 #include <vector>
 #include <list>
@@ -127,6 +128,17 @@ typedef struct _FILETIME {
   DWORD dwLowDateTime;
   DWORD dwHighDateTime;
 } FILETIME;
+
+typedef struct _SYSTEMTIME {
+  WORD wYear;
+  WORD wMonth;
+  WORD wDayOfWeek;
+  WORD wDay;
+  WORD wHour;
+  WORD wMinute;
+  WORD wSecond;
+  WORD wMilliseconds;
+} SYSTEMTIME, *PSYSTEMTIME, *LPSYSTEMTIME;
 
 typedef struct tagMSG {
   HWND hwnd;
@@ -274,6 +286,25 @@ inline BOOL QueryPerformanceCounter(LARGE_INTEGER* li) {
   if (!li) return FALSE;
   li->QuadPart = 0;
   return TRUE;
+}
+inline void GetLocalTime(LPSYSTEMTIME st) {
+  if (!st) return;
+  std::memset(st, 0, sizeof(*st));
+  std::time_t now = std::time(nullptr);
+  std::tm local{};
+#if defined(_WIN32)
+  localtime_s(&local, &now);
+#else
+  localtime_r(&now, &local);
+#endif
+  st->wYear = static_cast<WORD>(local.tm_year + 1900);
+  st->wMonth = static_cast<WORD>(local.tm_mon + 1);
+  st->wDayOfWeek = static_cast<WORD>(local.tm_wday);
+  st->wDay = static_cast<WORD>(local.tm_mday);
+  st->wHour = static_cast<WORD>(local.tm_hour);
+  st->wMinute = static_cast<WORD>(local.tm_min);
+  st->wSecond = static_cast<WORD>(local.tm_sec);
+  st->wMilliseconds = 0;
 }
 inline HWND GetActiveWindow() { return nullptr; }
 inline int MessageBoxA(HWND, LPCSTR, LPCSTR, UINT) { return 0; }


### PR DESCRIPTION
## Summary
- Route `rs2_layout_roundtrip()` through `CSaveFile::Load` / `Save` using path-seams option 1 (`g_BaseDir` + Layout basenames; no absolute path to `Save`).
- Allowlist `CSaveFile.cpp` with minimal header/stub growth; add `port/rs2_roundtrip_stubs.cpp` so the harness links without the full object graph.
- ctest `rs2_roundtrip` is `WILL_FAIL` until byte-identity work under parent `#10`; failures print `roundtrip diff` (not SKIP).

## Test plan
- [x] `./scripts/check.sh` green
- [x] `./build/check/rs2_roundtrip --self-test-diff` prints `roundtrip diff` reporter ok
- [x] Fixture run exits 1 with `roundtrip diff: CSaveFile::Load failed` (stubbed `ReadWarp`)

Closes #36

Made with [Cursor](https://cursor.com)