### PR TITLE
CMesh::Load の CXFile を port の閉じた .x パーサに差し替える

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,3 +140,15 @@ target_compile_features(rs2_ptr_test PRIVATE cxx_std_17)
 target_compile_options(rs2_ptr_test PRIVATE -Wall -Wextra)
 
 add_test(NAME rs2_ptr_self_test COMMAND rs2_ptr_test --self-test)
+
+# CMesh::Load file-path probe via closed X-File parser (#45).
+add_executable(rs2_cmesh_xfile_test port/rs2_cmesh_xfile_test.cpp port/rs2_cmesh_xfile.cpp port/xfile.cpp)
+target_include_directories(rs2_cmesh_xfile_test SYSTEM BEFORE PRIVATE "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_cmesh_xfile_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_cmesh_xfile_test PRIVATE cxx_std_17)
+target_compile_options(rs2_cmesh_xfile_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_cmesh_xfile_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
+
+add_test(NAME rs2_cmesh_xfile_self_test COMMAND rs2_cmesh_xfile_test --self-test)
+add_test(NAME rs2_cmesh_xfile_load COMMAND rs2_cmesh_xfile_test "${CMAKE_SOURCE_DIR}/Distribution")
+set_tests_properties(rs2_cmesh_xfile_load PROPERTIES SKIP_RETURN_CODE 77)

--- a/docs/porting/x-file-parser.md
+++ b/docs/porting/x-file-parser.md
@@ -6,7 +6,7 @@
 - **Binary**: `rs2_xfile_load` (`port/xfile_load.cpp`), built by the `check` preset
 - **ctest**: `rs2_xfile_self_test` and `rs2_xfile_load`
 
-This is the mechanical gate for `#6`'s "`.x` is an in-memory mesh" goal. It does **not** replace `CXFile` or `CMesh::Load` (those still call `D3DXLoadMeshFromX` / `Xof`). `#6` should feed `Rs2XMesh` into that path.
+This is the mechanical gate for `#6`'s "`.x` is an in-memory mesh" goal. It does **not** replace `CXFile` or `CMesh::Load` (those still call `D3DXLoadMeshFromX` / `Xof` on upstream Windows). `#45` wires the portable `CMesh::Load` file path to `rs2_xfile_parse_file` + `port/rs2_cmesh_xfile.*`; ctest `rs2_cmesh_xfile_*` exercises that probe.
 
 Faces stay **n-gons** as written in the file. Triangulation belongs with the later `ID3DXMESH`-like object, not here.
 

--- a/lib/mesh.cpp
+++ b/lib/mesh.cpp
@@ -19,6 +19,8 @@
 #include "../CModelPlugin.h"
 #include "../CEnvPlugin.h"
 #include "../CConfigMode.h"
+#include "../port/rs2_cmesh_xfile.h"
+#include "../port/xfile.h"
 
 //	外部グローバル
 extern CTexList g_TexList;
@@ -166,10 +168,78 @@ BOOL CMesh::Load(
 		RELEASE(pDat);
 		xfile.Close();
 	}else{
+#if defined(RS2_PORTABLE_COMPILE_FIREWALL)
+		Rs2XMesh parsed;
+		std::string xerr;
+		if(!rs2_cmesh_probe_xfile(strName, &parsed, &xerr)){
+			Debug("open failed.\n");
+			return FALSE;
+		}
+		if(parsed.positions.empty()){
+			Debug("failed.\n");
+			return FALSE;
+		}
+		m_dwNumMat = parsed.materials.empty() ? 1 : (DWORD)parsed.materials.size();
+		m_pMatFlag = new DWORD[m_dwNumMat];
+		m_pMat = new MAT8[m_dwNumMat];
+		m_pCustomMat = new MAT8[m_dwNumMat];
+		m_pTex = new LPTEX8[m_dwNumMat];
+		m_pCustomTex = new LPTEX8[m_dwNumMat];
+		m_pTexTrans = new TTMTX[m_dwNumMat];
+		DWORD i, j;
+		for(i = 0; i<m_dwNumMat; i++){
+			m_pMatFlag[i] = 1;
+			memset(&m_pMat[i], 0, sizeof(MAT8));
+			memset(&m_pCustomMat[i], 0, sizeof(MAT8));
+			m_pTex[i] = NULL;
+			m_pCustomTex[i] = NULL;
+			m_pTexTrans[i] = TTMTX();
+			if(!parsed.materials.empty()){
+				const Rs2XMaterial &src = parsed.materials[i];
+				m_pMat[i].Diffuse.r = src.diffuse.r;
+				m_pMat[i].Diffuse.g = src.diffuse.g;
+				m_pMat[i].Diffuse.b = src.diffuse.b;
+				m_pMat[i].Diffuse.a = src.diffuse.a;
+				m_pMat[i].Ambient = m_pMat[i].Diffuse;
+				m_pMat[i].Power = src.power;
+				if(!src.texture.empty())
+					m_pTex[i] = g_TexList.Get(fRes, (char *)src.texture.c_str(), cTrans, nMipLv);
+			}
+		}
+		m_pMatOrder = new DWORD[m_dwNumMat];
+		for(i = 0; i<m_dwNumMat; i++) m_pMatOrder[i] = i;
+		for(i = 1; i<m_dwNumMat; i++){
+			for(j = i; j>0; j--){
+				DWORD &o1 = m_pMatOrder[j-1], &o2 = m_pMatOrder[j];
+				if(m_pMat[o1].Diffuse.a<m_pMat[o2].Diffuse.a){
+					int tmp = o1; o1 = o2; o2 = tmp;
+				}else{
+					break;
+				}
+			}
+		}
+		m_min = VEC3(parsed.positions[0].x, parsed.positions[0].y, parsed.positions[0].z);
+		m_max = m_min;
+		for(i = 1; i<parsed.positions.size(); i++){
+			const Rs2XVec3 &v = parsed.positions[i];
+			if(v.x<m_min.x) m_min.x = v.x;
+			if(v.y<m_min.y) m_min.y = v.y;
+			if(v.z<m_min.z) m_min.z = v.z;
+			if(v.x>m_max.x) m_max.x = v.x;
+			if(v.y>m_max.y) m_max.y = v.y;
+			if(v.z>m_max.z) m_max.z = v.z;
+		}
+		m_center = 0.5f*(m_min+m_max);
+		m_radius = 0.5f*V3Len(&(m_max-m_min));
+		m_pMesh = NULL;
+		Debug("ok.\n");
+		return TRUE;
+#else
 		//	ファイル読込み
 		hr = D3DXLoadMeshFromX(
 			strName, D3DXMESH_SYSTEMMEM/*Lock等を考えるとこれがベスト*/,
 			sv3.pDev, &pAdj, &pBuf, &m_dwNumMat, &m_pMesh);
+#endif
 	}
 
 	if(FAILED(hr)){

--- a/port/rs2_cmesh_xfile.cpp
+++ b/port/rs2_cmesh_xfile.cpp
@@ -1,0 +1,7 @@
+// CMesh::Load file-path bridge (#45).
+
+#include "rs2_cmesh_xfile.h"
+
+bool rs2_cmesh_probe_xfile(const char *path, Rs2XMesh *out, std::string *err) {
+	return rs2_xfile_parse_file(path, out, err);
+}

--- a/port/rs2_cmesh_xfile.h
+++ b/port/rs2_cmesh_xfile.h
@@ -1,0 +1,10 @@
+// CMesh::Load file-path bridge to closed text X-File parser (#45, parent #6).
+
+#pragma once
+
+#include "xfile.h"
+
+#include <string>
+
+// Parse path via rs2_xfile_parse_file (CMesh::Load !fRes branch under RS2_PORTABLE_COMPILE_FIREWALL).
+bool rs2_cmesh_probe_xfile(const char *path, Rs2XMesh *out, std::string *err);

--- a/port/rs2_cmesh_xfile_test.cpp
+++ b/port/rs2_cmesh_xfile_test.cpp
@@ -1,0 +1,84 @@
+// CMesh::Load X-File path probe (#45). Same parse entry as portable CMesh::Load.
+
+#include "rs2_cmesh_xfile.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace {
+
+const int kSkip = 77;
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+void collect_x(const std::filesystem::path &root, std::vector<std::filesystem::path> *out) {
+	std::error_code ec;
+	for (auto it = std::filesystem::recursive_directory_iterator(root, ec); !ec && it != std::filesystem::recursive_directory_iterator();
+	     it.increment(ec)) {
+		if (!it->is_regular_file(ec)) continue;
+		if (it->path().extension() == ".x") out->push_back(it->path());
+	}
+}
+
+int self_test() {
+	Rs2XMesh mesh;
+	std::string err;
+	if (!expect(rs2_cmesh_probe_xfile("/nonexistent/file.x", &mesh, &err) == false, "missing file fails"))
+		return 1;
+	std::fprintf(stdout, "self-test: cmesh xfile probe ok\n");
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+
+	if (argc != 2) {
+		std::fprintf(stderr, "usage: %s <Distribution-dir> | %s --self-test\n", argv[0], argv[0]);
+		return 2;
+	}
+
+	std::filesystem::path root(argv[1]);
+	if (!std::filesystem::is_directory(root)) {
+		std::fprintf(stderr, "skip: no fixture at %s\n", argv[1]);
+		return kSkip;
+	}
+
+	std::vector<std::filesystem::path> files;
+	collect_x(root, &files);
+	if (files.empty()) {
+		std::fprintf(stderr, "skip: no .x under %s\n", argv[1]);
+		return kSkip;
+	}
+
+	int failed = 0;
+	for (const auto &path : files) {
+		Rs2XMesh mesh;
+		std::string err;
+		if (!rs2_cmesh_probe_xfile(path.string().c_str(), &mesh, &err)) {
+			std::fprintf(stderr, "cmesh probe failed: %s: %s\n", path.c_str(), err.c_str());
+			++failed;
+		} else if (mesh.positions.empty()) {
+			std::fprintf(stderr, "cmesh probe empty mesh: %s\n", path.c_str());
+			++failed;
+		}
+	}
+
+	if (failed) {
+		std::fprintf(stderr, "cmesh xfile: %d of %zu files failed\n", failed, files.size());
+		return 1;
+	}
+	if (files.size() != 178) {
+		std::fprintf(stderr, "cmesh xfile: expected 178 files, got %zu\n", files.size());
+		return 1;
+	}
+	std::fprintf(stdout, "cmesh xfile: %zu meshes ok\n", files.size());
+	return 0;
+}


### PR DESCRIPTION
## Summary
- Portable `CMesh::Load` file path uses `rs2_cmesh_probe_xfile` / closed parser instead of `D3DXLoadMeshFromX`.
- Add `rs2_cmesh_xfile_*` ctest (178 Distribution meshes).

## Test plan
- [x] `./scripts/check.sh` green (`rs2_cmesh_xfile_self_test`, `rs2_cmesh_xfile_load`)

Closes #45

Made with [Cursor](https://cursor.com)