### PR TITLE
Address / %p 書出しを 8 桁 hex に固定する

### DIFF
--- a/CDiaInst.cpp
+++ b/CDiaInst.cpp
@@ -163,7 +163,7 @@ void CDiaListBase::Save(
 ){
 	string ind2 = string(ind)+"\t";
 	fprintf(df, "%s%s{\n", ind, Label());
-	fprintf(df, "%s\tTrainGroup = %p;\n", ind, group);
+	fprintf(df, "%s\tTrainGroup = " RS2_PTR_FMT ";\n", ind, rs2_ptr32(group));
 	fprintf(df, "%s\tUseDefault = %s;\n", ind, YESNO[m_UseDefault]);
 	IPDiaElementBase ipde = m_DiaList.begin();
 	for(; ipde!=m_DiaList.end(); ipde++) (*ipde)->Save(df, (char *)ind2.c_str());

--- a/CLine.cpp
+++ b/CLine.cpp
@@ -64,7 +64,7 @@ void CPoleLink::Save(
 	FILE *df,	//	ファイル
 	char *pref	//	プレフィックス
 ){
-	fprintf(df, "%s%d, %d, %p;\n", pref, m_Side, m_Track, m_Link);
+	fprintf(df, "%s%d, %d, " RS2_PTR_FMT ";\n", pref, m_Side, m_Track, rs2_ptr32(m_Link));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -274,7 +274,7 @@ void CPole::Save(
 	FILE *df	//	ファイル
 ){
 	fprintf(df, "\t\t\tPole{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\tPolePlugin = \"%s\";\n", CheckPluginID(m_PolePlugin));
 	fprintf(df, "\t\t\t\tPos = "); V3Save(df, m_Pos, ";\n");
 	fprintf(df, "\t\t\t\tOrigDir = "); V3Save(df, m_OrigDir, ";\n");
@@ -282,7 +282,7 @@ void CPole::Save(
 		fprintf(df, "\t\t\t\tLineList = ");
 		IPLine ipl = m_LineList.begin();
 		for(; ipl!=m_LineList.end(); ipl++) fprintf(df,
-			ipl==m_LineList.begin() ? "%p" : ", %p", *ipl);
+			ipl==m_LineList.begin() ? RS2_PTR_FMT : ", " RS2_PTR_FMT, rs2_ptr32(*ipl));
 		fprintf(df, ";\n");
 	}
 	fprintf(df, "\t\t\t}\n");
@@ -470,7 +470,7 @@ void CLine::Save(
 	FILE *df	//	ファイル
 ){
 	fprintf(df, "\t\t\tLine{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\tLinePlugin = \"%s\";\n", CheckPluginID(m_LinePlugin));
 	SaveMapVector(df, "\t\t\t\tLineMapV = ", m_LineMapV);
 	fprintf(df, "\t\t\t\tRight = "); V3Save(df, m_Right, ";\n");

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,3 +132,11 @@ target_compile_options(rs2_path_test PRIVATE -Wall -Wextra)
 add_test(NAME rs2_path_self_test COMMAND rs2_path_test --self-test)
 add_test(NAME rs2_path_distribution COMMAND rs2_path_test "${CMAKE_SOURCE_DIR}/Distribution")
 set_tests_properties(rs2_path_distribution PROPERTIES SKIP_RETURN_CODE 77)
+
+# Pointer ID 8-digit hex write / HexPointer-compatible parse (#40).
+add_executable(rs2_ptr_test port/rs2_ptr_test.cpp)
+target_include_directories(rs2_ptr_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ptr_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ptr_test PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_ptr_self_test COMMAND rs2_ptr_test --self-test)

--- a/CPier.cpp
+++ b/CPier.cpp
@@ -296,7 +296,7 @@ void CPier::Save(
 	FILE *df	//	ƒtƒ@ƒCƒ‹
 ){
 	fprintf(df, "\t\t\tPier{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\tPierPlugin = \"%s\";\n", CheckPluginID(m_PierPlugin));
 	fprintf(df, "\t\t\t\tJointPos = "); V3Save(df, R2L(m_JointObject.GetPos()), ";\n");
 	fprintf(df, "\t\t\t\tJointDir = "); V3Save(df, R2L(m_JointObject.GetDir()), ";\n");

--- a/CRailConnector.cpp
+++ b/CRailConnector.cpp
@@ -126,7 +126,7 @@ void CRailConnectorLink::Save(
 	FILE *df,	//	ファイル
 	char *pref	//	プレフィックス
 ){
-	fprintf(df, "%s%d, %d, %p;\n", pref, m_Side, m_Point, m_Link);
+	fprintf(df, "%s%d, %d, " RS2_PTR_FMT ";\n", pref, m_Side, m_Point, rs2_ptr32(m_Link));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -180,7 +180,7 @@ void CRailWayLink::Save(
 	FILE *df,	//	ファイル
 	char *pref	//	プレフィックス
 ){
-	fprintf(df, "%s%d, %p;\n", pref, m_Side, m_Link);
+	fprintf(df, "%s%d, " RS2_PTR_FMT ";\n", pref, m_Side, rs2_ptr32(m_Link));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -214,7 +214,7 @@ char *CPierPos::Read(
 void CPierPos::Save(
 	FILE *df	//	ファイル
 ){
-	fprintf(df, "\t\t\t\t\tPierLink = %f, %p;\n", m_Pos, m_Link);
+	fprintf(df, "\t\t\t\t\tPierLink = %f, " RS2_PTR_FMT ";\n", m_Pos, rs2_ptr32(m_Link));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -252,8 +252,8 @@ char *CPolePos::Read(
 void CPolePos::Save(
 	FILE *df	//	ファイル
 ){
-	fprintf(df, "\t\t\t\t\tPoleLink = %f, %d, %s, %p;\n",
-		m_Pos, m_Track, YESNO[m_Multi], m_Link);
+	fprintf(df, "\t\t\t\t\tPoleLink = %f, %d, %s, " RS2_PTR_FMT ";\n",
+		m_Pos, m_Track, YESNO[m_Multi], rs2_ptr32(m_Link));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -510,12 +510,12 @@ void CRailConnector::Save(
 	FILE *df	//	ファイル
 ){
 	fprintf(df, "\t\t\tRailConnector{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	m_Splitter.Save(df, "\t\t\t\t");
 	fprintf(df, "\t\t\t\tCant = %f;\n", m_Cant);
 	fprintf(df, "\t\t\t\tSide = %d;\n", m_Side);
 	fprintf(df, "\t\t\t\tTrailPoint = %d, %d;\n", m_TrailPoint[0], m_TrailPoint[1]);
-	fprintf(df, "\t\t\t\tUser = %p;\n", m_User);
+	fprintf(df, "\t\t\t\tUser = " RS2_PTR_FMT ";\n", rs2_ptr32(m_User));
 	int i, j;
 	for(i = 0; i<2; i++) for(j = 0; j<2; j++)
 		m_Link[i][j].Save(df, FlashIn("\t\t\t\tLink%d%d = ", i, j));

--- a/CRailWay.cpp
+++ b/CRailWay.cpp
@@ -1425,7 +1425,7 @@ void CRailWay::Save(
 	FILE *df	//	ファイル
 ){
 	fprintf(df, "\t\t\tRailWay{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\tRailPlugin = \"%s\";\n", CheckPluginID(m_RailPlugin));
 	fprintf(df, "\t\t\t\tTiePlugin = \"%s\";\n", CheckPluginID(m_TiePlugin));
 	fprintf(df, "\t\t\t\tGirderPlugin = \"%s\";\n", CheckPluginID(m_GirderPlugin));
@@ -1444,7 +1444,7 @@ void CRailWay::Save(
 	}
 	m_Link[0].Save(df, "\t\t\t\tLink0 = ");
 	m_Link[1].Save(df, "\t\t\t\tLink1 = ");
-	fprintf(df, "\t\t\t\tPlatform = %p;\n", m_Platform);
+	fprintf(df, "\t\t\t\tPlatform = " RS2_PTR_FMT ";\n", rs2_ptr32(m_Platform));
 	if(IsRailBlock()) fprintf(df, "\t\t\t\tRailBlock = \"%s\";\n", ExpandDoubleQuote(m_RailBlock).c_str());
 	if(IsSpeedLimit()) fprintf(df, "\t\t\t\tSpeedLimit = %d;\n", m_SpeedLimit);
 
@@ -1470,7 +1470,7 @@ void CRailWay::Save(
 		fprintf(df, "\t\t\t\tGroupEnd = ");
 		IPGroupEndLocator ipge = m_GroupEnd.begin();
 		for(; ipge!=m_GroupEnd.end(); ipge++)
-			fprintf(df, ipge==m_GroupEnd.begin() ? "%p" : ", %p", *ipge);
+			fprintf(df, ipge==m_GroupEnd.begin() ? RS2_PTR_FMT : ", " RS2_PTR_FMT, rs2_ptr32(*ipge));
 		fprintf(df, ";\n");
 	}
 
@@ -1484,7 +1484,7 @@ void CRailWay::SaveWarp(
 	FILE *df	//	ファイル
 ){
 	fprintf(df, "\tWarp{\n");
-	fprintf(df, "\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	m_Link[0].Save(df, "\t\tLink0 = ");
 	m_Link[1].Save(df, "\t\tLink1 = ");
 	fprintf(df, "\t}\n");

--- a/CSaveFile.cpp
+++ b/CSaveFile.cpp
@@ -955,8 +955,8 @@ int CSaveFile::Save(
 	fprintf(df, "RailBlockList{\n");
 	map<std::string, CTrainGroup *>::iterator railblock;
 	for(railblock = g_RailBlockMap.begin(); railblock!=g_RailBlockMap.end(); ++railblock){
-		if(railblock->second) fprintf(df, "\tRailBlock = \"%s\", %p;\n",
-			ExpandDoubleQuote(railblock->first).c_str(), railblock->second);
+		if(railblock->second) fprintf(df, "\tRailBlock = \"%s\", " RS2_PTR_FMT ";\n",
+			ExpandDoubleQuote(railblock->first).c_str(), rs2_ptr32(railblock->second));
 	}
 	fprintf(df, "}\n\n");
 
@@ -969,7 +969,7 @@ int CSaveFile::Save(
 	fprintf(df, "}\n\n");
 
 	fprintf(df, "SceneList{\n");
-	fprintf(df, "\tCurrentScene = %p;\n", g_Scene);
+	fprintf(df, "\tCurrentScene = " RS2_PTR_FMT ";\n", rs2_ptr32(g_Scene));
 	CScene *scene = m_SceneList;
 	while(scene){
 		scene->Save(df);

--- a/CScene.cpp
+++ b/CScene.cpp
@@ -899,7 +899,7 @@ void CScene::Save(
 	FILE *df	//	ƒtƒ@ƒCƒ‹
 ){
 	fprintf(df, "\tScene{\n");
-	fprintf(df, "\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\tName = \"%s\";\n", ExpandDoubleQuote(m_Name).c_str());
 	fprintf(df, "\t\tSurfacePlugin = \"%s\";\n", CheckPluginID(m_SurfacePlugin));
 	fprintf(df, "\t\tEnvPlugin = \"%s\";\n", CheckPluginID(m_EnvPlugin));

--- a/CStation.cpp
+++ b/CStation.cpp
@@ -141,7 +141,7 @@ void CPlatformInst::Save(
 	FILE *df	//	ファイル
 ){	
 	fprintf(df, "\t\t\t\t\tPlatform{\n");
-	fprintf(df, "\t\t\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\t\t\tStoppable = %s;\n", YESNO[m_Stoppable]);
 	fprintf(df, "\t\t\t\t\t\tOpenDoor = %s, %s;\n",
 		YESNO[m_OpenDoor[0]], YESNO[m_OpenDoor[1]]);
@@ -149,7 +149,7 @@ void CPlatformInst::Save(
 		fprintf(df, "\t\t\t\t\t\tRailList = ");
 		IPRailWay ipr = m_RailList.begin();
 		for(; ipr!=m_RailList.end(); ipr++) fprintf(
-			df, ipr==m_RailList.begin() ? "%p" : ", %p", *ipr);
+			df, ipr==m_RailList.begin() ? RS2_PTR_FMT : ", " RS2_PTR_FMT, rs2_ptr32(*ipr));
 		fprintf(df, ";\n");
 	}
 	fprintf(df, "\t\t\t\t\t}\n");
@@ -361,7 +361,7 @@ void CStation::Save(
 	FILE *df	//	ファイル
 ){	
 	fprintf(df, "\t\t\tStation{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\tStationPlugin = \"%s\";\n", CheckPluginID(m_StationPlugin));
 	SaveModelInst(df, "\t\t\t\t", true);
 	fprintf(df, "\t\t\t\tPlatformList{\n");

--- a/CStruct.cpp
+++ b/CStruct.cpp
@@ -237,7 +237,7 @@ void CStruct::Save(
 	FILE *df	//	ƒtƒ@ƒCƒ‹
 ){
 	fprintf(df, "\t\t\tStruct{\n");
-	fprintf(df, "\t\t\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\t\t\tStructPlugin = \"%s\";\n", CheckPluginID(m_StructPlugin));
 	SaveModelInst(df, "\t\t\t\t", true);
 	fprintf(df, "\t\t\t}\n");

--- a/CTrainGroup.cpp
+++ b/CTrainGroup.cpp
@@ -1274,7 +1274,7 @@ void CTrainGroup::Save(
 	FILE *df	//	ƒtƒ@ƒCƒ‹
 ){
 	fprintf(df, "\tTrainGroup{\n");
-	fprintf(df, "\t\tAddress = %p;\n", this);
+	fprintf(df, "\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	fprintf(df, "\t\tName = \"%s\";\n", ExpandDoubleQuote(m_Name).c_str());
 	fprintf(df, "\t\tCabinPos = ");
 	V3Save(df, m_CabinPos[0], ", "); V3Save(df, m_CabinPos[1], ";\n");
@@ -1286,7 +1286,7 @@ void CTrainGroup::Save(
 		fprintf(df, "\t\tTargetSpeed = %f;\n", m_TargetSpeed);
 		fprintf(df, "\t\tCurrentSpeed = %f;\n", m_CurrentSpeed);
 		fprintf(df, "\t\tStopTarget = %f;\n", m_StopTarget);
-		fprintf(df, "\t\tDepartureTime = %p, %p;\n",
+		fprintf(df, "\t\tDepartureTime = %08x, %08x;\n",
 			*(PDWORD)&m_DepartureTime, *((PDWORD)&m_DepartureTime+1));
 		fprintf(df, "\t\tDoorWait = %d;\n", m_DoorWait);
 		fprintf(df, "\t\tOpenDoor = %s, %s;\n", YESNO[m_OpenDoor[0]], YESNO[m_OpenDoor[1]]);
@@ -1298,17 +1298,17 @@ void CTrainGroup::Save(
 		if(m_PointList.size()){
 			fprintf(df, "\t\tPointList = ");
 			for(ipr = m_PointList.begin(); ipr!=m_PointList.end(); ipr++)
-				fprintf(df, ipr==m_PointList.begin() ? "%p" : ", %p", *ipr);
+				fprintf(df, ipr==m_PointList.begin() ? RS2_PTR_FMT : ", " RS2_PTR_FMT, rs2_ptr32(*ipr));
 			fprintf(df, ";\n");
 		}
 		if(m_SeekList.size()){
 			fprintf(df, "\t\tSeekList = ");
 			for(ipr = m_SeekList.begin(); ipr!=m_SeekList.end(); ipr++)
-				fprintf(df, ipr==m_SeekList.begin() ? "%p" : ", %p", *ipr);
+				fprintf(df, ipr==m_SeekList.begin() ? RS2_PTR_FMT : ", " RS2_PTR_FMT, rs2_ptr32(*ipr));
 			fprintf(df, ";\n");
 		}
 		m_DiaElement.Save(df, "\t\t");
-		fprintf(df, "\t\tPlatform = %p;\n", m_Platform);
+		fprintf(df, "\t\tPlatform = " RS2_PTR_FMT ";\n", rs2_ptr32(m_Platform));
 	}
 	CTrain *train = m_TrainList;
 	while(train){

--- a/CTrainSetCurve.cpp
+++ b/CTrainSetCurve.cpp
@@ -196,8 +196,8 @@ void CGroupEndLocator::Save(
 	char *pref	//	プレフィックス
 ){
 	fprintf(df, "%s%s{\n", ind, pref);
-	fprintf(df, "%s\tAddress = %p;\n", ind, this);
-	fprintf(df, "%s\tLocation = %d, %f, %p;\n", ind, m_Side, m_Offset, m_SetRail);
+	fprintf(df, "%s\tAddress = " RS2_PTR_FMT ";\n", ind, rs2_ptr32(this));
+	fprintf(df, "%s\tLocation = %d, %f, " RS2_PTR_FMT ";\n", ind, m_Side, m_Offset, rs2_ptr32(m_SetRail));
 	fprintf(df, "%s}\n", ind);
 }
 

--- a/CWindowDivInfo.cpp
+++ b/CWindowDivInfo.cpp
@@ -101,7 +101,7 @@ void CWindowInfo::Save(
 	if(m_Div){
 		m_Div->Save(df, indent2);
 	}else{
-		fprintf(df, "%s\tScene = %p;\n", indent.c_str(), m_Scene);
+		fprintf(df, "%s\tScene = " RS2_PTR_FMT ";\n", indent.c_str(), rs2_ptr32(m_Scene));
 		m_Camera.Save(df, indent2);
 	}
 	fprintf(df, "%s}\n", indent.c_str());

--- a/Script.cpp
+++ b/Script.cpp
@@ -283,8 +283,12 @@ char *HexPointer(
 			}else{
 				char save = *tmp;
 				*tmp = 0;
-				void *val;
-				sscanf(str, "%p", &val);
+				void *val = NULL;
+				/* Bare hex (8 or 16 digits). Avoid sscanf %p (0x differs by host). */
+				if(!rs2_parse_ptr(str, &val)){
+					*tmp = save;
+					return NULL;
+				}
 				*ret = val;
 				*tmp = save;
 				return Space(tmp);

--- a/port/rs2_ptr.h
+++ b/port/rs2_ptr.h
@@ -1,0 +1,36 @@
+// Fixed-width pointer IDs for .rs2 Save (#40).
+// Values are g_AddressMap keys, not dereference targets.
+// Write as 8 lowercase hex digits (zero-padded) for 32-bit Windows interop.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+// fprintf conversion for pointer-like IDs (use with RS2_PTR_FMT).
+inline unsigned rs2_ptr32(const void *p) {
+	return static_cast<unsigned>(reinterpret_cast<uintptr_t>(p));
+}
+
+#ifndef RS2_PTR_FMT
+#define RS2_PTR_FMT "%08x"
+#endif
+
+// Format into buf; always writes 8 lowercase hex digits (+ NUL) when n >= 9.
+inline bool rs2_format_ptr(char *buf, size_t n, const void *p) {
+	if (!buf || n < 9) return false;
+	std::snprintf(buf, n, RS2_PTR_FMT, rs2_ptr32(p));
+	return true;
+}
+
+// Parse bare hex (no 0x). Accepts 1..16 hex digits; leading zeros OK.
+// Returns false if empty or non-hex remains after digits.
+inline bool rs2_parse_ptr(const char *hex, void **out) {
+	if (!hex || !*hex || !out) return false;
+	char *end = nullptr;
+	unsigned long long v = std::strtoull(hex, &end, 16);
+	if (end == hex || (end && *end != '\0')) return false;
+	*out = reinterpret_cast<void *>(static_cast<uintptr_t>(v));
+	return true;
+}

--- a/port/rs2_ptr_test.cpp
+++ b/port/rs2_ptr_test.cpp
@@ -1,0 +1,71 @@
+// Pointer ID format / HexPointer roundtrip self-test (#40).
+
+#include "rs2_ptr.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+// Mirror HexPointer digit scan + rs2_parse_ptr (Script.cpp path without udx).
+bool parse_like_hex_pointer(const char *input, void **out) {
+	if (!input || !*input) return false;
+	const char *p = input;
+	auto is_hex = [](char c) {
+		return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+	};
+	if (!is_hex(*p)) return false;
+	while (is_hex(*p)) ++p;
+	std::string hex(input, static_cast<size_t>(p - input));
+	return rs2_parse_ptr(hex.c_str(), out);
+}
+
+int self_test() {
+	char buf[16];
+	void *sample = reinterpret_cast<void *>(static_cast<uintptr_t>(0x0195DCA8u));
+	if (!expect(rs2_format_ptr(buf, sizeof(buf), sample), "format ok")) return 1;
+	if (!expect(std::strcmp(buf, "0195dca8") == 0, "8-digit lowercase")) return 1;
+	if (!expect(std::strlen(buf) == 8, "width 8")) return 1;
+
+	void *nullp = nullptr;
+	if (!expect(rs2_format_ptr(buf, sizeof(buf), nullp) && std::strcmp(buf, "00000000") == 0,
+	            "null -> 00000000"))
+		return 1;
+
+	// High bits truncated to low 32 for write interop.
+	void *wide = reinterpret_cast<void *>(static_cast<uintptr_t>(0x7fff00000195DCA8ull));
+	if (!expect(rs2_format_ptr(buf, sizeof(buf), wide) && std::strcmp(buf, "0195dca8") == 0,
+	            "truncate high bits"))
+		return 1;
+
+	void *got = nullptr;
+	if (!expect(parse_like_hex_pointer("0195DCA8", &got) && got == sample, "read 8 upper"))
+		return 1;
+	if (!expect(parse_like_hex_pointer("0195dca8", &got) && got == sample, "read 8 lower"))
+		return 1;
+	if (!expect(parse_like_hex_pointer("000000000195DCA8", &got) && got == sample,
+	            "read 16-digit padded"))
+		return 1;
+	void *wide_got = nullptr;
+	if (!expect(parse_like_hex_pointer("7fff00000195dca8", &wide_got) && wide_got == wide,
+	            "read full 16-digit"))
+		return 1;
+	if (!expect(!parse_like_hex_pointer("", &got), "reject empty")) return 1;
+	if (!expect(!parse_like_hex_pointer("xyz", &got), "reject non-hex")) return 1;
+
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/stdafx.h
+++ b/stdafx.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include "lib/udx.h"
 #include "port/path.h"
+#include "port/rs2_ptr.h"
 
 typedef list<string>::iterator Istring;
 


### PR DESCRIPTION
## Summary
- Add `port/rs2_ptr.h` (`RS2_PTR_FMT` / `rs2_ptr32` / parse) and wire it through `stdafx.h`.
- Mechanically replace layout/plugin Save `fprintf` `%p` with 8-digit lowercase hex; `HexPointer` uses `rs2_parse_ptr` for 8- and 16-digit bare hex.
- Add `rs2_ptr_self_test` ctest for format ↔ parse (Closes #40).

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_ptr_self_test`)
- [ ] Spot-check a Save path still emits `Address = 0195dca8;` style IDs (no `0x`, width 8)


Made with [Cursor](https://cursor.com)