### PR TITLE
Add closed FVF stride, CPU vertex buffer, and DrawPrimitiveUP ring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,3 +216,14 @@ add_test(NAME rs2_config_plugin_self_test COMMAND rs2_config_plugin_test --self-
 add_test(NAME rs2_config_plugin_load COMMAND rs2_config_plugin_test
   "${CMAKE_SOURCE_DIR}/Distribution")
 set_tests_properties(rs2_config_plugin_load PROPERTIES SKIP_RETURN_CODE 77)
+
+# Closed FVF stride / CPU VB / DrawPrimitiveUP ring (#74). No GL draw.
+add_executable(rs2_ffp_fvf_test port/ffp_fvf_test.cpp port/ffp_fvf.cpp)
+target_include_directories(rs2_ffp_fvf_test SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_ffp_fvf_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_fvf_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_fvf_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_fvf_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
+
+add_test(NAME rs2_ffp_fvf_self_test COMMAND rs2_ffp_fvf_test --self-test)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -234,8 +234,12 @@ rg -n 'SetVertexShader\(' --glob '*.{cpp,h}' --glob '!port/stub/**'
 
 ---
 
+## Vertex layer (port, #74)
+
+Stride, attribute offsets, CPU vertex buffers, and `DrawPrimitiveUP` ring records are in [`ffp-vertex-layer.md`](ffp-vertex-layer.md) (`port/ffp_fvf.*`). `FVF_S` stays rejected. GLSL / render-state emulation is a later `#5` slice.
+
 ## What #5 should implement next
 
-1. **M3 required tier** ? Implement the core `D3DRS_*` / stage-0 / stage-1-env / FVF matrix rows above until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles.
+1. **M3 required tier** ? Implement the core `D3DRS_*` / stage-0 / stage-1-env / FVF shader matrix rows above until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF stride / CPU VB / UP *record* already live in `port/ffp_fvf` (#74); wire `IDirect3DDevice8` and upload the ring to a dynamic VBO.
 2. **Deferrable tier** ? Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** ? No new render states in game code without updating this document; unknown FVF/state combos should assert in debug builds ([adr-backend.md](adr-backend.md)).

--- a/docs/porting/ffp-vertex-layer.md
+++ b/docs/porting/ffp-vertex-layer.md
@@ -1,0 +1,43 @@
+# FVF vertex layer (`port/ffp_fvf`)
+
+- **Issue**: [#74](https://github.com/lollipop-onl/railsim2-portable/issues/74) (parent [#5](https://github.com/lollipop-onl/railsim2-portable/issues/5))
+- **Depends on**: [ffp-render-states.md](ffp-render-states.md) closed FVF set
+- **Related**: [adr-backend.md](adr-backend.md) (shader-per-FVF; `DrawPrimitiveUP` Å® dynamic VBO ring)
+
+## What this slice is
+
+Port-layer tables and CPU storage for the **M3-required** FVF aliases (`FVF_TL` Åc `FVF_NX2`). Game `lib/vertex.cpp` stays off the allowlist. There is no GLSL and no FFP state emulation.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_layout` / `rs2_ffp_stride` | Closed FVF Å® byte stride + attribute offsets (`position` / `rhw` / `normal` / `diffuse` / `tex0` / `tex1`) |
+| `rs2_ffp_vb_*` | CPU vertex buffer; `Lock` / `Unlock` expose a writable span (caller `memcpy`) |
+| `rs2_ffp_set_fvf` + `rs2_ffp_draw_primitive_up` | Record one UP draw: vertex bytes + FVF + primitive type + count. **Draw is a no-op.** |
+
+Unknown FVF values, including deferrable `FVF_S` (`D3DFVF_XYZ` only), return `false` / `E_FAIL`. Do not add `FVF_S` here; that is the shadow-volume slice.
+
+D3D8 `CreateVertexBuffer` / `DrawPrimitiveUP` / `IDirect3DVertexBuffer8` in `port/stub/d3d8.h` remain no-ops so allowlisted game TUs do not take a link dependency yet. Wire those methods to this API when a later slice implements the GL device.
+
+## Closed strides (must match `lib/vertex.h` structs)
+
+| Alias | Bits | Stride |
+|-------|------|--------|
+| `FVF_TL` | `XYZRHW \| DIFFUSE` | 20 |
+| `FVF_TLX` | `XYZRHW \| DIFFUSE \| TEX1` | 28 |
+| `FVF_L` | `XYZ \| DIFFUSE` | 16 |
+| `FVF_LX` | `XYZ \| DIFFUSE \| TEX1` | 24 |
+| `FVF_LX2` | `XYZ \| DIFFUSE \| TEX2` | 32 |
+| `FVF_N` | `XYZ \| NORMAL \| DIFFUSE` | 28 |
+| `FVF_NX` | `XYZ \| NORMAL \| DIFFUSE \| TEX1` | 36 |
+| `FVF_NX2` | `XYZ \| NORMAL \| DIFFUSE \| TEX2` | 44 |
+| `FVF_S` | `XYZ` | **rejected** |
+
+Decode order is the D3D FVF packing order: position (`xyz` or `xyz+rhw`), optional normal, optional diffuse, then 8-byte UV pairs. Diffuse is always **4-byte `D3DCOLOR`**, not host `sizeof(DWORD)` (8 on LP64). Offsets use `RS2_FFP_ABSENT` when a field is not in the FVF.
+
+## Entrance for the GL slice
+
+1. Select a shader variant by `Rs2FfpLayout.fvf` (or `attrs`).
+2. Bind a real VBO from `rs2_ffp_vb_*` storage, or upload `Rs2FfpUpRecord` through a dynamic VBO ring ([adr-backend.md](adr-backend.md): no client arrays).
+3. `rs2_ffp_up_last` / `rs2_ffp_up_at` are valid until the next wrap (`16` slots) or `rs2_ffp_up_reset`.
+
+ctest: `rs2_ffp_fvf_self_test` (`port/ffp_fvf_test.cpp --self-test`).

--- a/port/ffp_fvf.cpp
+++ b/port/ffp_fvf.cpp
@@ -1,0 +1,222 @@
+// Closed FVF decode + CPU VB + DrawPrimitiveUP ring (#74). Draw stays a no-op.
+
+#include "ffp_fvf.h"
+
+#include <cstring>
+#include <vector>
+
+namespace {
+
+const UINT kUpRing = 16;
+
+struct UpSlot {
+	Rs2FfpUpRecord rec{};
+	std::vector<unsigned char> bytes;
+};
+
+DWORD g_fvf = 0;
+UpSlot g_ring[kUpRing];
+UINT g_head = 0;
+UINT g_count = 0;
+
+bool decode_layout(DWORD fvf, Rs2FfpLayout *out) {
+	Rs2FfpLayout layout{};
+	layout.fvf = fvf;
+	layout.off_rhw = RS2_FFP_ABSENT;
+	layout.off_normal = RS2_FFP_ABSENT;
+	layout.off_diffuse = RS2_FFP_ABSENT;
+	layout.off_tex0 = RS2_FFP_ABSENT;
+	layout.off_tex1 = RS2_FFP_ABSENT;
+
+	UINT off = 0;
+	const bool has_rhw = (fvf & D3DFVF_XYZRHW) != 0;
+	const bool has_xyz = (fvf & D3DFVF_XYZ) != 0;
+	if (has_rhw == has_xyz) return false;
+
+	layout.attrs |= RS2_FFP_ATTR_POSITION;
+	layout.off_position = 0;
+	if (has_rhw) {
+		layout.attrs |= RS2_FFP_ATTR_RHW;
+		layout.off_rhw = 12;
+		off = 16;
+	} else {
+		off = 12;
+	}
+
+	if (fvf & D3DFVF_NORMAL) {
+		layout.attrs |= RS2_FFP_ATTR_NORMAL;
+		layout.off_normal = off;
+		off += 12;
+	}
+	if (fvf & D3DFVF_DIFFUSE) {
+		// D3DCOLOR is 4 bytes even when host DWORD is wider.
+		layout.attrs |= RS2_FFP_ATTR_DIFFUSE;
+		layout.off_diffuse = off;
+		off += 4;
+	}
+
+	const unsigned tex = (fvf & 0xF00u) >> 8;
+	if (tex >= 1) {
+		layout.attrs |= RS2_FFP_ATTR_TEX0;
+		layout.off_tex0 = off;
+		off += 8;
+	}
+	if (tex >= 2) {
+		layout.attrs |= RS2_FFP_ATTR_TEX1;
+		layout.off_tex1 = off;
+		off += 8;
+	}
+	if (tex > 2) return false;
+
+	layout.stride = off;
+	*out = layout;
+	return true;
+}
+
+bool vertex_count(DWORD prim_type, UINT prim_count, UINT *out) {
+	if (!out || prim_count == 0) return false;
+	switch (prim_type) {
+	case D3DPT_POINTLIST:
+		*out = prim_count;
+		return true;
+	case D3DPT_LINELIST:
+		*out = prim_count * 2u;
+		return true;
+	case D3DPT_LINESTRIP:
+		*out = prim_count + 1u;
+		return true;
+	case D3DPT_TRIANGLELIST:
+		*out = prim_count * 3u;
+		return true;
+	case D3DPT_TRIANGLESTRIP:
+	case D3DPT_TRIANGLEFAN:
+		*out = prim_count + 2u;
+		return true;
+	default:
+		return false;
+	}
+}
+
+}  // namespace
+
+struct Rs2FfpVertexBuffer {
+	DWORD fvf = 0;
+	std::vector<unsigned char> bytes;
+	bool locked = false;
+};
+
+bool rs2_ffp_is_closed(DWORD fvf) {
+	switch (fvf) {
+	case RS2_FVF_TL:
+	case RS2_FVF_TLX:
+	case RS2_FVF_L:
+	case RS2_FVF_LX:
+	case RS2_FVF_LX2:
+	case RS2_FVF_N:
+	case RS2_FVF_NX:
+	case RS2_FVF_NX2:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool rs2_ffp_layout(DWORD fvf, Rs2FfpLayout *out) {
+	if (!out || !rs2_ffp_is_closed(fvf)) return false;
+	return decode_layout(fvf, out);
+}
+
+UINT rs2_ffp_stride(DWORD fvf) {
+	Rs2FfpLayout layout;
+	if (!rs2_ffp_layout(fvf, &layout)) return 0;
+	return layout.stride;
+}
+
+HRESULT rs2_ffp_vb_create(UINT length, DWORD fvf, Rs2FfpVertexBuffer **out) {
+	if (!out || length == 0 || !rs2_ffp_is_closed(fvf)) return E_FAIL;
+	auto *vb = new Rs2FfpVertexBuffer;
+	vb->fvf = fvf;
+	vb->bytes.assign(length, 0);
+	vb->locked = false;
+	*out = vb;
+	return S_OK;
+}
+
+void rs2_ffp_vb_release(Rs2FfpVertexBuffer *vb) { delete vb; }
+
+HRESULT rs2_ffp_vb_lock(Rs2FfpVertexBuffer *vb, UINT offset, UINT size, void **pp,
+                        DWORD) {
+	if (!vb || !pp || vb->locked) return E_FAIL;
+	if (offset > vb->bytes.size()) return E_FAIL;
+	const UINT n = size ? size : static_cast<UINT>(vb->bytes.size() - offset);
+	if (offset + n > vb->bytes.size()) return E_FAIL;
+	vb->locked = true;
+	*pp = vb->bytes.data() + offset;
+	return S_OK;
+}
+
+HRESULT rs2_ffp_vb_unlock(Rs2FfpVertexBuffer *vb) {
+	if (!vb || !vb->locked) return E_FAIL;
+	vb->locked = false;
+	return S_OK;
+}
+
+DWORD rs2_ffp_vb_fvf(const Rs2FfpVertexBuffer *vb) { return vb ? vb->fvf : 0; }
+
+UINT rs2_ffp_vb_size(const Rs2FfpVertexBuffer *vb) {
+	return vb ? static_cast<UINT>(vb->bytes.size()) : 0;
+}
+
+HRESULT rs2_ffp_set_fvf(DWORD fvf) {
+	if (!rs2_ffp_is_closed(fvf)) return E_FAIL;
+	g_fvf = fvf;
+	return S_OK;
+}
+
+DWORD rs2_ffp_current_fvf() { return g_fvf; }
+
+HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *data,
+                                  UINT stride) {
+	Rs2FfpLayout layout;
+	if (!data || !rs2_ffp_layout(g_fvf, &layout)) return E_FAIL;
+	if (stride != layout.stride) return E_FAIL;
+	UINT nvert = 0;
+	if (!vertex_count(prim_type, prim_count, &nvert)) return E_FAIL;
+	const UINT bytes = nvert * stride;
+
+	UpSlot &slot = g_ring[g_head];
+	const auto *src = static_cast<const unsigned char *>(data);
+	slot.bytes.assign(src, src + bytes);
+	slot.rec.fvf = g_fvf;
+	slot.rec.prim_type = prim_type;
+	slot.rec.prim_count = prim_count;
+	slot.rec.stride = stride;
+	slot.rec.bytes = bytes;
+	slot.rec.vertices = slot.bytes.data();
+
+	g_head = (g_head + 1u) % kUpRing;
+	if (g_count < kUpRing) ++g_count;
+	return S_OK;
+}
+
+void rs2_ffp_up_reset() {
+	for (UINT i = 0; i < kUpRing; ++i) {
+		g_ring[i] = UpSlot{};
+	}
+	g_head = 0;
+	g_count = 0;
+	g_fvf = 0;
+}
+
+UINT rs2_ffp_up_count() { return g_count; }
+
+const Rs2FfpUpRecord *rs2_ffp_up_at(UINT index) {
+	if (index >= g_count) return nullptr;
+	const UINT start = (g_head + kUpRing - g_count) % kUpRing;
+	return &g_ring[(start + index) % kUpRing].rec;
+}
+
+const Rs2FfpUpRecord *rs2_ffp_up_last() {
+	if (g_count == 0) return nullptr;
+	return &g_ring[(g_head + kUpRing - 1u) % kUpRing].rec;
+}

--- a/port/ffp_fvf.h
+++ b/port/ffp_fvf.h
@@ -1,0 +1,76 @@
+// Closed D3D8 FVF stride / attribute table, CPU vertex buffer, DrawPrimitiveUP
+// ring record (#74, parent #5). No GL draw. FVF_S is deferred and rejected.
+
+#pragma once
+
+#include <d3d8.h>
+
+#ifndef RS2_FFP_ABSENT
+#define RS2_FFP_ABSENT (~0u)
+#endif
+
+// Named aliases match lib/vertex.h (and CShadowVolume.h for FVF_S).
+#define RS2_FVF_TL (D3DFVF_XYZRHW | D3DFVF_DIFFUSE)
+#define RS2_FVF_TLX (D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1)
+#define RS2_FVF_L (D3DFVF_XYZ | D3DFVF_DIFFUSE)
+#define RS2_FVF_LX (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
+#define RS2_FVF_LX2 (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX2)
+#define RS2_FVF_N (D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE)
+#define RS2_FVF_NX (D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE | D3DFVF_TEX1)
+#define RS2_FVF_NX2 (D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE | D3DFVF_TEX2)
+#define RS2_FVF_S (D3DFVF_XYZ)
+
+enum Rs2FfpAttr : unsigned {
+	RS2_FFP_ATTR_POSITION = 1u << 0,
+	RS2_FFP_ATTR_RHW = 1u << 1,
+	RS2_FFP_ATTR_NORMAL = 1u << 2,
+	RS2_FFP_ATTR_DIFFUSE = 1u << 3,
+	RS2_FFP_ATTR_TEX0 = 1u << 4,
+	RS2_FFP_ATTR_TEX1 = 1u << 5
+};
+
+struct Rs2FfpLayout {
+	DWORD fvf;
+	UINT stride;
+	unsigned attrs;
+	UINT off_position;
+	UINT off_rhw;
+	UINT off_normal;
+	UINT off_diffuse;
+	UINT off_tex0;
+	UINT off_tex1;
+};
+
+bool rs2_ffp_is_closed(DWORD fvf);
+bool rs2_ffp_layout(DWORD fvf, Rs2FfpLayout *out);
+UINT rs2_ffp_stride(DWORD fvf);
+
+struct Rs2FfpVertexBuffer;
+
+HRESULT rs2_ffp_vb_create(UINT length, DWORD fvf, Rs2FfpVertexBuffer **out);
+void rs2_ffp_vb_release(Rs2FfpVertexBuffer *vb);
+HRESULT rs2_ffp_vb_lock(Rs2FfpVertexBuffer *vb, UINT offset, UINT size, void **pp,
+                        DWORD flags);
+HRESULT rs2_ffp_vb_unlock(Rs2FfpVertexBuffer *vb);
+DWORD rs2_ffp_vb_fvf(const Rs2FfpVertexBuffer *vb);
+UINT rs2_ffp_vb_size(const Rs2FfpVertexBuffer *vb);
+
+HRESULT rs2_ffp_set_fvf(DWORD fvf);
+DWORD rs2_ffp_current_fvf();
+
+HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *data,
+                                  UINT stride);
+
+struct Rs2FfpUpRecord {
+	DWORD fvf;
+	DWORD prim_type;
+	UINT prim_count;
+	UINT stride;
+	UINT bytes;
+	const void *vertices;
+};
+
+void rs2_ffp_up_reset();
+UINT rs2_ffp_up_count();
+const Rs2FfpUpRecord *rs2_ffp_up_at(UINT index);
+const Rs2FfpUpRecord *rs2_ffp_up_last();

--- a/port/ffp_fvf_test.cpp
+++ b/port/ffp_fvf_test.cpp
@@ -1,0 +1,220 @@
+// Closed FVF stride / CPU VB / DrawPrimitiveUP ring self-test (#74).
+
+#include "ffp_fvf.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+// D3DCOLOR is 4 bytes on Win32. Host DWORD may be 8; pack like the FVF table.
+using Color = std::uint32_t;
+
+struct VtxTL {
+	float x, y, z, rhw;
+	Color d;
+};
+struct VtxTLX {
+	float x, y, z, rhw;
+	Color d;
+	float u, v;
+};
+struct VtxL {
+	float x, y, z;
+	Color d;
+};
+struct VtxLX {
+	float x, y, z;
+	Color d;
+	float u, v;
+};
+struct VtxLX2 {
+	float x, y, z;
+	Color d;
+	float u1, v1, u2, v2;
+};
+struct VtxN {
+	float x, y, z;
+	float nx, ny, nz;
+	Color d;
+};
+struct VtxNX {
+	float x, y, z;
+	float nx, ny, nz;
+	Color d;
+	float u, v;
+};
+struct VtxNX2 {
+	float x, y, z;
+	float nx, ny, nz;
+	Color d;
+	float u1, v1, u2, v2;
+};
+
+static_assert(sizeof(VtxTL) == 20 && sizeof(VtxTLX) == 28 && sizeof(VtxL) == 16 &&
+                  sizeof(VtxLX) == 24 && sizeof(VtxLX2) == 32 && sizeof(VtxN) == 28 &&
+                  sizeof(VtxNX) == 36 && sizeof(VtxNX2) == 44,
+              "Win32 D3DCOLOR packing");
+
+struct FvfCase {
+	DWORD fvf;
+	UINT stride;
+	unsigned attrs;
+	UINT off_pos;
+	UINT off_rhw;
+	UINT off_n;
+	UINT off_d;
+	UINT off_t0;
+	UINT off_t1;
+};
+
+const FvfCase kCases[] = {
+    {RS2_FVF_TL, sizeof(VtxTL),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_RHW | RS2_FFP_ATTR_DIFFUSE, 0, 12,
+     RS2_FFP_ABSENT, 16, RS2_FFP_ABSENT, RS2_FFP_ABSENT},
+    {RS2_FVF_TLX, sizeof(VtxTLX),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_RHW | RS2_FFP_ATTR_DIFFUSE | RS2_FFP_ATTR_TEX0,
+     0, 12, RS2_FFP_ABSENT, 16, 20, RS2_FFP_ABSENT},
+    {RS2_FVF_L, sizeof(VtxL), RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_DIFFUSE, 0,
+     RS2_FFP_ABSENT, RS2_FFP_ABSENT, 12, RS2_FFP_ABSENT, RS2_FFP_ABSENT},
+    {RS2_FVF_LX, sizeof(VtxLX),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_DIFFUSE | RS2_FFP_ATTR_TEX0, 0, RS2_FFP_ABSENT,
+     RS2_FFP_ABSENT, 12, 16, RS2_FFP_ABSENT},
+    {RS2_FVF_LX2, sizeof(VtxLX2),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_DIFFUSE | RS2_FFP_ATTR_TEX0 | RS2_FFP_ATTR_TEX1,
+     0, RS2_FFP_ABSENT, RS2_FFP_ABSENT, 12, 16, 24},
+    {RS2_FVF_N, sizeof(VtxN),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_NORMAL | RS2_FFP_ATTR_DIFFUSE, 0, RS2_FFP_ABSENT,
+     12, 24, RS2_FFP_ABSENT, RS2_FFP_ABSENT},
+    {RS2_FVF_NX, sizeof(VtxNX),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_NORMAL | RS2_FFP_ATTR_DIFFUSE |
+         RS2_FFP_ATTR_TEX0,
+     0, RS2_FFP_ABSENT, 12, 24, 28, RS2_FFP_ABSENT},
+    {RS2_FVF_NX2, sizeof(VtxNX2),
+     RS2_FFP_ATTR_POSITION | RS2_FFP_ATTR_NORMAL | RS2_FFP_ATTR_DIFFUSE |
+         RS2_FFP_ATTR_TEX0 | RS2_FFP_ATTR_TEX1,
+     0, RS2_FFP_ABSENT, 12, 24, 28, 36},
+};
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool layouts_ok() {
+	for (const FvfCase &c : kCases) {
+		Rs2FfpLayout layout;
+		if (!expect(rs2_ffp_is_closed(c.fvf), "closed fvf")) return false;
+		if (!expect(rs2_ffp_layout(c.fvf, &layout), "layout")) return false;
+		if (rs2_ffp_stride(c.fvf) != c.stride || layout.stride != c.stride) {
+			std::fprintf(stderr, "self-test: stride fvf=0x%lx got %u want %u\n",
+			             static_cast<unsigned long>(c.fvf), layout.stride, c.stride);
+			return false;
+		}
+		if (!expect(layout.attrs == c.attrs, "attrs")) return false;
+		if (!expect(layout.off_position == c.off_pos && layout.off_rhw == c.off_rhw &&
+		                layout.off_normal == c.off_n && layout.off_diffuse == c.off_d &&
+		                layout.off_tex0 == c.off_t0 && layout.off_tex1 == c.off_t1,
+		            "offsets"))
+			return false;
+	}
+	if (!expect(!rs2_ffp_is_closed(RS2_FVF_S) && rs2_ffp_stride(RS2_FVF_S) == 0,
+	            "FVF_S deferred"))
+		return false;
+	if (!expect(!rs2_ffp_layout(0x1234u, nullptr) && rs2_ffp_stride(0x1234u) == 0,
+	            "unknown fvf"))
+		return false;
+	return true;
+}
+
+bool vb_roundtrip_ok() {
+	VtxNX src{};
+	src.x = 1;
+	src.y = 2;
+	src.z = 3;
+	src.nx = 0;
+	src.ny = 1;
+	src.nz = 0;
+	src.d = 0x11223344u;
+	src.u = 0.5f;
+	src.v = 0.25f;
+
+	Rs2FfpVertexBuffer *vb = nullptr;
+	// Host HRESULT is 64-bit; E_FAIL is not < 0, so do not use FAILED().
+	if (!expect(rs2_ffp_vb_create(sizeof(src), RS2_FVF_S, &vb) != S_OK, "vb reject S"))
+		return false;
+	if (!expect(rs2_ffp_vb_create(sizeof(src), RS2_FVF_NX, &vb) == S_OK && vb,
+	            "vb create"))
+		return false;
+	if (!expect(rs2_ffp_vb_fvf(vb) == RS2_FVF_NX && rs2_ffp_vb_size(vb) == sizeof(src),
+	            "vb meta"))
+		return false;
+
+	void *p = nullptr;
+	if (!expect(rs2_ffp_vb_lock(vb, 0, 0, &p, 0) == S_OK && p, "lock")) {
+		rs2_ffp_vb_release(vb);
+		return false;
+	}
+	std::memcpy(p, &src, sizeof(src));
+	if (!expect(rs2_ffp_vb_unlock(vb) == S_OK, "unlock")) {
+		rs2_ffp_vb_release(vb);
+		return false;
+	}
+
+	p = nullptr;
+	if (!expect(rs2_ffp_vb_lock(vb, 0, sizeof(src), &p, 0) == S_OK && p &&
+	                std::memcmp(p, &src, sizeof(src)) == 0,
+	            "lock readback")) {
+		rs2_ffp_vb_release(vb);
+		return false;
+	}
+	if (!expect(rs2_ffp_vb_unlock(vb) == S_OK, "unlock 2")) {
+		rs2_ffp_vb_release(vb);
+		return false;
+	}
+
+	rs2_ffp_vb_release(vb);
+	return true;
+}
+
+bool up_record_ok() {
+	rs2_ffp_up_reset();
+	VtxTL verts[2] = {{0, 0, 0, 1, 0xFFFFFFFFu}, {10, 5, 0, 1, 0xFF00FF00u}};
+
+	if (!expect(rs2_ffp_set_fvf(RS2_FVF_S) != S_OK, "set FVF_S")) return false;
+	if (!expect(rs2_ffp_set_fvf(RS2_FVF_TL) == S_OK, "set FVF_TL")) return false;
+	if (!expect(rs2_ffp_draw_primitive_up(D3DPT_LINELIST, 1, verts, 99) != S_OK,
+	            "bad stride"))
+		return false;
+	if (!expect(rs2_ffp_draw_primitive_up(D3DPT_LINELIST, 1, verts, sizeof(VtxTL)) ==
+	                S_OK,
+	            "up record"))
+		return false;
+
+	const Rs2FfpUpRecord *rec = rs2_ffp_up_last();
+	if (!expect(rec != nullptr && rs2_ffp_up_count() == 1, "one record")) return false;
+	if (!expect(rec->fvf == RS2_FVF_TL && rec->prim_type == D3DPT_LINELIST &&
+	                rec->prim_count == 1 && rec->stride == sizeof(VtxTL) &&
+	                rec->bytes == sizeof(verts) && rec->vertices &&
+	                std::memcmp(rec->vertices, verts, sizeof(verts)) == 0,
+	            "up payload"))
+		return false;
+	if (!expect(rs2_ffp_up_at(0) == rec, "at(0) is last")) return false;
+	return true;
+}
+
+int self_test() {
+	if (!layouts_ok()) return 1;
+	if (!vb_roundtrip_ok()) return 1;
+	if (!up_record_ok()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -231,6 +231,7 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetTexture(DWORD, IDirect3DTexture8*) { return S_OK; }
   HRESULT GetTexture(DWORD, IDirect3DBaseTexture8**) { return S_OK; }
   HRESULT DrawPrimitive(D3DPRIMITIVETYPE, UINT, UINT) { return S_OK; }
+  // CPU record: port/ffp_fvf.h (rs2_ffp_draw_primitive_up). Draw stays no-op.
   HRESULT DrawPrimitiveUP(D3DPRIMITIVETYPE, UINT, const void*, UINT) { return S_OK; }
   HRESULT DrawIndexedPrimitive(D3DPRIMITIVETYPE, UINT, UINT, UINT, UINT, const void*) { return S_OK; }
   HRESULT SetStreamSource(UINT, IDirect3DVertexBuffer8*, UINT) { return S_OK; }
@@ -247,6 +248,7 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetRenderTarget(IDirect3DSurface8*, IDirect3DSurface8*) { return S_OK; }
   HRESULT GetRenderTarget(IDirect3DSurface8**) { return S_OK; }
   HRESULT GetDepthStencilSurface(IDirect3DSurface8**) { return S_OK; }
+  // CPU VB: port/ffp_fvf.h (rs2_ffp_vb_*). Closed FVF only; not wired here yet.
   HRESULT CreateVertexBuffer(UINT, DWORD, DWORD, DWORD, IDirect3DVertexBuffer8**) { return S_OK; }
   HRESULT CreateImageSurface(UINT, UINT, D3DFORMAT, IDirect3DSurface8**) { return S_OK; }
   HRESULT CreateDepthStencilSurface(UINT, UINT, D3DFORMAT, DWORD, IDirect3DSurface8**) { return S_OK; }


### PR DESCRIPTION
## Summary
- Port-layer FVF table (`port/ffp_fvf`) maps the M3-required aliases (`FVF_TL` … `FVF_NX2`) to D3D8 stride and attribute offsets (`position` / `rhw` / `normal` / `diffuse` / `tex0` / `tex1`).
- CPU vertex buffers `Lock`/`Unlock` for memcpy, plus a `DrawPrimitiveUP` ring that records vertices + FVF + primitive type + count (draw stays no-op). Unknown FVF and deferrable `FVF_S` return `E_FAIL`.
- `rs2_ffp_fvf_self_test` covers stride, VB roundtrip, and one UP record. Docs: `docs/porting/ffp-vertex-layer.md`. `lib/vertex.cpp` stays off the allowlist; no GLSL.

Closes #74

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_ffp_fvf_self_test`)
- [ ] Confirm CI on this PR


Made with [Cursor](https://cursor.com)