### PR TITLE
Confirm Linux case-sensitive asset path policy (closes #41)

### DIFF
--- a/docs/porting/path-seams.md
+++ b/docs/porting/path-seams.md
@@ -199,3 +199,38 @@ rg -n --glob '!build/**' --glob '!.git/**' --glob '!Distribution/**' --glob '!po
 ```
 
 `./scripts/check.sh` must stay green (`rs2_path_self_test` + `rs2_path_distribution`).
+
+## Case sensitivity (#41)
+
+Windows (and some macOS volumes) treat path components as case-insensitive. Linux does not. After #32, asset I/O goes through `port/path.cpp` without rewriting game path strings or renaming Distribution files.
+
+### Inventory (what can break)
+
+| Path | Role | Case risk |
+|------|------|-----------|
+| `rs2_path_join` + `rs2_fopen` / `rs2_is_dir` / `rs2_chdir` / `rs2_rename` / `rs2_remove` / `rs2_fullpath` | Closed-set open and cwd | **Exact** component spelling. Wrong case fails on Linux. |
+| `rs2_list_dir` + `glob_match` | Former `_findfirst` loops | Extension / name match uses `icmp` (case-insensitive), matching typical Win32 `_findfirst` behavior. Returned names keep **on-disk** spelling. |
+| Hardcoded `DirName()` / `TextName2()` / `LAYOUT_DIRNAME` / `Language.txt` / `Config.txt` | Install-tree literals | Must match Distribution (or runtime-created) names byte-for-byte. |
+| Plugin-relative riders after `CPlugin::ChDir` | `Model.x`, textures, `*.txt` sidecars | Resolved under the virtual cwd; same exact-match rule as `rs2_fopen`. |
+| Names from `rs2_list_dir` then re-opened | Layout / plugin / template lists | Safe: reopen uses the spelling the directory walk returned. |
+
+### Distribution check (this repo)
+
+Against `Distribution/en/RailSim2` (and the same tree under `jp/`):
+
+- Top-level type dirs (`Rail`, `Layout`, …), `Language.txt`, and `Layout/Sample.rs2` match the game literals exactly.
+- Every plugin folder has `*2.txt` (or old-form `*.txt`) with the expected casing; no sibling names that differ only by case.
+- Relative asset refs inside those `.txt` files resolve with exact case under the plugin directory (no “open only via casefold” hits in a scan of `.x` / image / wave names).
+
+Runtime-only dirs (`Undo/`, `Picture/`, `Video/`, `Config.txt`) are created with the same literals the game later opens, so they do not introduce a case gap.
+
+### Policy: keep strict open / chdir
+
+**Do not** add a case-folding resolver in `rs2_fopen` / `rs2_chdir` / `rs2_is_dir`. Evidence:
+
+1. Shipped Distribution and game string literals already agree; a folding walker would be speculative.
+2. Issue #41 forbids guessing a large path rewrite; fix the resolution layer only when a real mismatch appears.
+3. `rs2_list_dir` already folds pattern matches; callers that open listed names stay correct on Linux.
+4. If third-party or hand-edited assets ever disagree in case, prefer fixing the asset or the authoring string over silent folding (folding hides collisions and diverges from “path as written” debugging).
+
+`rs2_path_self_test` creates a probe file and, on a case-sensitive volume, asserts that a wrong-case `rs2_fopen` fails while `*.RS2`-style listing still succeeds. On case-insensitive volumes the strict-fail check is skipped.

--- a/docs/porting/upstream.md
+++ b/docs/porting/upstream.md
@@ -51,4 +51,4 @@ There is no separate denylist of "do not touch" paths. Scope is defined by the s
 - X-File templates in `Distribution`: [`x-file-templates.md`](x-file-templates.md)
 - Closed text `.x` parser: [`x-file-parser.md`](x-file-parser.md)
 - `.rs2` roundtrip ctest: [`rs2-roundtrip.md`](rs2-roundtrip.md)
-- Path I/O seams (`chdir` / `fopen` / `_findfirst`): [`path-seams.md`](path-seams.md)
+- Path I/O seams (`chdir` / `fopen` / `_findfirst`, case policy): [`path-seams.md`](path-seams.md)

--- a/port/path_test.cpp
+++ b/port/path_test.cpp
@@ -1,4 +1,4 @@
-// Path join / list / fullpath self-test (#32). Does not link CSaveFile.
+// Path join / list / fullpath self-test (#32, case policy #41). Does not link CSaveFile.
 
 #include "path.h"
 
@@ -87,6 +87,35 @@ int self_test() {
 	f = rs2_fopen("Sample.rs2", "rb");
 	if (!expect(f != nullptr, "fopen relative after virtual cwd")) return 1;
 	std::fclose(f);
+
+	// #41: list_dir patterns stay case-insensitive (Win32 _findfirst-like);
+	// open/chdir stay strict on case-sensitive volumes.
+	if (!rs2_path_join(buf, sizeof(buf), tmp.string().c_str(), "Layout")) return 1;
+	if (!expect(rs2_chdir(tmp.string().c_str()) == 0, "chdir tmp for case probe")) return 1;
+	if (!expect(rs2_list_dir(buf, "*.RS2", false, &names) && names.size() == 1 &&
+	                names[0] == "Sample.rs2",
+	            "list *.RS2 finds Sample.rs2"))
+		return 1;
+
+	{
+		std::ofstream probe((tmp / "Layout" / "CaseProbe.txt").string());
+		probe << "probe\n";
+	}
+	char probe_wrong[RS2_PATH_MAX];
+	if (!rs2_path_join(probe_wrong, sizeof(probe_wrong), tmp.string().c_str(), "Layout",
+	                   "caseprobe.txt"))
+		return 1;
+	FILE *wrong = rs2_fopen(probe_wrong, "rb");
+	const bool fs_case_insensitive = (wrong != nullptr);
+	if (wrong) std::fclose(wrong);
+	if (!fs_case_insensitive) {
+		if (!expect(rs2_fopen(probe_wrong, "rb") == nullptr,
+		            "strict fopen rejects wrong case on case-sensitive FS"))
+			return 1;
+		if (!expect(rs2_chdir("layout") != 0,
+		            "strict chdir rejects wrong case on case-sensitive FS"))
+			return 1;
+	}
 
 	std::filesystem::remove_all(tmp, ec);
 	return 0;


### PR DESCRIPTION
## Summary
- Inventoried case-sensitivity risks for `port/path*` and Distribution; documented the closed-set matrix and conclusion in `docs/porting/path-seams.md`.
- Kept **strict** `rs2_fopen` / `rs2_chdir` (no speculative casefold walker): shipped assets and `DirName()` / `TextName2()` literals already match byte-for-byte; `rs2_list_dir` remains case-insensitive for Win32-like globs.
- Extended `rs2_path_self_test` with a wrong-case probe (asserts fail on case-sensitive FS; skips on case-insensitive volumes) and `*.RS2` listing.

Closes #41.

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_path_self_test` + `rs2_path_distribution`)
- [ ] Skim the new “Case sensitivity (#41)” section in `docs/porting/path-seams.md`
- [ ] Confirm PR does not touch `Script.cpp` / `%p` / HexPointer / `.rs2` write paths (#40)


Made with [Cursor](https://cursor.com)