### PR TITLE
Document _mbs* / Imm* charset seams

### DIFF
--- a/docs/porting/charset-internal.md
+++ b/docs/porting/charset-internal.md
@@ -29,7 +29,7 @@ Rationale: UTF-8 keeps `std::string` safe on Linux/macOS without widening every 
 
 ## Consequences (follow-up slices, not this ADR)
 
-- Replace `_mbs*` with a small `lib/rs2_text` (or `port/`) facade: `to_utf8(cp932)`, `to_cp932(utf8)`, NFC/NFD only where paths cross OS APIs.
+- Replace `_mbs*` with a small `lib/rs2_text` (or `port/`) facade: `to_utf8(cp932)`, `to_cp932(utf8)`, NFC/NFD only where paths cross OS APIs. Closed call set: [charset-seams.md](charset-seams.md).
 - IME: SDL / backend `TEXTINPUT` events deliver UTF-8; `CEditBox` stops calling `Imm*` directly.
 - Tests: Japanese layout name and `Sample.rs2` string fields must **byte-match** Windows saves after load->save (parent #9 / #10).
 

--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -1,0 +1,174 @@
+# Charset seams (`_mbs*` / Imm*)
+
+- **Issue**: [#62](https://github.com/lollipop-onl/railsim2-portable/issues/62) (parent [#9](https://github.com/lollipop-onl/railsim2-portable/issues/9); depends on [#46](https://github.com/lollipop-onl/railsim2-portable/issues/46))
+- **ADR**: [charset-internal.md](charset-internal.md) (UTF-8 in-process; CP932 at file / Win32-compat boundaries)
+- **Tree**: game `*.cpp` / `lib/*.cpp` at this document's commit. Counts exclude comments.
+- **This slice does not implement conversion helpers or IME.** Later `#9` slices should replace **this closed set**, not walk the whole tree.
+
+## Corrections to issue #62
+
+| Claim in #62 | Fact |
+|--------------|------|
+| `_mbsinc` / `_mbslen` in `port/stub/mbstring.h` are byte-wise; `_mbsicmp` is `strcasecmp` | True. See [Stub status](#stub-status). |
+| Call sites are scattered across `lib/editbox.cpp` (Imm*), `lib/texture.cpp`, `lib/mesh.cpp`, `CPlugin.cpp`, `CFileMode.cpp`, `CTreeElement.cpp` | True for **live** game / `lib/` callers. `lib/editbox.cpp` has **no** `_mbs*`; it is the Imm* island. |
+| `_ismb*` must be inventoried with `_mbs*` | `_ismbblead` / `_ismbbtrail` are stub-only. **Zero** game or `lib/` callers. |
+
+`_mbsicmp` is the **only** `_mbs*` / `_ismb*` token used outside `port/stub/`. Twelve call expressions in **five** files. Do not add `_mbsinc` / `_mbslen` / `_ismb*` replacements until a caller appears.
+
+## Closed `_mbsicmp` set (compare)
+
+All live uses are **case-insensitive compare**. None walk or measure CP932 characters.
+
+| File | Function | Compared strings | Layer |
+|------|----------|------------------|-------|
+| `CPlugin.cpp` | `CPlugin::Compare` | `m_Name`, then `m_ID`, then `m_Author` | Name / author: plugin txt (I/O). ID: plugin folder name (filename). |
+| `CPlugin.cpp` | `CPluginList::FindPlugin` | lookup `id` vs `ptr->m_ID`; then `id` vs `Default()` | Filename / `.rs2` plugin-id field. Miss -> `g_LackPlugin` path `"Type\\id"`. |
+| `CFileMode.cpp` | `CFileListView::ConfirmRename` | list-column old basename vs `FixFileExt(..., "rs2")` new name | `.rs2` **filename**. Equality -> no-op (skip `rs2_rename`). |
+| `CFileMode.cpp` | `CFileMode::ScanInputInterface` | chosen / current `m_NewFileName` vs `g_SaveFile->GetFileName()` | `.rs2` **filename**. Inequality -> Save As path; equality -> overwrite `Save`. |
+| `CFileMode.cpp` | `CFileMode::ListFile` | each `CLayoutInfo::m_FileName` vs `g_SaveFile->GetFileName()` | `.rs2` **filename** from `rs2_list_dir`. Match highlights the open layout. |
+| `CTreeElement.cpp` | `CTreeElement::Compare` | `m_String` vs `rhs->m_String` (dirs sort before files) | **UI label**. Plugin rows copy `CPlugin::m_Name` (`InsertItem`). Dir rows are in-memory folder labels (`lang(NewDir)` / rename). |
+| `lib/texture.cpp` | `CTexList::Get` | cache `TEXINFO::strName` vs `_fullpath(strName)` (or resource name) | **Asset path** key. Not user-visible text. |
+| `lib/mesh.cpp` | `CMeshList::Get` | cache `MESHINFO::strName` vs `_fullpath(strName)` | **Asset path** key. Then `MoveToFile` for sidecar textures. |
+
+Do not expand a `_mbs*` rewrite into plugin `Load()` bodies, `CSaveFile` parsers, or `Language.txt`. Those files never call `_mbs*`.
+
+## File I/O vs internal UI
+
+ADR rule: CP932 stays on disk; `std::string` after load becomes UTF-8. Classify the closed set that way so a helper slice knows **where** to convert.
+
+### File / path boundary (keep on-disk bytes until a helper exists)
+
+| Source | How it is filled | Reaches `_mbsicmp` as |
+|--------|------------------|------------------------|
+| `Layout/*.rs2` basename | `rs2_list_dir` / `CInputDialog` / `CListElement` rename | `CFileMode` three compares; `g_SaveFile->m_FileName` |
+| Plugin directory name | `rs2_list_dir` -> `CPlugin` ctor `m_ID = id` | `Compare` / `FindPlugin` |
+| `{Type}2.txt` / old `{Type}.txt` | `LoadBinaryText` + `AsgnString("PluginName"/"PluginAuthor")`; old form `fscanf` | `m_Name` / `m_Author` in `Compare` only |
+| Mesh / texture file name | caller relative name + `_fullpath` / virtual cwd (`docs/porting/path-seams.md`) | `CTexList::Get` / `CMeshList::Get` |
+
+`.rs2` **contents** that are user text (not compared with `_mbs*`):
+
+- `CSaveFile::m_FileNote` <-> `AsgnString("Note")` / `fprintf Note` (`CSaveFile.cpp`). The file dialog copies this through `CEditCtrl` (`m_NoteEdit.GetRealtimeText()`), not `_mbsicmp`.
+- Plugin ids **inside** the layout script are lookup keys for `FindPlugin` (boundary: script bytes today, UTF-8 after the ADR conversion).
+
+`Language.txt` / `Config.txt` are I/O (`docs/porting/path-seams.md`) but have **zero** `_mbs*` callers. Out of this set.
+
+### Internal UI (UTF-8 after the ADR; Imm* must deliver UTF-8)
+
+| Store | Owner | How it is filled |
+|-------|-------|------------------|
+| `CEditBox::m_str` | committed buffer | `Create(pre)`, `AddChar` / `AddString`, clipboard `CF_TEXT`, `CompEnd` (IME result) |
+| `CEditBox::m_comp` | composition preview | `GetCompStr` (`GCS_COMPSTR`); cleared after `CompEnd` |
+| `CEditBox::m_show` | draw copy | `m_str` plus inserted `m_comp` while converting |
+| `CEditCtrl::m_Text` | game edit field | `GetText` / `GetRealtimeText` |
+| `CTreeElement::m_String` | plugin tree label | ctor / `EndRename` |
+| `CListElement::m_String[0]` | list first column | ctor / `EndRename` |
+
+`CPlugin::InsertItem` copies `m_Name` (file-origin) into `CTreeElement::m_String` (UI). After conversion, that copy is UTF-8; the on-disk `PluginName` line stays CP932.
+
+Plugin-tree **directory** labels are UI-only (`CTreeDirElement::ConfirmRename` returns `true` and does not write a file). Plugin **file** rename goes `CTreeFileElement` -> `CPlugin::ConfirmRename`, which defaults to `false` (no disk write unless a subclass overrides). Layout `.rs2` rename **does** hit the filesystem (`CFileListView::ConfirmRename`).
+
+## Closed Imm* set
+
+`<imm.h>` is pulled once, from `lib/headers.h` (every udx TU). Game sources never include it directly.
+
+### Calls that exist
+
+| File | Function | API | Role |
+|------|----------|-----|------|
+| `lib/editbox.cpp` | `CEditBox::Create` | `ImmGetContext` | Store `m_hImc` from `svw.hWnd`. |
+| `lib/editbox.cpp` | `Create` / `Release` | `ImmSetOpenStatus` | Force IME on/off from the `imm` argument (`-1` off, `>0` on, `0` leave). **Not declared** in `port/stub/imm.h`. |
+| `lib/editbox.cpp` | `Release` | `ImmReleaseContext` | Drop `m_hImc`. |
+| `lib/editbox.h` | `IsFEPOpen` | `ImmGetOpenStatus` | Gate `GetCompStr` and full-width space insert. Stub always `FALSE`. |
+| `lib/editbox.h` | `GetFEPCursorPos` | `ImmGetCompositionString(..., GCS_CURSORPOS, NULL, 0)` | Composition caret. **Does not write** `m_str`. |
+| `lib/editbox.cpp` | `ScanInput` | `GCS_COMPCLAUSE` size, then 1 byte of `GCS_COMPATTR` | Detect conversion (`attr != ATTR_INPUT`) vs raw IME input. |
+| `lib/editbox.cpp` | `Render` | `GCS_COMPCLAUSE` + `GCS_COMPATTR` | Clause underlines. **Does not write** `m_str`. |
+| `lib/editbox.cpp` | `GetCompStr` | `GCS_COMPSTR` | Preview bytes -> `m_comp` only. |
+| `lib/editbox.cpp` | `GetResultStr` | `GCS_RESULTSTR` | Confirmed bytes -> `m_comp`, then `CompEnd` inserts into `m_str`. |
+| `lib/window.cpp` | `WindowProc` `WM_IME_SETCONTEXT` | `ImmGetDefaultIMEWnd` | `SendMessage(..., WM_CLOSE)` so the OS IME window stays hidden. **Not declared** in `port/stub/imm.h`. |
+
+`ImmSetCompositionWindow` / `ImmSetCandidateWindow` are stub-only. No callers.
+
+`lib/window.cpp` never feeds text. Hiding the default IME window is why `CEditBox` draws composition itself.
+
+### How Imm* bytes enter `CEditBox` text
+
+```
+ImmGetContext -> m_hImc
+        |
+        +-- GCS_COMPSTR  -> GetCompStr  -> m_comp     (preview; GetText ignores)
+        +-- GCS_RESULTSTR -> GetResultStr -> m_comp
+                |
+                CompEnd: m_str.insert(m_pos, m_comp); Clip(); m_comp.clear()
+                |
+                GetText(str) copies m_str
+```
+
+`GetText` is the **only** committed-text exit. Fan-out (do not rewrite these for IME; they already consume `std::string`):
+
+| Consumer | Exit | Where the string goes |
+|----------|------|------------------------|
+| `CEditCtrl::FinishInput` / `Render` (focus loss) | `GetText` -> `m_Text` | Dialog / note / name fields. |
+| `CEditCtrl::GetRealtimeText` | `GetText` while focused | `CFileMode` writes `g_SaveFile->m_FileNote` every scan (later `.rs2` `Note`). `CDiaDialog` writes `m_Name` / clock fields. |
+| `CListElement::EndRename` | `GetText` -> `m_String[0]` | `CFileListView::ConfirmRename` may `rs2_rename` a `.rs2`. |
+| `CTreeElement::EndRename` | `GetText` -> `m_String` | UI label; plugin file rename only if `ConfirmRename` succeeds. |
+
+Non-IME paths into `m_str` (same buffer, not Imm*): `WM_CHAR` -> `DequeueChar` -> `AddChar` (ASCII `IsPrintChar`); `AddString("Å@")` when IME is open and Space is pressed; clipboard `CF_TEXT`. Caret move / delete uses `CharNext` / `CharPrev` (see [Adjacent, not this set](#adjacent-not-this-set)).
+
+On the native `check` build, `ImmGetOpenStatus` is `FALSE` and `ImmGetCompositionString` returns `0`, so `m_comp` stays empty. Japanese composition is dead until an IME slice replaces this island.
+
+`port/rs2_roundtrip_stubs.cpp` defines a no-op `CEditBox` for the roundtrip binary. That stub is **not** an Imm* caller and is out of the IME replacement set.
+
+## Stub status
+
+| Stub | Behavior | Effect on this set |
+|------|----------|--------------------|
+| `_mbsicmp` | `strcasecmp` | Wrong for CP932 (lead/trail bytes can look like ASCII letters). All 12 compares. |
+| `_mbsinc` / `_mbslen` | `p+1` / `strlen` | Unused. |
+| `_ismbblead` / `_ismbbtrail` | CP932 lead/trail tables | Unused. `Is2ByteChar` in `lib/editbox.h` duplicates the lead test and is also unused. |
+| `ImmGetContext` | `nullptr` | `m_hImc` is null; further Imm* no-ops. |
+| `ImmGetOpenStatus` | `FALSE` | `GetCompStr` skipped. |
+| `ImmGetCompositionStringA` | `0` | No composition / result bytes. |
+| `ImmSetOpenStatus` / `ImmGetDefaultIMEWnd` | **missing** | Only needed when `lib/editbox.cpp` / `lib/window.cpp` are linked. `CEditCtrl.cpp` is allowlisted and includes the header; `lib/editbox.cpp` is the udx object that actually calls `ImmSetOpenStatus`. |
+
+Do not grow these stubs in a helper slice except to compile. Behavior belongs in `lib/` / `port/` as [charset-internal.md](charset-internal.md) says.
+
+## Adjacent, not this set
+
+Later slices must **not** treat these as part of the `_mbs*` / Imm* closed set, but they share the same CP932 walk problem:
+
+| API | Where | Notes |
+|-----|-------|-------|
+| `CharNext` / `CharPrev` | `CEditBox` backspace / delete / caret / `Clip` / `EliminateTabAndCRLF` | Stub in `port/stub/windows.h` is `+/- 1` byte. This is the **scan** seam for edit text. Parent `#9` / `#8` may replace it with UTF-8 walk after Imm* is gone. |
+| `Is2ByteChar` | `lib/editbox.h` only | Dead. |
+| `MultiByteToWideChar(CP_ACP, ...)` | `lib/music.cpp`, `lib/movie.cpp` | Those headers are commented out of `lib/udx.h`. Out of scope (`#16` / media). |
+| `mbstowcs` | `lib/comm.cpp` | DirectPlay session name (`#11`). |
+| GDI `HFONT` / `CStringTexture` | UI draw | `#16`. |
+
+`#10` Save format and `#8` input implementation stay on their own inventories. This document only names where `_mbsicmp` and Imm* already are.
+
+## What a follow-up slice may touch
+
+One conversion-helper PR should be enough for `_mbsicmp` if it supplies a UTF-8 (or explicit CP932) case-fold compare and is wired **only** into the five files above.
+
+One IME PR should replace `lib/editbox.cpp` + the `WM_IME_SETCONTEXT` hide in `lib/window.cpp` with backend `TEXTINPUT` (UTF-8) writing `m_str` / `m_comp`. Do not reimplement `CEditCtrl` / list / tree rename.
+
+**Must not** (this inventory and those follow-ups):
+
+- Implement `to_utf8` / `to_cp932` in *this* document's PR (already done as docs-only).
+- Mass-convert game sources to UTF-8 (`encoding-guard.sh`).
+- Rewrite `.rs2` / plugin on-disk format (`#10`).
+- Touch `CMakeLists.txt`, `port/native_sources.txt`, `docs/porting/ffp-render-states.md`, or `docs/porting/input-seams.md`.
+
+## Verification
+
+Closed-set `_mbs*` / `_ismb*` / Imm* should stay inside the files named above (`port/stub/` excepted):
+
+```bash
+rg -n --glob '!build/**' --glob '!.git/**' --glob '!Distribution/**' --glob '!port/stub/**' \
+  --glob '!docs/**' --glob '!port/rs2_roundtrip_stubs.cpp' \
+  '\b_mbs|\b_ismb|ImmGet|ImmSet|ImmRelease|#include\s*<imm\.h>'
+```
+
+Expect: five `_mbsicmp` files, `lib/editbox.cpp` / `lib/editbox.h`, `lib/window.cpp`, and `lib/headers.h`'s `#include <imm.h>`.
+
+`./scripts/check.sh` must stay green (docs only).


### PR DESCRIPTION
## Summary
- Close the `_mbs*` / Imm* call set in `docs/porting/charset-seams.md` so later #9 helper / IME slices replace only those sites.
- Live `_mbs*` usage is `_mbsicmp` compare only (12 calls in 5 files). `_mbsinc` / `_mbslen` / `_ismb*` are stub-only.
- Link the inventory from `docs/porting/charset-internal.md`.

Closes #62

## Test plan
- [x] `./scripts/check.sh` green (docs only)
- [x] Verification `rg` matches the five `_mbsicmp` files plus `lib/editbox.*`, `lib/window.cpp`, `lib/headers.h`
- [ ] Skim `charset-seams.md` tables: file I/O vs UI, Imm* -> `CEditBox::m_str` path


Made with [Cursor](https://cursor.com)