### PR TITLE
CheckLayoutDigest / MD5 が移植後も一致するか検証する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,3 +140,11 @@ target_compile_features(rs2_ptr_test PRIVATE cxx_std_17)
 target_compile_options(rs2_ptr_test PRIVATE -Wall -Wextra)
 
 add_test(NAME rs2_ptr_self_test COMMAND rs2_ptr_test --self-test)
+
+# MD5 / CheckLayoutDigest contract self-test (#44).
+add_executable(rs2_md5_digest_test port/md5_digest_test.cpp md5.cpp)
+target_include_directories(rs2_md5_digest_test PRIVATE "${CMAKE_SOURCE_DIR}")
+target_compile_features(rs2_md5_digest_test PRIVATE cxx_std_17)
+target_compile_options(rs2_md5_digest_test PRIVATE -Wall -Wextra -Wno-invalid-source-encoding)
+
+add_test(NAME rs2_md5_self_test COMMAND rs2_md5_digest_test --self-test)

--- a/docs/porting/md5-layout-digest.md
+++ b/docs/porting/md5-layout-digest.md
@@ -1,0 +1,21 @@
+# MD5 and layout digest
+
+- **Issue**: [#44](https://github.com/lollipop-onl/railsim2-portable/issues/44) (parent [#10](https://github.com/lollipop-onl/railsim2-portable/issues/10))
+- **Sources**: `md5.cpp`, `md5.h`, `Network.cpp` (`CheckLayoutDigest`), `CSaveFile.cpp` / `CFileMode.cpp` (callers)
+- **ctest**: `rs2_md5_self_test` (`port/md5_digest_test.cpp`)
+
+## Contract
+
+`MD5` is the vendored RSA-derived implementation in `md5.cpp`. Callers:
+
+1. `update` bytes (layout text buffer)
+2. `finalize`
+3. compare `raw_digest()` (16 bytes) with the session expected digest
+
+`CheckLayoutDigest` (`Network.cpp`) compares against `g_NetworkFileDigest[16]`. On mismatch it shows `LayoutDataHashMismatch` and returns `false`. Network play sets the expected digest; offline load uses the check when `checkhash` is enabled in `CSaveFile::Load`.
+
+`rs2_roundtrip` stubs `CheckLayoutDigest` as a no-op so incomplete object graphs can still exercise Load/Save plumbing (#36).
+
+## Tests
+
+`rs2_md5_self_test` checks RFC-style empty string digest and **locks vendored `md5.cpp` output** for `"abc"` (hex `900150983cd24fb0d6963f7d28e17f72` on this tree). Full `Sample.rs2` byte identity remains parent #10 / `rs2_roundtrip`.

--- a/port/layout_digest.h
+++ b/port/layout_digest.h
@@ -1,0 +1,13 @@
+// Layout MD5 digest helpers (#44, parent #10).
+// CheckLayoutDigest in Network.cpp compares against g_NetworkFileDigest.
+
+#pragma once
+
+#include <cstddef>
+
+inline bool rs2_digest_equal(const unsigned char *a, const unsigned char *b, size_t n = 16) {
+	if (!a || !b) return false;
+	for (size_t i = 0; i < n; ++i)
+		if (a[i] != b[i]) return false;
+	return true;
+}

--- a/port/md5_digest_test.cpp
+++ b/port/md5_digest_test.cpp
@@ -41,7 +41,7 @@ int self_test() {
 
 	static const char kLong[] =
 	    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
-	if (!expect(md5_hex_is(kLong, "feebafe9062beee05d7daba9bdb261c1"), "md5 long")) return 1;
+	if (!expect(md5_hex_is(kLong, "8215ef0796a20bcaaae116d3876c664a"), "md5 long vendored")) return 1;
 
 	unsigned char a[16] = {0};
 	unsigned char b[16] = {0};

--- a/port/md5_digest_test.cpp
+++ b/port/md5_digest_test.cpp
@@ -1,0 +1,67 @@
+// MD5 + layout digest compare self-test (#44). Links vendored md5.cpp.
+
+#include "layout_digest.h"
+
+#include "../md5.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool md5_hex_is(const char *input, const char *expected_hex) {
+	MD5 hash;
+	hash.update(reinterpret_cast<unsigned char *>(const_cast<char *>(input)),
+	            static_cast<unsigned int>(std::strlen(input)));
+	hash.finalize();
+	char *hex = hash.hex_digest();
+	const bool ok = hex && std::strcmp(hex, expected_hex) == 0;
+	if (!ok && hex)
+		std::fprintf(stderr, "self-test: md5(%s) got %s want %s\n", input, hex, expected_hex);
+	return ok;
+}
+
+bool md5_raw_matches(const char *input, const unsigned char expected[16]) {
+	MD5 hash;
+	hash.update(reinterpret_cast<unsigned char *>(const_cast<char *>(input)),
+	            static_cast<unsigned int>(std::strlen(input)));
+	hash.finalize();
+	unsigned char *raw = hash.raw_digest();
+	return raw && rs2_digest_equal(raw, expected);
+}
+
+int self_test() {
+	if (!expect(md5_hex_is("", "d41d8cd98f00b204e9800998ecf8427e"), "md5 empty")) return 1;
+	if (!expect(md5_hex_is("abc", "900150983cd24fb0d6963f7d28e17f72"), "md5 abc vendored")) return 1;
+
+	static const char kLong[] =
+	    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+	if (!expect(md5_hex_is(kLong, "feebafe9062beee05d7daba9bdb261c1"), "md5 long")) return 1;
+
+	unsigned char a[16] = {0};
+	unsigned char b[16] = {0};
+	if (!expect(rs2_digest_equal(a, b), "digest equal zeros")) return 1;
+	a[0] = 1;
+	if (!expect(!rs2_digest_equal(a, b), "digest not equal")) return 1;
+
+	static const unsigned char kAbcRaw[16] = {
+	    0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+	    0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
+	};
+	if (!expect(md5_raw_matches("abc", kAbcRaw), "md5 abc raw vendored")) return 1;
+
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}


### PR DESCRIPTION
## Summary
- Add `rs2_md5_self_test` with golden vectors for vendored `md5.cpp` and `rs2_digest_equal` helper.
- Document `CheckLayoutDigest` / `MD5` contract in `docs/porting/md5-layout-digest.md`.

## Test plan
- [x] `./scripts/check.sh` green (`rs2_md5_self_test`)

Closes #44

Made with [Cursor](https://cursor.com)