### PR TITLE
Save-side float format: RS2_FLOAT_FMT + round-trip ctest (#50)

### DIFF
--- a/CCamera.cpp
+++ b/CCamera.cpp
@@ -614,10 +614,10 @@ void CCamera::Save(
 	string indent	//	ƒCƒ“ƒfƒ“ƒg
 ){
 	fprintf(df, "%sCamera{\n", indent.c_str());
-	fprintf(df, "%s\tHead = %f;\n", indent.c_str(), m_Head);
-	fprintf(df, "%s\tPitch = %f;\n", indent.c_str(), m_Pitch);
-	fprintf(df, "%s\tDist = %f;\n", indent.c_str(), m_Dist);
-	fprintf(df, "%s\tFieldOfView = %f;\n", indent.c_str(), m_FieldOfView);
+	fprintf(df, "%s\tHead = " RS2_FLOAT_FMT ";\n", indent.c_str(), m_Head);
+	fprintf(df, "%s\tPitch = " RS2_FLOAT_FMT ";\n", indent.c_str(), m_Pitch);
+	fprintf(df, "%s\tDist = " RS2_FLOAT_FMT ";\n", indent.c_str(), m_Dist);
+	fprintf(df, "%s\tFieldOfView = " RS2_FLOAT_FMT ";\n", indent.c_str(), m_FieldOfView);
 	fprintf(df, "%s\tFocus = ", indent.c_str()); V3Save(df, m_Focus, ";\n");
 	fprintf(df, "%s}\n", indent.c_str());
 }

--- a/CDiaInst.cpp
+++ b/CDiaInst.cpp
@@ -379,6 +379,6 @@ void CDiaElement::Save(
 	fprintf(df, "%s\tAction = %d;\n", ind, m_Action);
 	fprintf(df, "%s\tTimeType = %d;\n", ind, m_TimeType);
 	fprintf(df, "%s\tTime = %d, %d, %d;\n", ind, m_Hour, m_Minute, m_Second);
-	fprintf(df, "%s\tOffset = %f;\n", ind, m_Offset);
+	fprintf(df, "%s\tOffset = " RS2_FLOAT_FMT ";\n", ind, m_Offset);
 	fprintf(df, "%s}\n", ind, m_Offset);
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,14 @@ target_compile_options(rs2_ptr_test PRIVATE -Wall -Wextra)
 
 add_test(NAME rs2_ptr_self_test COMMAND rs2_ptr_test --self-test)
 
+# Save-side float %.6f write / ConstValue-compatible parse (#50).
+add_executable(rs2_float_test port/rs2_float_test.cpp)
+target_include_directories(rs2_float_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_float_test PRIVATE cxx_std_17)
+target_compile_options(rs2_float_test PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_float_self_test COMMAND rs2_float_test --self-test)
+
 # MD5 / CheckLayoutDigest contract self-test (#44).
 add_executable(rs2_md5_digest_test port/md5_digest_test.cpp md5.cpp)
 target_include_directories(rs2_md5_digest_test PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/CParticle.cpp
+++ b/CParticle.cpp
@@ -96,7 +96,7 @@ void CParticleState::Save(
 	FILE *df,	//	ファイル
 	char *ind	//	インデント
 ){
-	fprintf(df, "%sParticleState = %f, ", ind, m_EmissionCredit);
+	fprintf(df, "%sParticleState = " RS2_FLOAT_FMT ", ", ind, m_EmissionCredit);
 	V3Save(df, m_OldPos, ";\n");
 }
 

--- a/CPier.cpp
+++ b/CPier.cpp
@@ -301,6 +301,6 @@ void CPier::Save(
 	fprintf(df, "\t\t\t\tJointPos = "); V3Save(df, R2L(m_JointObject.GetPos()), ";\n");
 	fprintf(df, "\t\t\t\tJointDir = "); V3Save(df, R2L(m_JointObject.GetDir()), ";\n");
 	fprintf(df, "\t\t\t\tJointUp = "); V3Save(df, R2L(m_JointObject.GetUp()), ";\n");
-	fprintf(df, "\t\t\t\tSurfaceAlt = %f;\n", m_SurfaceAlt);
+	fprintf(df, "\t\t\t\tSurfaceAlt = " RS2_FLOAT_FMT ";\n", m_SurfaceAlt);
 	fprintf(df, "\t\t\t}\n");
 }

--- a/CProfilePlugin.cpp
+++ b/CProfilePlugin.cpp
@@ -814,6 +814,6 @@ void SaveMapVector(
 	if(!mapv.size()) return;
 	fprintf(df, pref);
 	int i;
-	for(i = 0; i<mapv.size(); i++) fprintf(df, i ? ", %f" : "%f", mapv[i]);
+	for(i = 0; i<mapv.size(); i++) fprintf(df, i ? ", " RS2_FLOAT_FMT : RS2_FLOAT_FMT, mapv[i]);
 	fprintf(df, ";\n");
 }

--- a/CRailConnector.cpp
+++ b/CRailConnector.cpp
@@ -214,7 +214,7 @@ char *CPierPos::Read(
 void CPierPos::Save(
 	FILE *df	//	ファイル
 ){
-	fprintf(df, "\t\t\t\t\tPierLink = %f, " RS2_PTR_FMT ";\n", m_Pos, rs2_ptr32(m_Link));
+	fprintf(df, "\t\t\t\t\tPierLink = " RS2_FLOAT_FMT ", " RS2_PTR_FMT ";\n", m_Pos, rs2_ptr32(m_Link));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -252,7 +252,7 @@ char *CPolePos::Read(
 void CPolePos::Save(
 	FILE *df	//	ファイル
 ){
-	fprintf(df, "\t\t\t\t\tPoleLink = %f, %d, %s, " RS2_PTR_FMT ";\n",
+	fprintf(df, "\t\t\t\t\tPoleLink = " RS2_FLOAT_FMT ", %d, %s, " RS2_PTR_FMT ";\n",
 		m_Pos, m_Track, YESNO[m_Multi], rs2_ptr32(m_Link));
 }
 
@@ -512,7 +512,7 @@ void CRailConnector::Save(
 	fprintf(df, "\t\t\tRailConnector{\n");
 	fprintf(df, "\t\t\t\tAddress = " RS2_PTR_FMT ";\n", rs2_ptr32(this));
 	m_Splitter.Save(df, "\t\t\t\t");
-	fprintf(df, "\t\t\t\tCant = %f;\n", m_Cant);
+	fprintf(df, "\t\t\t\tCant = " RS2_FLOAT_FMT ";\n", m_Cant);
 	fprintf(df, "\t\t\t\tSide = %d;\n", m_Side);
 	fprintf(df, "\t\t\t\tTrailPoint = %d, %d;\n", m_TrailPoint[0], m_TrailPoint[1]);
 	fprintf(df, "\t\t\t\tUser = " RS2_PTR_FMT ";\n", rs2_ptr32(m_User));

--- a/CRailWay.cpp
+++ b/CRailWay.cpp
@@ -1440,7 +1440,7 @@ void CRailWay::Save(
 	fprintf(df, "\t\t\t\tMultiTrackDummy = %s;\n", YESNO[m_MultiTrackDummy]);
 	if(m_MultiTrackDummy){
 		fprintf(df, "\t\t\t\tDummyTrackNum = %d;\n", m_DummyTrackNum);
-		fprintf(df, "\t\t\t\tDummyTrackInterval = %f;\n", m_DummyTrackInterval);
+		fprintf(df, "\t\t\t\tDummyTrackInterval = " RS2_FLOAT_FMT ";\n", m_DummyTrackInterval);
 	}
 	m_Link[0].Save(df, "\t\t\t\tLink0 = ");
 	m_Link[1].Save(df, "\t\t\t\tLink1 = ");
@@ -1455,13 +1455,13 @@ void CRailWay::Save(
 	fprintf(df, "\t\t\t\t}\n");
 
 	fprintf(df, "\t\t\t\tPierList{\n");
-	fprintf(df, "\t\t\t\t\tPierPos = %f;\n", m_PierPos);
+	fprintf(df, "\t\t\t\t\tPierPos = " RS2_FLOAT_FMT ";\n", m_PierPos);
 	IPierPos ipi = m_PierList.begin();
 	for(; ipi!=m_PierList.end(); ipi++) ipi->Save(df);
 	fprintf(df, "\t\t\t\t}\n");
 
 	fprintf(df, "\t\t\t\tPoleList{\n");
-	fprintf(df, "\t\t\t\t\tPolePos = %f;\n", m_PolePos);
+	fprintf(df, "\t\t\t\t\tPolePos = " RS2_FLOAT_FMT ";\n", m_PolePos);
 	IPolePos ipo = m_PoleList.begin();
 	for(; ipo!=m_PoleList.end(); ipo++) ipo->Save(df);
 	fprintf(df, "\t\t\t\t}\n");

--- a/CRailwayMode.cpp
+++ b/CRailwayMode.cpp
@@ -168,7 +168,7 @@ void CRailwayMode::SaveRailwaySetting(
 	fprintf(file, "\tLiftRailSurface = %s;\n", YESNO[ms_LiftRailSurface.GetCheck()]);
 	fprintf(file, "\tMultiTrack = %s;\n", YESNO[ms_MultiTrackCheck.GetCheck()]);
 	fprintf(file, "\tTrackNum = %d;\n", GetTrackNum());
-	fprintf(file, "\tTrackInterval = %f;\n", GetTrackInterval());
+	fprintf(file, "\tTrackInterval = " RS2_FLOAT_FMT ";\n", GetTrackInterval());
 	fprintf(file, "}\n\n");
 }
 

--- a/CRailwayPluginSet.cpp
+++ b/CRailwayPluginSet.cpp
@@ -171,7 +171,7 @@ void CRailwayPluginSet::Save(
 	fprintf(file, "\tLiftRailSurface = %s;\n", YESNO[m_LiftRailSurface]);
 	fprintf(file, "\tMultiTrack = %s;\n", YESNO[m_MultiTrack]);
 	fprintf(file, "\tTrackNum = %d;\n", m_TrackNum);
-	fprintf(file, "\tTrackInterval = %f;\n", m_TrackInterval);
+	fprintf(file, "\tTrackInterval = " RS2_FLOAT_FMT ";\n", m_TrackInterval);
 	fprintf(file, "}\n");
 }
 

--- a/CTrainGroup.cpp
+++ b/CTrainGroup.cpp
@@ -1283,9 +1283,9 @@ void CTrainGroup::Save(
 	fprintf(df, "\t\tEnabled = %s;\n", YESNO[m_Enabled]);
 	if(m_Enabled){
 		fprintf(df, "\t\tState = %d;\n", m_State);
-		fprintf(df, "\t\tTargetSpeed = %f;\n", m_TargetSpeed);
-		fprintf(df, "\t\tCurrentSpeed = %f;\n", m_CurrentSpeed);
-		fprintf(df, "\t\tStopTarget = %f;\n", m_StopTarget);
+		fprintf(df, "\t\tTargetSpeed = " RS2_FLOAT_FMT ";\n", m_TargetSpeed);
+		fprintf(df, "\t\tCurrentSpeed = " RS2_FLOAT_FMT ";\n", m_CurrentSpeed);
+		fprintf(df, "\t\tStopTarget = " RS2_FLOAT_FMT ";\n", m_StopTarget);
 		fprintf(df, "\t\tDepartureTime = %08x, %08x;\n",
 			*(PDWORD)&m_DepartureTime, *((PDWORD)&m_DepartureTime+1));
 		fprintf(df, "\t\tDoorWait = %d;\n", m_DoorWait);

--- a/CTrainSetCurve.cpp
+++ b/CTrainSetCurve.cpp
@@ -197,7 +197,7 @@ void CGroupEndLocator::Save(
 ){
 	fprintf(df, "%s%s{\n", ind, pref);
 	fprintf(df, "%s\tAddress = " RS2_PTR_FMT ";\n", ind, rs2_ptr32(this));
-	fprintf(df, "%s\tLocation = %d, %f, " RS2_PTR_FMT ";\n", ind, m_Side, m_Offset, rs2_ptr32(m_SetRail));
+	fprintf(df, "%s\tLocation = %d, " RS2_FLOAT_FMT ", " RS2_PTR_FMT ";\n", ind, m_Side, m_Offset, rs2_ptr32(m_SetRail));
 	fprintf(df, "%s}\n", ind);
 }
 

--- a/CWindowDivInfo.cpp
+++ b/CWindowDivInfo.cpp
@@ -6,7 +6,7 @@
 #include "CScene.h"
 #include "CSaveFile.h"
 
-//	“à•”’è”
+//	“à•”’è”
 const int DRAG_BAR_WIDTH = 1;
 
 CWindowInfo::CWindowInfo(){
@@ -66,10 +66,10 @@ void CWindowInfo::OnDeleteScene(CScene *scene){
 }
 
 /*
- *	“Ç
+ *	“Ç
  */
 char *CWindowInfo::Read(
-	char *str	//	‘ÎÛ•¶š—ñ
+	char *str	//	‘ÎÛ•¶š—ñ
 ){
 	char *eee;
 	if(!(str = BeginBlock(eee = str, "WindowInfo"))) throw CSynErr(eee);
@@ -469,10 +469,10 @@ void CWindowDivInfo::OnDeleteScene(CScene *scene){
 }
 
 /*
- *	“Ç
+ *	“Ç
  */
 char *CWindowDivInfo::Read(
-	char *str	//	‘ÎÛ•¶š—ñ
+	char *str	//	‘ÎÛ•¶š—ñ
 ){
 	char *eee;
 	if(!(str = BeginBlock(eee = str, "WindowDivInfo"))) throw CSynErr(eee);
@@ -498,8 +498,8 @@ void CWindowDivInfo::Save(
 	string indent	//	ƒCƒ“ƒfƒ“ƒg
 ){
 	fprintf(df, "%sWindowDivInfo{\n", indent.c_str());
-	fprintf(df, "%s\tHorzRatio = %f;\n", indent.c_str(), m_HorzRatio);
-	fprintf(df, "%s\tVertRatio = %f;\n", indent.c_str(), m_VertRatio);
+	fprintf(df, "%s\tHorzRatio = " RS2_FLOAT_FMT ";\n", indent.c_str(), m_HorzRatio);
+	fprintf(df, "%s\tVertRatio = " RS2_FLOAT_FMT ";\n", indent.c_str(), m_VertRatio);
 	string indent2 = indent+"\t";
 	int i, j;
 	for(i = 0; i<WIN_DIV_MAX; ++i){

--- a/SystemCover.h
+++ b/SystemCover.h
@@ -74,7 +74,7 @@ inline void V3Save(
 	VEC3 &v,	//	ベクトル
 	char *e		//	サフィックス
 ){
-	fprintf(df, "(%f, %f, %f)%s", v.x, v.y, v.z, e);
+	fprintf(df, "(" RS2_FLOAT_FMT ", " RS2_FLOAT_FMT ", " RS2_FLOAT_FMT ")%s", v.x, v.y, v.z, e);
 }
 
 #endif

--- a/docs/porting/rs2-float-format.md
+++ b/docs/porting/rs2-float-format.md
@@ -1,0 +1,42 @@
+# Save-side float format (`%f`)
+
+- **Issue**: [#50](https://github.com/lollipop-onl/railsim2-portable/issues/50) (parent [#10](https://github.com/lollipop-onl/railsim2-portable/issues/10))
+- **Header**: `port/rs2_float.h` (`RS2_FLOAT_FMT`, `rs2_format_float`, `rs2_parse_float`)
+- **ctest**: `rs2_float_self_test` (`port/rs2_float_test.cpp`)
+
+## Contract
+
+Legacy RailSim2 Save uses C `fprintf` with `%f`. On 32-bit Windows that prints **six digits after the decimal point** (for example `139.665771`, `-0.000000`). Portable Save must keep that text shape so Load (`ConstValue` / `ConstFloat` in `Script.cpp`, which uses `sscanf(..., "%f", ...)`) round-trips.
+
+`RS2_FLOAT_FMT` is `"%.6f"`. Use it anywhere Save writes a layout float (including `V3Save` in `SystemCover.h`).
+
+Version fields (`RailSimVersion = %.2f`) and UI/debug `FlashIn` / `sprintf` paths are **not** part of this contract.
+
+## Write inventory (Save / plugin Save)
+
+| Location | Pattern |
+|----------|---------|
+| `SystemCover.h` | `V3Save` ? vector `(x, y, z)` triples |
+| `CCamera.cpp` | `Head`, `Pitch`, `Dist`, `FieldOfView` + `V3Save` focus |
+| `CWindowDivInfo.cpp` | `HorzRatio`, `VertRatio` |
+| `CTrainGroup.cpp` | `TargetSpeed`, `CurrentSpeed`, `StopTarget` + `V3Save` cabin |
+| `CTrain.cpp` | `V3Save` old position / tilt |
+| `CTrainSetCurve.cpp` | `Location` offset |
+| `CRailWay.cpp` | `DummyTrackInterval`, `PierPos`, `PolePos` |
+| `CRailConnector.cpp` | `PierLink`, `PoleLink`, `Cant` + `V3Save` pose |
+| `CRailwayMode.cpp`, `CRailwayPluginSet.cpp` | `TrackInterval` |
+| `CProfilePlugin.cpp` | height map comma list |
+| `CPier.cpp` | `SurfaceAlt` + joint `V3Save` |
+| `CParticle.cpp` | `ParticleState` credit + `V3Save` |
+| `CModelInst.cpp`, `CCustomizerMover.cpp` | `V3Save` pose |
+| `CLine.cpp` | `V3Save` line geometry |
+| `CDiaInst.cpp` | dia `Offset` |
+| `CSaveFile.cpp` | wind `V3Save` |
+
+## Read inventory (Load)
+
+`ConstFloat` / `ConstValue` in `Script.cpp` parse floats for vectors, plugin fields, and curve offsets. Save write sites above must stay compatible with that parser.
+
+## Tests
+
+`rs2_float_self_test` locks `RS2_FLOAT_FMT` output against literals from `Distribution/en/RailSim2/Layout/Sample.rs2` and checks format Å® `strtof` Å® bitwise float equality. Full `Sample.rs2` byte identity remains parent #10 / `rs2_roundtrip`.

--- a/port/rs2_float.h
+++ b/port/rs2_float.h
@@ -1,0 +1,28 @@
+// Fixed decimal float text for .rs2 Save (#50).
+// Matches legacy Windows fprintf "%f" (six digits after the decimal point).
+
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+#ifndef RS2_FLOAT_FMT
+#define RS2_FLOAT_FMT "%.6f"
+#endif
+
+// Format into buf; writes RS2_FLOAT_FMT text (+ NUL) when n is large enough.
+inline bool rs2_format_float(char *buf, size_t n, float f) {
+	if (!buf || n < 2) return false;
+	std::snprintf(buf, n, RS2_FLOAT_FMT, f);
+	return true;
+}
+
+// Parse a float token the way ConstValue does after the numeric span (sscanf %f).
+inline bool rs2_parse_float(const char *text, float *out) {
+	if (!text || !*text || !out) return false;
+	char *end = nullptr;
+	float v = std::strtof(text, &end);
+	if (end == text) return false;
+	*out = v;
+	return true;
+}

--- a/port/rs2_float_test.cpp
+++ b/port/rs2_float_test.cpp
@@ -1,0 +1,63 @@
+// Save-side float format round-trip self-test (#50).
+
+#include "rs2_float.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool floats_equal(float a, float b) {
+	return std::memcmp(&a, &b, sizeof(float)) == 0;
+}
+
+bool roundtrip(float in) {
+	char buf[64];
+	if (!rs2_format_float(buf, sizeof(buf), in)) return false;
+	float out = 0.0f;
+	if (!rs2_parse_float(buf, &out)) return false;
+	return floats_equal(in, out);
+}
+
+bool format_is(const char *expected, float f) {
+	char buf[64];
+	if (!rs2_format_float(buf, sizeof(buf), f)) return false;
+	return std::strcmp(buf, expected) == 0;
+}
+
+int self_test() {
+	// Sample.rs2 literals (Distribution/en/RailSim2/Layout/Sample.rs2).
+	if (!expect(format_is("0.030583", 0.030583f), "sample Dir1.x")) return 1;
+	if (!expect(format_is("0.000000", 0.0f), "sample zero")) return 1;
+	if (!expect(format_is("-0.023673", -0.023673f), "sample Dir1.z")) return 1;
+	if (!expect(format_is("139.665771", 139.665771f), "sample Pos.x")) return 1;
+	if (!expect(format_is("1.000000", 1.0f), "sample unit")) return 1;
+
+	float neg_zero = -0.0f;
+	if (!expect(format_is("-0.000000", neg_zero), "sample negative zero")) return 1;
+	if (!expect(roundtrip(neg_zero), "roundtrip negative zero")) return 1;
+
+	const float cases[] = {
+	    0.030583f, -0.023673f, 139.665771f, 0.999802f, -1.793967f,
+	    180.037186f, -0.019921f, 0.400000f,
+	};
+	for (float f : cases) {
+		if (!expect(roundtrip(f), "roundtrip sample value")) return 1;
+	}
+
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/stdafx.h
+++ b/stdafx.h
@@ -9,6 +9,7 @@
 #include "lib/udx.h"
 #include "port/path.h"
 #include "port/rs2_ptr.h"
+#include "port/rs2_float.h"
 
 typedef list<string>::iterator Istring;
 


### PR DESCRIPTION
## Summary
- Add `port/rs2_float.h` with `RS2_FLOAT_FMT` (`"%.6f"`) and format/parse helpers matching legacy Windows Save text and `ConstValue`/`ConstFloat` load.
- Replace layout Save `fprintf` `%f` sites (including `V3Save`) with `RS2_FLOAT_FMT`; document write/read inventory in `docs/porting/rs2-float-format.md`.
- Add `rs2_float_self_test` ctest with Sample.rs2 literals and format→parse round-trip checks.

## Test plan
- [x] `./scripts/check.sh` green
- [x] `ctest --preset check -R rs2_float_self_test` passes
- [ ] Does not change `%p`, MD5, or full Sample.rs2 byte identity (deferred to other #10 slices)

Closes #50

Made with [Cursor](https://cursor.com)