### PR TITLE
Lock Config.txt and plugin *2.txt load smoke (#58)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,3 +202,17 @@ target_compile_definitions(rs2_cmesh_xfile_test PRIVATE RS2_PORTABLE_COMPILE_FIR
 add_test(NAME rs2_cmesh_xfile_self_test COMMAND rs2_cmesh_xfile_test --self-test)
 add_test(NAME rs2_cmesh_xfile_load COMMAND rs2_cmesh_xfile_test "${CMAKE_SOURCE_DIR}/Distribution")
 set_tests_properties(rs2_cmesh_xfile_load PROPERTIES SKIP_RETURN_CODE 77)
+
+# Config.txt smoke/roundtrip and *2.txt LoadHeader (#58). Does not link CConfigMode.
+add_executable(rs2_config_plugin_test
+  port/rs2_config_plugin_test.cpp
+  port/rs2_config_plugin.cpp
+  port/path.cpp)
+target_include_directories(rs2_config_plugin_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_config_plugin_test PRIVATE cxx_std_17)
+target_compile_options(rs2_config_plugin_test PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_config_plugin_self_test COMMAND rs2_config_plugin_test --self-test)
+add_test(NAME rs2_config_plugin_load COMMAND rs2_config_plugin_test
+  "${CMAKE_SOURCE_DIR}/Distribution")
+set_tests_properties(rs2_config_plugin_load PROPERTIES SKIP_RETURN_CODE 77)

--- a/docs/porting/config-plugin-compat.md
+++ b/docs/porting/config-plugin-compat.md
@@ -1,0 +1,51 @@
+# Config.txt / Language.txt / plugin `*2.txt` verification
+
+- **Issue**: [#58](https://github.com/lollipop-onl/railsim2-portable/issues/58) (parent [#10](https://github.com/lollipop-onl/railsim2-portable/issues/10))
+- **Sources**: `port/rs2_config_plugin.{h,cpp}`, `port/rs2_config_plugin_test.cpp`
+- **ctest**: `rs2_config_plugin_self_test`, `rs2_config_plugin_load`
+- **Path rules**: [path-seams.md](path-seams.md)
+
+This slice locks **text-definition** load for settings and one representative plugin header. It does **not** change `.rs2` layout format, expand to every plugin type, or enter M3 / `.x` draw. Layout mechanical gates stay in [rs2-roundtrip.md](rs2-roundtrip.md) / #59.
+
+## Call-site inventory
+
+| Symbol | File | When | Path |
+|--------|------|------|------|
+| `CConfigMode::Load` | `CConfigMode.cpp` | `CGameMode::WakeUp` after `InitLanguage` | `rs2_path_join(g_BaseDir, "Config.txt")` then `LoadBinaryText`. Missing file Å® in-code defaults (`goto SET`), still `true`. Parse `CSynErr` Å® `false`. Leftover after `ConfigMode{}` is `g_ConfigScript`. |
+| `CConfigMode::Save` | `CConfigMode.cpp` | `CGameMode` shutdown when `!g_RSPV` | `fopen(cfgpath, "wt")`. Writes `DatafileHeader` + `ConfigMode` (current `RAILSIM_VERSION` 2.15), then `SaveModeSettings` (per-mode tails). `YESNO[]` is `"no"` / `"yes"`. |
+| `CGameMode::LoadModeSettings` | `CGameMode.cpp` | after modes exist | Walks `g_ConfigScript` through each mode `LoadSetting`, including `g_ConfigMode->LoadSetting`. Errors still tagged `"Config.txt"`. |
+| `CGameMode::SaveModeSettings` | `CGameMode.cpp` | from `CConfigMode::Save` | Appends per-mode blocks after `ConfigMode{}`. Out of this ctest (not required for settings smoke). |
+| `InitLanguage` | `Language.cpp` | `CGameMode::WakeUp` (first) | `LoadBinaryText(rs2_path_join(g_BaseDir, LANG_FILE_NAME))` with `LANG_FILE_NAME = "Language.txt"`. `DatafileType = Language`, then `Language.Name`, then the `Resource{}` string table. |
+| `CPlugin::LoadHeader` / `PreLoad` | `CPlugin.cpp` | `CPluginList::List` per folder | `fopen` `{type}/{id}/{Type}2.txt` (`TextName2`, e.g. `Rail2.txt`) else old-form `TextName`. Header only: `PluginHeader` + `PluginType == DirName()`. Full `CPlugin::Load` / meshes stay later. |
+
+`Distribution/*/RailSim2` ships `Language.txt` and plugin `*2.txt`. `Config.txt` is **runtime-created**; first boot uses the defaults path.
+
+## Contract (ctest)
+
+`rs2_config_plugin_self_test`
+
+- Missing `Config.txt` Å® `rs2_config_load_or_defaults` applies the same locals `CConfigMode::Load` uses before `SET` (640x480, `Default_JR_Narrow`, Åc).
+- Parse a `CConfigMode::Save`-shaped 2.15 buffer; keep 2.00 buffers valid (no `WindowShadow` / `ShowMap` / `Stereoscopy`, gated defaults remain).
+- Write + parse roundtrip of non-default fields (`YESNO` lowercase, `RailSimVersion = %.2f`, `Interval = %.2f`).
+- Inline `PluginHeader` + `Language` `DatafileHeader` smoke.
+
+`rs2_config_plugin_load` (`Distribution/`)
+
+- `Language.txt` header (`Name` non-empty).
+- `Rail/Default_JR_Narrow/Rail2.txt` `LoadHeader` (`PluginType = Rail`). There is no `Rail/Rail01/` in Distribution; this is the default selected rail ID.
+- `Config.txt` if present, else defaults. Missing fixture root Å® exit **77**.
+
+```bash
+./scripts/check.sh
+# or:
+ctest --preset check --output-on-failure -R rs2_config_plugin
+```
+
+The harness is a closed Script.cpp-shaped scanner in `port/`. It does not link `CConfigMode` / `CRailPlugin` (UI, sound, mesh). Trailing per-mode settings after `ConfigMode{}` are ignored, matching `g_ConfigScript`.
+
+## Out of scope
+
+- `.rs2` object graph / `%p` / MD5 / float lexemes (#40 / #44 / #50 / #54 / #59)
+- Full plugin `Load()` (profiles, `.x`, wav, M3)
+- Every `*2.txt` in Distribution
+- Rewriting `CConfigMode.cpp` / `Language.cpp`

--- a/port/rs2_config_plugin.cpp
+++ b/port/rs2_config_plugin.cpp
@@ -1,0 +1,603 @@
+#include "rs2_config_plugin.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+
+namespace {
+
+bool is_sjis_lead(unsigned char c) {
+	return (c >= 0x81 && c <= 0x9F) || (c >= 0xE0 && c <= 0xFC);
+}
+
+const char *cp932_next(const char *p) {
+	if (!p || !*p) return p;
+	unsigned char c = static_cast<unsigned char>(*p);
+	if (is_sjis_lead(c) && p[1]) return p + 2;
+	return p + 1;
+}
+
+void set_err(char *err, size_t errn, const char *msg) {
+	if (err && errn) std::snprintf(err, errn, "%s", msg ? msg : "parse error");
+}
+
+bool read_all(const char *path, std::string *out) {
+	std::ifstream in(path, std::ios::binary);
+	if (!in) return false;
+	std::ostringstream ss;
+	ss << in.rdbuf();
+	*out = ss.str();
+	return true;
+}
+
+struct Cur {
+	const char *p;
+	char errbuf[128];
+
+	explicit Cur(const char *text) : p(text ? text : "") { errbuf[0] = 0; }
+
+	void fail(const char *msg) { std::snprintf(errbuf, sizeof(errbuf), "%s", msg); }
+
+	bool skip() {
+		while (p && *p) {
+			unsigned char c = static_cast<unsigned char>(*p);
+			if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+				p++;
+				continue;
+			}
+			if (c == 0x81 && static_cast<unsigned char>(p[1]) == 0x40) {
+				p += 2;
+				continue;
+			}
+			if (p[0] == '/' && p[1] == '/') {
+				p += 2;
+				while (*p && *p != '\n') p = cp932_next(p);
+				continue;
+			}
+			if (p[0] == '/' && p[1] == '*') {
+				p += 2;
+				bool closed = false;
+				while (*p) {
+					if (p[0] == '*' && p[1] == '/') {
+						p += 2;
+						closed = true;
+						break;
+					}
+					p = cp932_next(p);
+				}
+				if (!closed) {
+					fail("comment end not found");
+					return false;
+				}
+				continue;
+			}
+			break;
+		}
+		return true;
+	}
+
+	bool peek_ident(std::string *out) {
+		if (!skip()) return false;
+		if (!(('A' <= *p && *p <= 'Z') || ('a' <= *p && *p <= 'z') || *p == '_')) return false;
+		const char *s = p;
+		p++;
+		while (('A' <= *p && *p <= 'Z') || ('a' <= *p && *p <= 'z') || *p == '_' ||
+		       ('0' <= *p && *p <= '9'))
+			p++;
+		if (out) out->assign(s, p);
+		return true;
+	}
+
+	bool ident_is(const char *want) {
+		const char *save = p;
+		std::string got;
+		if (!peek_ident(&got) || got != want) {
+			p = save;
+			return false;
+		}
+		return skip();
+	}
+
+	bool ch(char c) {
+		if (!skip()) return false;
+		if (*p != c) return false;
+		p++;
+		return skip();
+	}
+
+	bool begin_block(const char *name) { return ident_is(name) && ch('{'); }
+
+	bool end_block() { return ch('}'); }
+
+	bool assignment(const char *key) { return ident_is(key) && ch('='); }
+
+	bool number(int *outi, float *outf) {
+		if (!skip()) return false;
+		const char *s = p;
+		if (*p == '-') p++;
+		bool digit = false;
+		while ('0' <= *p && *p <= '9') {
+			digit = true;
+			p++;
+		}
+		if (*p == '.') {
+			p++;
+			while ('0' <= *p && *p <= '9') {
+				digit = true;
+				p++;
+			}
+		}
+		if (!digit) {
+			p = s;
+			return false;
+		}
+		char tmp[64];
+		size_t n = static_cast<size_t>(p - s);
+		if (n >= sizeof(tmp)) {
+			p = s;
+			return false;
+		}
+		std::memcpy(tmp, s, n);
+		tmp[n] = 0;
+		int i = 0;
+		float f = 0.0f;
+		std::sscanf(tmp, "%d", &i);
+		std::sscanf(tmp, "%f", &f);
+		if (outi) *outi = i;
+		if (outf) *outf = f;
+		return skip();
+	}
+
+	bool string_lit(std::string *out) {
+		if (!skip()) return false;
+		if (*p != '"') return false;
+		p++;
+		const char *s = p;
+		while (*p) {
+			if (*p == '\r' || *p == '\n') {
+				fail("string exceeds line break");
+				return false;
+			}
+			if (p[0] == '\\' && p[1] == '"') {
+				p += 2;
+				continue;
+			}
+			if (*p == '"') {
+				if (out) out->assign(s, p);
+				p++;
+				return skip();
+			}
+			p = cp932_next(p);
+		}
+		fail("unterminated string");
+		return false;
+	}
+
+	bool asgn_yesno(const char *key, bool *out) {
+		if (!assignment(key)) return false;
+		std::string yn;
+		if (!peek_ident(&yn) || (yn != "yes" && yn != "no")) return false;
+		*out = yn == "yes";
+		return ch(';');
+	}
+
+	bool asgn_int(const char *key, int *out, int n) {
+		if (!assignment(key)) return false;
+		for (int i = 0; i < n; i++) {
+			if (i && !ch(',')) return false;
+			if (!number(out + i, nullptr)) return false;
+		}
+		return ch(';');
+	}
+
+	bool asgn_float(const char *key, float *out, int n) {
+		if (!assignment(key)) return false;
+		for (int i = 0; i < n; i++) {
+			if (i && !ch(',')) return false;
+			if (!number(nullptr, out + i)) return false;
+		}
+		return ch(';');
+	}
+
+	bool asgn_ident(const char *key, std::string *out) {
+		if (!assignment(key)) return false;
+		if (!peek_ident(out)) return false;
+		return ch(';');
+	}
+
+	bool asgn_string(const char *key, std::string *out) {
+		if (!assignment(key)) return false;
+		if (!string_lit(out)) return false;
+		return ch(';');
+	}
+
+	bool try_asgn_string(const char *key, std::string *out) {
+		const char *save = p;
+		if (asgn_string(key, out)) return true;
+		p = save;
+		return false;
+	}
+
+	bool try_asgn_float(const char *key, float *out, int n) {
+		const char *save = p;
+		if (asgn_float(key, out, n)) return true;
+		p = save;
+		return false;
+	}
+};
+
+const char *yesno(bool v) { return v ? "yes" : "no"; }
+
+}  // namespace
+
+void rs2_config_defaults(Rs2Config *out) {
+	if (!out) return;
+	*out = Rs2Config{};
+	out->version = RS2_CONFIG_VERSION;
+	out->hide_top_panel = false;
+	out->hide_right_panel = false;
+	out->window_shadow = true;
+	out->full_screen = true;
+	out->resolution[0] = 640;
+	out->resolution[1] = 480;
+	out->rail_mipmap = true;
+	out->train_mipmap = false;
+	out->struct_mipmap = false;
+	out->surface_mipmap = true;
+	out->compass = true;
+	out->wind_meter = true;
+	out->show_map = false;
+	out->shadow = false;
+	out->linear_filter = true;
+	out->env_map = true;
+	out->specular_light = true;
+	out->sun_lens_flare = true;
+	out->sun_whiteout = true;
+	out->misc_lens_flare = true;
+	out->misc_particle = true;
+	out->wind = true;
+	out->interface_sound = true;
+	out->rail_sound = true;
+	out->train_sound = true;
+	out->struct_sound = true;
+	out->surface_sound = true;
+	out->use_undo = true;
+	out->stereo_enabled = false;
+	out->stereo_method = 0;
+	out->stereo_interval = 1.0f;
+	out->selected_rail = "Default_JR_Narrow";
+	out->selected_tie = "Default_JRN_BallastPC";
+	out->selected_girder = "Default_JRN_SinglePC";
+	out->selected_pier = "Default_SinglePC";
+	out->selected_line = "Default_SimpleCatenary";
+	out->selected_pole = "Default_JRN_Single";
+	out->selected_train = "Aizentranza01";
+	out->selected_station = "MM02";
+	out->selected_struct = "Ship";
+	out->selected_surface = "Default";
+	out->selected_env = "Default";
+	out->selected_skin = "Default_Blue";
+}
+
+bool rs2_config_equal(const Rs2Config *a, const Rs2Config *b) {
+	if (!a || !b) return false;
+	return a->version == b->version && a->hide_top_panel == b->hide_top_panel &&
+	       a->hide_right_panel == b->hide_right_panel && a->window_shadow == b->window_shadow &&
+	       a->full_screen == b->full_screen && a->resolution[0] == b->resolution[0] &&
+	       a->resolution[1] == b->resolution[1] && a->rail_mipmap == b->rail_mipmap &&
+	       a->train_mipmap == b->train_mipmap && a->struct_mipmap == b->struct_mipmap &&
+	       a->surface_mipmap == b->surface_mipmap && a->compass == b->compass &&
+	       a->wind_meter == b->wind_meter && a->show_map == b->show_map && a->shadow == b->shadow &&
+	       a->linear_filter == b->linear_filter && a->env_map == b->env_map &&
+	       a->specular_light == b->specular_light && a->sun_lens_flare == b->sun_lens_flare &&
+	       a->sun_whiteout == b->sun_whiteout && a->misc_lens_flare == b->misc_lens_flare &&
+	       a->misc_particle == b->misc_particle && a->wind == b->wind &&
+	       a->interface_sound == b->interface_sound && a->rail_sound == b->rail_sound &&
+	       a->train_sound == b->train_sound && a->struct_sound == b->struct_sound &&
+	       a->surface_sound == b->surface_sound && a->use_undo == b->use_undo &&
+	       a->stereo_enabled == b->stereo_enabled && a->stereo_method == b->stereo_method &&
+	       a->stereo_interval == b->stereo_interval && a->selected_rail == b->selected_rail &&
+	       a->selected_tie == b->selected_tie && a->selected_girder == b->selected_girder &&
+	       a->selected_pier == b->selected_pier && a->selected_line == b->selected_line &&
+	       a->selected_pole == b->selected_pole && a->selected_train == b->selected_train &&
+	       a->selected_station == b->selected_station && a->selected_struct == b->selected_struct &&
+	       a->selected_surface == b->selected_surface && a->selected_env == b->selected_env &&
+	       a->selected_skin == b->selected_skin;
+}
+
+bool rs2_config_parse(const char *text, Rs2Config *out, char *err, size_t errn) {
+	if (!text || !out) {
+		set_err(err, errn, "null arg");
+		return false;
+	}
+	rs2_config_defaults(out);
+	Cur cur(text);
+	std::string dtype;
+	if (!cur.skip() || !cur.begin_block("DatafileHeader") ||
+	    !cur.asgn_float("RailSimVersion", &out->version, 1) ||
+	    !cur.asgn_ident("DatafileType", &dtype) || !cur.end_block()) {
+		set_err(err, errn, cur.errbuf[0] ? cur.errbuf : "DatafileHeader");
+		return false;
+	}
+	if (dtype != "Config") {
+		set_err(err, errn, "DatafileType != Config");
+		return false;
+	}
+	if (out->version > RS2_CONFIG_VERSION) {
+		set_err(err, errn, "unsupported Config version");
+		return false;
+	}
+	if (!cur.begin_block("ConfigMode")) {
+		set_err(err, errn, "ConfigMode");
+		return false;
+	}
+	if (!cur.begin_block("Interface") || !cur.asgn_yesno("HideTopPanel", &out->hide_top_panel) ||
+	    !cur.asgn_yesno("HideRightPanel", &out->hide_right_panel)) {
+		set_err(err, errn, "Interface");
+		return false;
+	}
+	if (out->version >= 2.03f && !cur.asgn_yesno("WindowShadow", &out->window_shadow)) {
+		set_err(err, errn, "WindowShadow");
+		return false;
+	}
+	if (!cur.end_block()) {
+		set_err(err, errn, "Interface end");
+		return false;
+	}
+	if (!cur.begin_block("Device") || !cur.asgn_yesno("FullScreen", &out->full_screen) ||
+	    !cur.asgn_int("Resolution", out->resolution, 2) ||
+	    !cur.asgn_yesno("RailMipMap", &out->rail_mipmap) ||
+	    !cur.asgn_yesno("TrainMipMap", &out->train_mipmap) ||
+	    !cur.asgn_yesno("StructMipMap", &out->struct_mipmap) ||
+	    !cur.asgn_yesno("SurfaceMipMap", &out->surface_mipmap) || !cur.end_block()) {
+		set_err(err, errn, "Device");
+		return false;
+	}
+	if (!cur.begin_block("Accessory") || !cur.asgn_yesno("Compass", &out->compass) ||
+	    !cur.asgn_yesno("WindMeter", &out->wind_meter)) {
+		set_err(err, errn, "Accessory");
+		return false;
+	}
+	if (out->version >= 2.03f && !cur.asgn_yesno("ShowMap", &out->show_map)) {
+		set_err(err, errn, "ShowMap");
+		return false;
+	}
+	if (!cur.end_block()) {
+		set_err(err, errn, "Accessory end");
+		return false;
+	}
+	if (!cur.begin_block("Effect") || !cur.asgn_yesno("Shadow", &out->shadow) ||
+	    !cur.asgn_yesno("LinearFilter", &out->linear_filter) ||
+	    !cur.asgn_yesno("EnvMap", &out->env_map) ||
+	    !cur.asgn_yesno("SpecularLight", &out->specular_light) ||
+	    !cur.asgn_yesno("SunLensFlare", &out->sun_lens_flare) ||
+	    !cur.asgn_yesno("SunWhiteout", &out->sun_whiteout) ||
+	    !cur.asgn_yesno("MiscLensFlare", &out->misc_lens_flare) ||
+	    !cur.asgn_yesno("MiscParticle", &out->misc_particle) || !cur.asgn_yesno("Wind", &out->wind) ||
+	    !cur.end_block()) {
+		set_err(err, errn, "Effect");
+		return false;
+	}
+	if (!cur.begin_block("Sound") || !cur.asgn_yesno("InterfaceSound", &out->interface_sound) ||
+	    !cur.asgn_yesno("RailSound", &out->rail_sound) ||
+	    !cur.asgn_yesno("TrainSound", &out->train_sound) ||
+	    !cur.asgn_yesno("StructSound", &out->struct_sound) ||
+	    !cur.asgn_yesno("SurfaceSound", &out->surface_sound) || !cur.end_block()) {
+		set_err(err, errn, "Sound");
+		return false;
+	}
+	if (!cur.begin_block("Misc") || !cur.asgn_yesno("UseUndo", &out->use_undo) || !cur.end_block()) {
+		set_err(err, errn, "Misc");
+		return false;
+	}
+	if (out->version >= 2.12f) {
+		if (!cur.begin_block("Stereoscopy") || !cur.asgn_yesno("Enabled", &out->stereo_enabled) ||
+		    !cur.asgn_int("Method", &out->stereo_method, 1) ||
+		    !cur.asgn_float("Interval", &out->stereo_interval, 1) || !cur.end_block()) {
+			set_err(err, errn, "Stereoscopy");
+			return false;
+		}
+	}
+	if (!cur.begin_block("SelectedPlugin") || !cur.asgn_string("Rail", &out->selected_rail) ||
+	    !cur.asgn_string("Tie", &out->selected_tie) ||
+	    !cur.asgn_string("Girder", &out->selected_girder) ||
+	    !cur.asgn_string("Pier", &out->selected_pier) ||
+	    !cur.asgn_string("Line", &out->selected_line) ||
+	    !cur.asgn_string("Pole", &out->selected_pole) ||
+	    !cur.asgn_string("Train", &out->selected_train) ||
+	    !cur.asgn_string("Station", &out->selected_station) ||
+	    !cur.asgn_string("Struct", &out->selected_struct) ||
+	    !cur.asgn_string("Surface", &out->selected_surface) ||
+	    !cur.asgn_string("Env", &out->selected_env) || !cur.asgn_string("Skin", &out->selected_skin) ||
+	    !cur.end_block() || !cur.end_block()) {
+		set_err(err, errn, "SelectedPlugin");
+		return false;
+	}
+	return true;
+}
+
+bool rs2_config_write(const Rs2Config *in, std::string *out) {
+	if (!in || !out) return false;
+	char ver[32];
+	char interval[32];
+	std::snprintf(ver, sizeof(ver), "%.2f", RS2_CONFIG_VERSION);
+	std::snprintf(interval, sizeof(interval), "%.2f", in->stereo_interval);
+	std::ostringstream ss;
+	ss << "/*\n *\tRailSim II Configuration Datafile\n */\n\n";
+	ss << "DatafileHeader{\n";
+	ss << "\tRailSimVersion = " << ver << ";\n";
+	ss << "\tDatafileType = Config;\n";
+	ss << "}\n\n";
+	ss << "ConfigMode{\n";
+	ss << "\tInterface{\n";
+	ss << "\t\tHideTopPanel = " << yesno(in->hide_top_panel) << ";\n";
+	ss << "\t\tHideRightPanel = " << yesno(in->hide_right_panel) << ";\n";
+	ss << "\t\tWindowShadow = " << yesno(in->window_shadow) << ";\n";
+	ss << "\t}\n";
+	ss << "\tDevice{\n";
+	ss << "\t\tFullScreen = " << yesno(in->full_screen) << ";\n";
+	ss << "\t\tResolution = " << in->resolution[0] << ", " << in->resolution[1] << ";\n";
+	ss << "\t\tRailMipMap = " << yesno(in->rail_mipmap) << ";\n";
+	ss << "\t\tTrainMipMap = " << yesno(in->train_mipmap) << ";\n";
+	ss << "\t\tStructMipMap = " << yesno(in->struct_mipmap) << ";\n";
+	ss << "\t\tSurfaceMipMap = " << yesno(in->surface_mipmap) << ";\n";
+	ss << "\t}\n";
+	ss << "\tAccessory{\n";
+	ss << "\t\tCompass = " << yesno(in->compass) << ";\n";
+	ss << "\t\tWindMeter = " << yesno(in->wind_meter) << ";\n";
+	ss << "\t\tShowMap = " << yesno(in->show_map) << ";\n";
+	ss << "\t}\n";
+	ss << "\tEffect{\n";
+	ss << "\t\tShadow = " << yesno(in->shadow) << ";\n";
+	ss << "\t\tLinearFilter = " << yesno(in->linear_filter) << ";\n";
+	ss << "\t\tEnvMap = " << yesno(in->env_map) << ";\n";
+	ss << "\t\tSpecularLight = " << yesno(in->specular_light) << ";\n";
+	ss << "\t\tSunLensFlare = " << yesno(in->sun_lens_flare) << ";\n";
+	ss << "\t\tSunWhiteout = " << yesno(in->sun_whiteout) << ";\n";
+	ss << "\t\tMiscLensFlare = " << yesno(in->misc_lens_flare) << ";\n";
+	ss << "\t\tMiscParticle = " << yesno(in->misc_particle) << ";\n";
+	ss << "\t\tWind = " << yesno(in->wind) << ";\n";
+	ss << "\t}\n";
+	ss << "\tSound{\n";
+	ss << "\t\tInterfaceSound = " << yesno(in->interface_sound) << ";\n";
+	ss << "\t\tRailSound = " << yesno(in->rail_sound) << ";\n";
+	ss << "\t\tTrainSound = " << yesno(in->train_sound) << ";\n";
+	ss << "\t\tStructSound = " << yesno(in->struct_sound) << ";\n";
+	ss << "\t\tSurfaceSound = " << yesno(in->surface_sound) << ";\n";
+	ss << "\t}\n";
+	ss << "\tMisc{\n";
+	ss << "\t\tUseUndo = " << yesno(in->use_undo) << ";\n";
+	ss << "\t}\n";
+	ss << "\tStereoscopy{\n";
+	ss << "\t\tEnabled = " << yesno(in->stereo_enabled) << ";\n";
+	ss << "\t\tMethod = " << in->stereo_method << ";\n";
+	ss << "\t\tInterval = " << interval << ";\n";
+	ss << "\t}\n";
+	ss << "\tSelectedPlugin{\n";
+	ss << "\t\tRail = \"" << in->selected_rail << "\";\n";
+	ss << "\t\tTie = \"" << in->selected_tie << "\";\n";
+	ss << "\t\tGirder = \"" << in->selected_girder << "\";\n";
+	ss << "\t\tPier = \"" << in->selected_pier << "\";\n";
+	ss << "\t\tLine = \"" << in->selected_line << "\";\n";
+	ss << "\t\tPole = \"" << in->selected_pole << "\";\n";
+	ss << "\t\tTrain = \"" << in->selected_train << "\";\n";
+	ss << "\t\tStation = \"" << in->selected_station << "\";\n";
+	ss << "\t\tStruct = \"" << in->selected_struct << "\";\n";
+	ss << "\t\tSurface = \"" << in->selected_surface << "\";\n";
+	ss << "\t\tEnv = \"" << in->selected_env << "\";\n";
+	ss << "\t\tSkin = \"" << in->selected_skin << "\";\n";
+	ss << "\t}\n";
+	ss << "}\n\n";
+	*out = ss.str();
+	return true;
+}
+
+bool rs2_config_load_file(const char *path, Rs2Config *out, char *err, size_t errn) {
+	std::string text;
+	if (!path || !read_all(path, &text)) {
+		set_err(err, errn, "open Config.txt failed");
+		return false;
+	}
+	return rs2_config_parse(text.c_str(), out, err, errn);
+}
+
+bool rs2_config_load_or_defaults(const char *path, Rs2Config *out, bool *used_defaults, char *err,
+                                 size_t errn) {
+	if (!out) return false;
+	std::string text;
+	if (!path || !read_all(path, &text)) {
+		rs2_config_defaults(out);
+		if (used_defaults) *used_defaults = true;
+		return true;
+	}
+	if (used_defaults) *used_defaults = false;
+	return rs2_config_parse(text.c_str(), out, err, errn);
+}
+
+bool rs2_plugin_header_parse(const char *text, const char *expect_type, Rs2PluginHeader *out,
+                             char *err, size_t errn) {
+	if (!text || !out) {
+		set_err(err, errn, "null arg");
+		return false;
+	}
+	*out = Rs2PluginHeader{};
+	Cur cur(text);
+	if (!cur.skip() || !cur.begin_block("PluginHeader") ||
+	    !cur.asgn_float("RailSimVersion", &out->version, 1) ||
+	    !cur.asgn_ident("PluginType", &out->type) || !cur.asgn_string("PluginName", &out->name) ||
+	    !cur.asgn_string("PluginAuthor", &out->author)) {
+		set_err(err, errn, cur.errbuf[0] ? cur.errbuf : "PluginHeader");
+		return false;
+	}
+	if (out->version < 2.00f || out->version > RS2_CONFIG_VERSION) {
+		set_err(err, errn, "unsupported plugin version");
+		return false;
+	}
+	if (expect_type && out->type != expect_type) {
+		set_err(err, errn, "PluginType mismatch");
+		return false;
+	}
+	float icon_rect[4] = {0, 0, 1, 1};
+	cur.try_asgn_string("IconTexture", &out->icon);
+	cur.try_asgn_float("IconRect", icon_rect, 4);
+	std::string desc;
+	while (cur.try_asgn_string("Description", &desc)) {
+		if (!out->description.empty()) out->description += "\n";
+		out->description += desc;
+	}
+	if (!cur.end_block()) {
+		set_err(err, errn, "PluginHeader end");
+		return false;
+	}
+	return true;
+}
+
+bool rs2_plugin_header_load_file(const char *path, const char *expect_type, Rs2PluginHeader *out,
+                                 char *err, size_t errn) {
+	std::string text;
+	if (!path || !read_all(path, &text)) {
+		set_err(err, errn, "open *2.txt failed");
+		return false;
+	}
+	return rs2_plugin_header_parse(text.c_str(), expect_type, out, err, errn);
+}
+
+bool rs2_language_header_parse(const char *text, Rs2LanguageHeader *out, char *err, size_t errn) {
+	if (!text || !out) {
+		set_err(err, errn, "null arg");
+		return false;
+	}
+	*out = Rs2LanguageHeader{};
+	Cur cur(text);
+	std::string dtype;
+	if (!cur.skip() || !cur.begin_block("DatafileHeader") ||
+	    !cur.asgn_float("RailSimVersion", &out->version, 1) ||
+	    !cur.asgn_ident("DatafileType", &dtype) || !cur.end_block()) {
+		set_err(err, errn, cur.errbuf[0] ? cur.errbuf : "Language DatafileHeader");
+		return false;
+	}
+	if (dtype != "Language") {
+		set_err(err, errn, "DatafileType != Language");
+		return false;
+	}
+	if (out->version < 2.02f || out->version > RS2_CONFIG_VERSION) {
+		set_err(err, errn, "unsupported Language version");
+		return false;
+	}
+	if (!cur.begin_block("Language") || !cur.asgn_string("Name", &out->name) || !cur.end_block()) {
+		set_err(err, errn, "Language Name");
+		return false;
+	}
+	return true;
+}
+
+bool rs2_language_header_load_file(const char *path, Rs2LanguageHeader *out, char *err,
+                                   size_t errn) {
+	std::string text;
+	if (!path || !read_all(path, &text)) {
+		set_err(err, errn, "open Language.txt failed");
+		return false;
+	}
+	return rs2_language_header_parse(text.c_str(), out, err, errn);
+}

--- a/port/rs2_config_plugin.h
+++ b/port/rs2_config_plugin.h
@@ -1,0 +1,89 @@
+// Config.txt / Language.txt / *2.txt script smoke (#58).
+// Matches CConfigMode::Load/Save and CPlugin::LoadHeader grammar, not UI.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#ifndef RS2_CONFIG_VERSION
+#define RS2_CONFIG_VERSION 2.15f
+#endif
+
+struct Rs2Config {
+	float version;
+	bool hide_top_panel;
+	bool hide_right_panel;
+	bool window_shadow;
+	bool full_screen;
+	int resolution[2];
+	bool rail_mipmap;
+	bool train_mipmap;
+	bool struct_mipmap;
+	bool surface_mipmap;
+	bool compass;
+	bool wind_meter;
+	bool show_map;
+	bool shadow;
+	bool linear_filter;
+	bool env_map;
+	bool specular_light;
+	bool sun_lens_flare;
+	bool sun_whiteout;
+	bool misc_lens_flare;
+	bool misc_particle;
+	bool wind;
+	bool interface_sound;
+	bool rail_sound;
+	bool train_sound;
+	bool struct_sound;
+	bool surface_sound;
+	bool use_undo;
+	bool stereo_enabled;
+	int stereo_method;
+	float stereo_interval;
+	std::string selected_rail;
+	std::string selected_tie;
+	std::string selected_girder;
+	std::string selected_pier;
+	std::string selected_line;
+	std::string selected_pole;
+	std::string selected_train;
+	std::string selected_station;
+	std::string selected_struct;
+	std::string selected_surface;
+	std::string selected_env;
+	std::string selected_skin;
+};
+
+struct Rs2PluginHeader {
+	float version;
+	std::string type;
+	std::string name;
+	std::string author;
+	std::string icon;
+	std::string description;
+};
+
+struct Rs2LanguageHeader {
+	float version;
+	std::string name;
+};
+
+void rs2_config_defaults(Rs2Config *out);
+bool rs2_config_equal(const Rs2Config *a, const Rs2Config *b);
+
+bool rs2_config_parse(const char *text, Rs2Config *out, char *err, size_t errn);
+bool rs2_config_write(const Rs2Config *in, std::string *out);
+bool rs2_config_load_file(const char *path, Rs2Config *out, char *err, size_t errn);
+bool rs2_config_load_or_defaults(const char *path, Rs2Config *out, bool *used_defaults,
+                                 char *err, size_t errn);
+
+bool rs2_plugin_header_parse(const char *text, const char *expect_type, Rs2PluginHeader *out,
+                             char *err, size_t errn);
+bool rs2_plugin_header_load_file(const char *path, const char *expect_type, Rs2PluginHeader *out,
+                                 char *err, size_t errn);
+
+bool rs2_language_header_parse(const char *text, Rs2LanguageHeader *out, char *err, size_t errn);
+bool rs2_language_header_load_file(const char *path, Rs2LanguageHeader *out, char *err,
+                                   size_t errn);

--- a/port/rs2_config_plugin_test.cpp
+++ b/port/rs2_config_plugin_test.cpp
@@ -1,0 +1,305 @@
+// Config.txt smoke/roundtrip and *2.txt LoadHeader smoke (#58).
+
+#include "path.h"
+#include "rs2_config_plugin.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+
+namespace {
+
+const int kSkip = 77;
+
+const char kSaveFormatConfig[] =
+    "/*\n"
+    " *\tRailSim II Configuration Datafile\n"
+    " */\n"
+    "\n"
+    "DatafileHeader{\n"
+    "\tRailSimVersion = 2.15;\n"
+    "\tDatafileType = Config;\n"
+    "}\n"
+    "\n"
+    "ConfigMode{\n"
+    "\tInterface{\n"
+    "\t\tHideTopPanel = yes;\n"
+    "\t\tHideRightPanel = no;\n"
+    "\t\tWindowShadow = yes;\n"
+    "\t}\n"
+    "\tDevice{\n"
+    "\t\tFullScreen = no;\n"
+    "\t\tResolution = 800, 600;\n"
+    "\t\tRailMipMap = yes;\n"
+    "\t\tTrainMipMap = no;\n"
+    "\t\tStructMipMap = no;\n"
+    "\t\tSurfaceMipMap = yes;\n"
+    "\t}\n"
+    "\tAccessory{\n"
+    "\t\tCompass = yes;\n"
+    "\t\tWindMeter = yes;\n"
+    "\t\tShowMap = no;\n"
+    "\t}\n"
+    "\tEffect{\n"
+    "\t\tShadow = no;\n"
+    "\t\tLinearFilter = yes;\n"
+    "\t\tEnvMap = yes;\n"
+    "\t\tSpecularLight = yes;\n"
+    "\t\tSunLensFlare = yes;\n"
+    "\t\tSunWhiteout = yes;\n"
+    "\t\tMiscLensFlare = yes;\n"
+    "\t\tMiscParticle = yes;\n"
+    "\t\tWind = yes;\n"
+    "\t}\n"
+    "\tSound{\n"
+    "\t\tInterfaceSound = yes;\n"
+    "\t\tRailSound = yes;\n"
+    "\t\tTrainSound = yes;\n"
+    "\t\tStructSound = yes;\n"
+    "\t\tSurfaceSound = yes;\n"
+    "\t}\n"
+    "\tMisc{\n"
+    "\t\tUseUndo = yes;\n"
+    "\t}\n"
+    "\tStereoscopy{\n"
+    "\t\tEnabled = no;\n"
+    "\t\tMethod = 0;\n"
+    "\t\tInterval = 1.00;\n"
+    "\t}\n"
+    "\tSelectedPlugin{\n"
+    "\t\tRail = \"Default_JR_Narrow\";\n"
+    "\t\tTie = \"Default_JRN_BallastPC\";\n"
+    "\t\tGirder = \"Default_JRN_SinglePC\";\n"
+    "\t\tPier = \"Default_SinglePC\";\n"
+    "\t\tLine = \"Default_SimpleCatenary\";\n"
+    "\t\tPole = \"Default_JRN_Single\";\n"
+    "\t\tTrain = \"Aizentranza01\";\n"
+    "\t\tStation = \"MM02\";\n"
+    "\t\tStruct = \"Ship\";\n"
+    "\t\tSurface = \"Default\";\n"
+    "\t\tEnv = \"Default\";\n"
+    "\t\tSkin = \"Default_Blue\";\n"
+    "\t}\n"
+    "}\n";
+
+const char kOldConfig[] =
+    "DatafileHeader{\n"
+    "\tRailSimVersion = 2.00;\n"
+    "\tDatafileType = Config;\n"
+    "}\n"
+    "ConfigMode{\n"
+    "\tInterface{\n"
+    "\t\tHideTopPanel = no;\n"
+    "\t\tHideRightPanel = no;\n"
+    "\t}\n"
+    "\tDevice{\n"
+    "\t\tFullScreen = yes;\n"
+    "\t\tResolution = 640, 480;\n"
+    "\t\tRailMipMap = yes;\n"
+    "\t\tTrainMipMap = no;\n"
+    "\t\tStructMipMap = no;\n"
+    "\t\tSurfaceMipMap = yes;\n"
+    "\t}\n"
+    "\tAccessory{\n"
+    "\t\tCompass = yes;\n"
+    "\t\tWindMeter = yes;\n"
+    "\t}\n"
+    "\tEffect{\n"
+    "\t\tShadow = no;\n"
+    "\t\tLinearFilter = yes;\n"
+    "\t\tEnvMap = yes;\n"
+    "\t\tSpecularLight = yes;\n"
+    "\t\tSunLensFlare = yes;\n"
+    "\t\tSunWhiteout = yes;\n"
+    "\t\tMiscLensFlare = yes;\n"
+    "\t\tMiscParticle = yes;\n"
+    "\t\tWind = yes;\n"
+    "\t}\n"
+    "\tSound{\n"
+    "\t\tInterfaceSound = yes;\n"
+    "\t\tRailSound = yes;\n"
+    "\t\tTrainSound = yes;\n"
+    "\t\tStructSound = yes;\n"
+    "\t\tSurfaceSound = yes;\n"
+    "\t}\n"
+    "\tMisc{\n"
+    "\t\tUseUndo = yes;\n"
+    "\t}\n"
+    "\tSelectedPlugin{\n"
+    "\t\tRail = \"Default_JR_Narrow\";\n"
+    "\t\tTie = \"Default_JRN_BallastPC\";\n"
+    "\t\tGirder = \"Default_JRN_SinglePC\";\n"
+    "\t\tPier = \"Default_SinglePC\";\n"
+    "\t\tLine = \"Default_SimpleCatenary\";\n"
+    "\t\tPole = \"Default_JRN_Single\";\n"
+    "\t\tTrain = \"Aizentranza01\";\n"
+    "\t\tStation = \"MM02\";\n"
+    "\t\tStruct = \"Ship\";\n"
+    "\t\tSurface = \"Default\";\n"
+    "\t\tEnv = \"Default\";\n"
+    "\t\tSkin = \"Default_Blue\";\n"
+    "\t}\n"
+    "}\n";
+
+const char kRail2Header[] =
+    "PluginHeader{\n"
+    "\tRailSimVersion = 2.00;\n"
+    "\tPluginType = Rail;\n"
+    "\tPluginName = \"Default JR-narrow\";\n"
+    "\tPluginAuthor = \"Okadu\";\n"
+    "\tIconTexture = \"..\\\\..\\\\Train\\\\Aizentranza01\\\\Icon.png\";\n"
+    "\tDescription = \"Popular narrow gauge in Japan.\";\n"
+    "}\n";
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool parse_ok(const char *text, Rs2Config *out, const char *label) {
+	char err[128];
+	if (rs2_config_parse(text, out, err, sizeof(err))) return true;
+	std::fprintf(stderr, "self-test: %s: %s\n", label, err);
+	return false;
+}
+
+int self_test() {
+	char err[128];
+	Rs2Config cfg;
+	bool used_defaults = false;
+	if (!expect(rs2_config_load_or_defaults("/no/such/Config.txt", &cfg, &used_defaults, err,
+	                                        sizeof(err)) &&
+	                used_defaults && cfg.full_screen && cfg.resolution[0] == 640 &&
+	                cfg.selected_rail == "Default_JR_Narrow",
+	            "missing Config.txt uses defaults"))
+		return 1;
+
+	if (!parse_ok(kSaveFormatConfig, &cfg, "Save-format Config.txt")) return 1;
+	if (!expect(cfg.hide_top_panel && !cfg.full_screen && cfg.resolution[0] == 800 &&
+	                cfg.resolution[1] == 600 && cfg.selected_train == "Aizentranza01",
+	            "Save-format field values"))
+		return 1;
+
+	if (!parse_ok(kOldConfig, &cfg, "2.00 Config.txt")) return 1;
+	if (!expect(cfg.version == 2.00f && cfg.window_shadow && !cfg.show_map && !cfg.stereo_enabled &&
+	                cfg.stereo_interval == 1.0f,
+	            "2.00 keeps gated defaults"))
+		return 1;
+
+	Rs2Config mutated;
+	rs2_config_defaults(&mutated);
+	mutated.hide_top_panel = true;
+	mutated.full_screen = false;
+	mutated.resolution[0] = 1024;
+	mutated.resolution[1] = 768;
+	mutated.shadow = true;
+	mutated.stereo_interval = 2.50f;
+	mutated.selected_struct = "Fence";
+	std::string written;
+	if (!expect(rs2_config_write(&mutated, &written), "write Config.txt")) return 1;
+	Rs2Config back;
+	if (!parse_ok(written.c_str(), &back, "roundtrip parse")) return 1;
+	mutated.version = RS2_CONFIG_VERSION;
+	if (!expect(rs2_config_equal(&mutated, &back), "roundtrip fields")) return 1;
+
+	Rs2PluginHeader plugin;
+	if (!expect(rs2_plugin_header_parse(kRail2Header, "Rail", &plugin, err, sizeof(err)) &&
+	                plugin.name == "Default JR-narrow" && plugin.author == "Okadu",
+	            "inline Rail2.txt header"))
+		return 1;
+
+	Rs2LanguageHeader lang;
+	const char *lang_txt =
+	    "DatafileHeader{\n"
+	    "\tRailSimVersion = 2.15;\n"
+	    "\tDatafileType = Language;\n"
+	    "}\n"
+	    "Language{\n"
+	    "\tName = \"English\";\n"
+	    "}\n";
+	if (!expect(rs2_language_header_parse(lang_txt, &lang, err, sizeof(err)) &&
+	                lang.name == "English",
+	            "inline Language.txt header"))
+		return 1;
+
+	return 0;
+}
+
+bool find_railsim2(const char *root, char *base, size_t n) {
+	if (rs2_path_join(base, n, root, "en", "RailSim2") && rs2_is_dir(base)) return true;
+	if (rs2_path_join(base, n, root, "RailSim2") && rs2_is_dir(base)) return true;
+	return false;
+}
+
+int load_distribution(const char *root) {
+	namespace fs = std::filesystem;
+	std::error_code ec;
+	if (!fs::is_directory(root, ec)) {
+		std::fprintf(stderr, "skip: no fixture at %s\n", root);
+		return kSkip;
+	}
+
+	char base[RS2_PATH_MAX];
+	if (!find_railsim2(root, base, sizeof(base))) {
+		std::fprintf(stderr, "skip: no RailSim2 under %s\n", root);
+		return kSkip;
+	}
+
+	char err[128];
+	char langpath[RS2_PATH_MAX];
+	if (!rs2_path_join(langpath, sizeof(langpath), base, "Language.txt")) return 1;
+	Rs2LanguageHeader lang;
+	if (!rs2_language_header_load_file(langpath, &lang, err, sizeof(err))) {
+		std::fprintf(stderr, "Language.txt: %s (%s)\n", err, langpath);
+		return 1;
+	}
+	if (lang.name.empty()) {
+		std::fprintf(stderr, "Language.txt: empty Name\n");
+		return 1;
+	}
+
+	char rail2file[RS2_PATH_MAX];
+	if (!rs2_path_join(rail2file, sizeof(rail2file), base, "Rail", "Default_JR_Narrow",
+	                   "Rail2.txt"))
+		return 1;
+	Rs2PluginHeader plugin;
+	if (!rs2_plugin_header_load_file(rail2file, "Rail", &plugin, err, sizeof(err))) {
+		std::fprintf(stderr, "Rail2.txt: %s (%s)\n", err, rail2file);
+		return 1;
+	}
+	if (plugin.name.empty()) {
+		std::fprintf(stderr, "Rail2.txt: empty PluginName\n");
+		return 1;
+	}
+
+	char cfgpath[RS2_PATH_MAX];
+	if (!rs2_path_join(cfgpath, sizeof(cfgpath), base, "Config.txt")) return 1;
+	Rs2Config cfg;
+	bool used_defaults = false;
+	if (!rs2_config_load_or_defaults(cfgpath, &cfg, &used_defaults, err, sizeof(err))) {
+		std::fprintf(stderr, "Config.txt: %s (%s)\n", err, cfgpath);
+		return 1;
+	}
+	if (used_defaults) {
+		std::printf("config: defaults path (no Config.txt under %s)\n", base);
+	} else {
+		std::printf("config: parsed Config.txt under %s\n", base);
+	}
+	std::printf("plugin: loaded %s (%s)\n", rail2file, plugin.name.c_str());
+	std::printf("language: %s (%s)\n", langpath, lang.name.c_str());
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	if (argc < 2) {
+		std::fprintf(stderr, "usage: rs2_config_plugin_test --self-test | <Distribution>\n");
+		return 2;
+	}
+	int st = self_test();
+	if (st) return st;
+	return load_distribution(argv[1]);
+}


### PR DESCRIPTION
## Summary
- Inventory `CConfigMode::Load` / `Save` and `Language.txt` (`InitLanguage`) call sites in `docs/porting/config-plugin-compat.md`.
- Add `rs2_config_plugin_self_test` / `rs2_config_plugin_load`: missing `Config.txt` uses in-code defaults; Save-format write/parse roundtrip; `Rail/Default_JR_Narrow/Rail2.txt` `LoadHeader` smoke (Distribution has no `Rail/Rail01/`).
- Closed Script.cpp-shaped scanner in `port/` — does not link `CConfigMode` / `CRailPlugin`, does not change `.rs2` layout, and does not expand to full plugin Load or M3.

Closes #58

## Test plan
- [x] `./scripts/check.sh` green (14/14, including `rs2_config_plugin_self_test` and `rs2_config_plugin_load`)
- [ ] CI `check` on this PR


Made with [Cursor](https://cursor.com)