### PR TITLE
Add CP932/UTF-8 rs2_text helper and replace closed _mbsicmp (#75)

### DIFF
--- a/CFileMode.cpp
+++ b/CFileMode.cpp
@@ -77,7 +77,7 @@ bool CFileListView::ConfirmRename(
 ){
 	char *oldname = item->GetString(0);
 	newname = FixFileExt((char *)newname.c_str(), "rs2");
-	if(!_mbsicmp((PUCHAR)oldname, (PUCHAR)newname.c_str())) return false;
+	if(!rs2_text_icmp((PUCHAR)oldname, (PUCHAR)newname.c_str())) return false;
 	char dir[RS2_PATH_MAX] = {}, from[RS2_PATH_MAX] = {}, to[RS2_PATH_MAX] = {};
 	if(CheckSlash(newname.c_str())
 		|| !rs2_path_join(dir, sizeof(dir), g_BaseDir, LAYOUT_DIRNAME)
@@ -586,7 +586,7 @@ void CFileMode::ScanInputInterface(){
 		CListElement *le = m_FileListView.GetFocusItem();
 		m_NewFileName = le && le->IsSelected() ? le->GetString(0) : g_SaveFile->m_FileName;
 		if(m_NewFileName.size()){
-			if(_mbsicmp((PUCHAR)m_NewFileName.c_str(), (PUCHAR)g_SaveFile->GetFileName()))
+			if(rs2_text_icmp((PUCHAR)m_NewFileName.c_str(), (PUCHAR)g_SaveFile->GetFileName()))
 				SaveFile((char *)m_NewFileName.c_str());
 			else if(!g_SaveFile->Save(
 				m_NewFileName.c_str(), LAYOUT_DIRNAME, true, true)) ListFile();
@@ -687,7 +687,7 @@ void CFileMode::ListFile(){
 	ILayoutInfo ili = m_LayoutInfoList.begin();
 	int current = -1;
 	for(; ili!=m_LayoutInfoList.end(); ili++){
-		if(!_mbsicmp((PUCHAR)ili->m_FileName.c_str(),
+		if(!rs2_text_icmp((PUCHAR)ili->m_FileName.c_str(),
 			(PUCHAR)g_SaveFile->GetFileName())){
 			current = m_FileListView.GetItemNum();
 			g_SaveFile->SetFileName((char *)ili->m_FileName.c_str());

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.24)
 
 project(railsim2-portable LANGUAGES CXX)
 
+# iconv for port/rs2_text CP932<->UTF-8 (#75). Not SDL; glibc is built-in on Linux.
+find_package(Iconv REQUIRED)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -32,7 +35,8 @@ if(RS2_NATIVE_SOURCES STREQUAL "")
 endif()
 
 add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
-  "${CMAKE_SOURCE_DIR}/port/path.cpp")
+  "${CMAKE_SOURCE_DIR}/port/path.cpp"
+  "${CMAKE_SOURCE_DIR}/port/rs2_text.cpp")
 
 target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub"
@@ -53,6 +57,7 @@ target_compile_definitions(railsim2_native PRIVATE
   RS2_PORTABLE_COMPILE_FIREWALL=1
   NOMINMAX
 )
+target_link_libraries(railsim2_native PRIVATE Iconv::Iconv)
 
 # Link skeleton: POSIX main only. Allowlisted game objects compile into
 # railsim2_native.a but are not linked yet — they still need udx globals
@@ -75,6 +80,7 @@ set(RS2_ROUNDTRIP_SOURCES
   port/rs2_roundtrip_ptr.cpp
   port/rs2_float_lexeme.cpp
   port/path.cpp
+  port/rs2_text.cpp
   CSaveFile.cpp
   Script.cpp
   md5.cpp
@@ -129,6 +135,7 @@ target_compile_definitions(rs2_roundtrip PRIVATE
   RS2_ROUNDTRIP=1
   NOMINMAX
 )
+target_link_libraries(rs2_roundtrip PRIVATE Iconv::Iconv)
 
 set(RS2_ROUNDTRIP_FIXTURE
   "${CMAKE_SOURCE_DIR}/Distribution/en/RailSim2/Layout/Sample.rs2")
@@ -227,3 +234,12 @@ target_compile_options(rs2_ffp_fvf_test PRIVATE -Wall -Wextra)
 target_compile_definitions(rs2_ffp_fvf_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
 
 add_test(NAME rs2_ffp_fvf_self_test COMMAND rs2_ffp_fvf_test --self-test)
+
+# CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
+add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)
+target_include_directories(rs2_text_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_text_test PRIVATE cxx_std_17)
+target_compile_options(rs2_text_test PRIVATE -Wall -Wextra)
+target_link_libraries(rs2_text_test PRIVATE Iconv::Iconv)
+
+add_test(NAME rs2_text_self_test COMMAND rs2_text_test --self-test)

--- a/CPlugin.cpp
+++ b/CPlugin.cpp
@@ -39,9 +39,9 @@ CPlugin::~CPlugin(){
 int CPlugin::Compare(
 	CPlugin *rhs	//	‰E•Ó
 ){
-	int ret = _mbsicmp((PUCHAR)m_Name.c_str(), (PUCHAR)rhs->m_Name.c_str());
-	if(!ret) ret = _mbsicmp((PUCHAR)m_ID.c_str(), (PUCHAR)rhs->m_ID.c_str());
-	if(!ret) ret = _mbsicmp((PUCHAR)m_Author.c_str(), (PUCHAR)rhs->m_Author.c_str());
+	int ret = rs2_text_icmp((PUCHAR)m_Name.c_str(), (PUCHAR)rhs->m_Name.c_str());
+	if(!ret) ret = rs2_text_icmp((PUCHAR)m_ID.c_str(), (PUCHAR)rhs->m_ID.c_str());
+	if(!ret) ret = rs2_text_icmp((PUCHAR)m_Author.c_str(), (PUCHAR)rhs->m_Author.c_str());
 	return ret;
 }
 
@@ -336,11 +336,11 @@ CPlugin *CPluginList::FindPlugin(
 	if(!*id) return NULL;
 	CPlugin *ptr = m_List;
 	while(ptr){
-		if(!_mbsicmp((PUCHAR)id, (PUCHAR)ptr->m_ID.c_str()))
+		if(!rs2_text_icmp((PUCHAR)id, (PUCHAR)ptr->m_ID.c_str()))
 			return load ? ptr->LoadAndGet() : ptr;
 		ptr = ptr->m_Next;
 	}
-	if(Default() && _mbsicmp((PUCHAR)id, (PUCHAR)Default()))
+	if(Default() && rs2_text_icmp((PUCHAR)id, (PUCHAR)Default()))
 		return FindPlugin(Default(), load);
 	g_LackPlugin.insert(FlashIn("%s\\%s", DirName(), id));
 	return NULL;

--- a/CTreeElement.cpp
+++ b/CTreeElement.cpp
@@ -99,7 +99,7 @@ int CTreeElement::Compare(
 	int ret;
 	if(IsDirectory()){
 		if(rhs->IsDirectory()){
-			ret = _mbsicmp(
+			ret = rs2_text_icmp(
 				(PUCHAR)m_String.c_str(), (PUCHAR)rhs->m_String.c_str());
 		}else{
 			return -1;
@@ -108,7 +108,7 @@ int CTreeElement::Compare(
 		if(rhs->IsDirectory()){
 			return 1;
 		}else{
-			ret = _mbsicmp(
+			ret = rs2_text_icmp(
 				(PUCHAR)m_String.c_str(), (PUCHAR)rhs->m_String.c_str());
 		}
 	}

--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -32,6 +32,8 @@ All live uses are **case-insensitive compare**. None walk or measure CP932 chara
 
 Do not expand a `_mbs*` rewrite into plugin `Load()` bodies, `CSaveFile` parsers, or `Language.txt`. Those files never call `_mbs*`.
 
+`port/rs2_text` (#75) is the closed-set helper: `rs2_cp932_to_utf8` / `rs2_utf8_to_cp932` convert at file boundaries (iconv; `.rs2` on-disk bytes stay CP932), and `rs2_text_icmp` replaces the twelve `_mbsicmp` calls in the five files above by decoding CP932 to UTF-8 then ASCII-case-folding. IME (`Imm*`) is unchanged.
+
 ## File I/O vs internal UI
 
 ADR rule: CP932 stays on disk; `std::string` after load becomes UTF-8. Classify the closed set that way so a helper slice knows **where** to convert.
@@ -148,8 +150,6 @@ Later slices must **not** treat these as part of the `_mbs*` / Imm* closed set, 
 
 ## What a follow-up slice may touch
 
-One conversion-helper PR should be enough for `_mbsicmp` if it supplies a UTF-8 (or explicit CP932) case-fold compare and is wired **only** into the five files above.
-
 One IME PR should replace `lib/editbox.cpp` + the `WM_IME_SETCONTEXT` hide in `lib/window.cpp` with backend `TEXTINPUT` (UTF-8) writing `m_str` / `m_comp`. Do not reimplement `CEditCtrl` / list / tree rename.
 
 **Must not** (this inventory and those follow-ups):
@@ -169,6 +169,6 @@ rg -n --glob '!build/**' --glob '!.git/**' --glob '!Distribution/**' --glob '!po
   '\b_mbs|\b_ismb|ImmGet|ImmSet|ImmRelease|#include\s*<imm\.h>'
 ```
 
-Expect: five `_mbsicmp` files, `lib/editbox.cpp` / `lib/editbox.h`, `lib/window.cpp`, and `lib/headers.h`'s `#include <imm.h>`.
+Expect: Imm* in `lib/editbox.cpp` / `lib/editbox.h`, `lib/window.cpp`, and `lib/headers.h`'s `#include <imm.h>`. Live `_mbsicmp` is gone (stub + comments only).
 
-`./scripts/check.sh` must stay green (docs only).
+`./scripts/check.sh` must stay green.

--- a/lib/mesh.cpp
+++ b/lib/mesh.cpp
@@ -786,7 +786,7 @@ CMesh *CMeshList::Get(BOOL fRes, LPCSTR strName, D3DCOLOR cTrans, int nMipLv){
 
 	while(p){
 		//	見つかれば参照カウンタを増やし、メッシュを返す
-		if(!_mbsicmp((PUCHAR)p->strName.c_str(), (PUCHAR)strName)
+		if(!rs2_text_icmp((PUCHAR)p->strName.c_str(), (PUCHAR)strName)
 			&& p->cTrans==cTrans && p->nMipLv==nMipLv){
 			//	Debug("[%s] is in mesh-list.\n", strName); /*デバッグ*/
 			p->nRef++;

--- a/lib/texture.cpp
+++ b/lib/texture.cpp
@@ -1,6 +1,7 @@
 //	Copyright (c) 2002 Midikyou
 
 #include "headers.h"
+#include "../port/rs2_text.h"
 #include "debug.h"
 #include "graphic.h"
 #include "vertex.h"
@@ -261,7 +262,7 @@ LPTEX8 CTexList::Get(BOOL fRes, LPCSTR strName, D3DCOLOR cTrans, int nMipLv){
 
 	while(p){
 		//	見つかれば参照カウンタを増やし、テクスチャを返す
-		if(!_mbsicmp((PUCHAR)p->strName.c_str(), (PUCHAR)strName)
+		if(!rs2_text_icmp((PUCHAR)p->strName.c_str(), (PUCHAR)strName)
 			&& p->cTrans==cTrans && p->nMipLv==nMipLv){
 			//	Debug("[%s] is in texture-list.\n", strName); /*デバッグ*/
 			p->nRef++;

--- a/port/rs2_text.cpp
+++ b/port/rs2_text.cpp
@@ -1,0 +1,84 @@
+#include "rs2_text.h"
+
+#include <cstring>
+#include <iconv.h>
+
+namespace {
+
+const char *g_utf8_name = nullptr;
+const char *g_cp932_name = nullptr;
+
+bool probe_iconv_names() {
+	if (g_utf8_name && g_cp932_name) return true;
+	static const char *const kUtf8[] = {"UTF-8", "UTF8", nullptr};
+	static const char *const kCp932[] = {
+	    "CP932", "WINDOWS-31J", "SJIS-WIN", "MS932", "MS_KANJI", "SHIFT_JIS", nullptr};
+	for (int i = 0; kUtf8[i]; ++i) {
+		for (int j = 0; kCp932[j]; ++j) {
+			iconv_t cd = iconv_open(kUtf8[i], kCp932[j]);
+			if (cd == (iconv_t)-1) continue;
+			iconv_close(cd);
+			cd = iconv_open(kCp932[j], kUtf8[i]);
+			if (cd == (iconv_t)-1) continue;
+			iconv_close(cd);
+			g_utf8_name = kUtf8[i];
+			g_cp932_name = kCp932[j];
+			return true;
+		}
+	}
+	return false;
+}
+
+std::string iconv_convert(const char *to, const char *from, const char *in) {
+	if (!in) in = "";
+	iconv_t cd = iconv_open(to, from);
+	if (cd == (iconv_t)-1) return std::string(in);
+
+	size_t inleft = std::strlen(in);
+	std::string out;
+	out.resize(inleft * 4 + 16);
+	char *inptr = const_cast<char *>(in);
+	char *outptr = out.data();
+	size_t outleft = out.size();
+	size_t n = iconv(cd, &inptr, &inleft, &outptr, &outleft);
+	if (n != (size_t)-1) {
+		iconv(cd, nullptr, nullptr, &outptr, &outleft);
+	}
+	iconv_close(cd);
+	if (n == (size_t)-1 || inleft != 0) return std::string(in);
+	out.resize(out.size() - outleft);
+	return out;
+}
+
+int ascii_icmp(const char *a, const char *b) {
+	while (*a && *b) {
+		unsigned char ca = (unsigned char)*a++;
+		unsigned char cb = (unsigned char)*b++;
+		if (ca >= 'A' && ca <= 'Z') ca = (unsigned char)(ca - 'A' + 'a');
+		if (cb >= 'A' && cb <= 'Z') cb = (unsigned char)(cb - 'A' + 'a');
+		if (ca != cb) return (int)ca - (int)cb;
+	}
+	return (int)(unsigned char)*a - (int)(unsigned char)*b;
+}
+
+}  // namespace
+
+std::string rs2_cp932_to_utf8(const char *cp932) {
+	if (!cp932) return std::string();
+	if (!probe_iconv_names()) return std::string(cp932);
+	return iconv_convert(g_utf8_name, g_cp932_name, cp932);
+}
+
+std::string rs2_utf8_to_cp932(const char *utf8) {
+	if (!utf8) return std::string();
+	if (!probe_iconv_names()) return std::string(utf8);
+	return iconv_convert(g_cp932_name, g_utf8_name, utf8);
+}
+
+int rs2_text_icmp(const char *a, const char *b) {
+	if (!a) a = "";
+	if (!b) b = "";
+	std::string ua = rs2_cp932_to_utf8(a);
+	std::string ub = rs2_cp932_to_utf8(b);
+	return ascii_icmp(ua.c_str(), ub.c_str());
+}

--- a/port/rs2_text.h
+++ b/port/rs2_text.h
@@ -1,0 +1,20 @@
+// CP932 <-> UTF-8 at file / Win32-compat boundaries (#75).
+// In-process text is UTF-8 (docs/porting/charset-internal.md).
+// Inputs to rs2_text_icmp are still CP932 (or ASCII) at the closed _mbsicmp sites.
+
+#pragma once
+
+#include <string>
+
+std::string rs2_cp932_to_utf8(const char *cp932);
+std::string rs2_utf8_to_cp932(const char *utf8);
+
+// Case-insensitive compare for the closed _mbsicmp set.
+// Decodes CP932 to UTF-8, then folds ASCII A-Z only (trail bytes stay intact).
+// Same return convention as strcmp / _mbsicmp.
+int rs2_text_icmp(const char *a, const char *b);
+
+inline int rs2_text_icmp(const unsigned char *a, const unsigned char *b) {
+	return rs2_text_icmp(reinterpret_cast<const char *>(a),
+	                     reinterpret_cast<const char *>(b));
+}

--- a/port/rs2_text_test.cpp
+++ b/port/rs2_text_test.cpp
@@ -1,0 +1,84 @@
+// CP932 <-> UTF-8 and _mbsicmp-replacement self-test (#75).
+// Test source stays ASCII; Japanese vectors are hex bytes.
+
+#include "rs2_text.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+int self_test() {
+	// Sample.rs2 basename (ASCII identity).
+	if (!expect(rs2_cp932_to_utf8("Sample.rs2") == "Sample.rs2", "ascii to utf8"))
+		return 1;
+	if (!expect(rs2_utf8_to_cp932("Sample.rs2") == "Sample.rs2", "ascii to cp932"))
+		return 1;
+
+	// 日本語レイアウト名 (issue example).
+	const char kLayoutCp932[] = {
+	    '\x93', '\xfa', '\x96', '\x7b', '\x8c', '\xea', '\x83', '\x8c', '\x83',
+	    '\x43', '\x83', '\x41', '\x83', '\x45', '\x83', '\x67', '\x96', '\xbc', 0};
+	const char kLayoutUtf8[] = {
+	    '\xe6', '\x97', '\xa5', '\xe6', '\x9c', '\xac', '\xe8', '\xaa', '\x9e',
+	    '\xe3', '\x83', '\xac', '\xe3', '\x82', '\xa4', '\xe3', '\x82', '\xa2',
+	    '\xe3', '\x82', '\xa6', '\xe3', '\x83', '\x88', '\xe5', '\x90', '\x8d', 0};
+	if (!expect(rs2_cp932_to_utf8(kLayoutCp932) == kLayoutUtf8, "layout cp932->utf8"))
+		return 1;
+	if (!expect(rs2_utf8_to_cp932(kLayoutUtf8) == kLayoutCp932, "layout utf8->cp932"))
+		return 1;
+	if (!expect(rs2_utf8_to_cp932(rs2_cp932_to_utf8(kLayoutCp932).c_str()) == kLayoutCp932,
+	            "layout roundtrip"))
+		return 1;
+
+	// デフォルト from jp Surface2.txt PluginName.
+	const char kDefaultCp932[] = {
+	    '\x83', '\x66', '\x83', '\x74', '\x83', '\x48', '\x83', '\x8b', '\x83', '\x67', 0};
+	const char kDefaultUtf8[] = {
+	    '\xe3', '\x83', '\x87', '\xe3', '\x83', '\x95', '\xe3', '\x82', '\xa9',
+	    '\xe3', '\x83', '\xab', '\xe3', '\x83', '\x88', 0};
+	if (!expect(rs2_cp932_to_utf8(kDefaultCp932) == kDefaultUtf8, "default cp932->utf8"))
+		return 1;
+	if (!expect(rs2_utf8_to_cp932(kDefaultUtf8) == kDefaultCp932, "default utf8->cp932"))
+		return 1;
+
+	// ASCII case-insensitive (plugin / .rs2 filenames).
+	if (!expect(rs2_text_icmp("Sample.rs2", "sample.rs2") == 0, "ascii icmp fold"))
+		return 1;
+	if (!expect(rs2_text_icmp("FOO.RS2", "foo.rs2") == 0, "ascii icmp upper"))
+		return 1;
+	if (!expect(rs2_text_icmp("a.rs2", "b.rs2") < 0, "ascii icmp order")) return 1;
+	if (!expect(rs2_text_icmp("Foo", "Foo") == 0, "ascii icmp same")) return 1;
+
+	// Trail-byte trap: ア (0x8341) vs ヂ (0x8361). strcasecmp would fold 0x41/0x61.
+	const char kA[] = {'\x83', '\x41', 0};
+	const char kDi[] = {'\x83', '\x61', 0};
+	if (!expect(rs2_text_icmp(kA, kDi) != 0, "trail byte not ascii-folded")) return 1;
+	if (!expect(rs2_text_icmp(kA, kA) == 0, "katakana equal")) return 1;
+
+	// ASCII fold beside a CP932 lead pair (A日 vs a日).
+	const char kAHi[] = {'A', '\x93', '\xfa', 0};
+	const char kALo[] = {'a', '\x93', '\xfa', 0};
+	if (!expect(rs2_text_icmp(kAHi, kALo) == 0, "ascii fold plus kanji")) return 1;
+
+	if (!expect(rs2_text_icmp(kLayoutCp932, kLayoutCp932) == 0, "layout icmp same"))
+		return 1;
+	if (!expect(rs2_text_icmp(kLayoutCp932, kDefaultCp932) != 0, "layout vs default"))
+		return 1;
+
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/stdafx.h
+++ b/stdafx.h
@@ -10,6 +10,7 @@
 #include "port/path.h"
 #include "port/rs2_ptr.h"
 #include "port/rs2_float.h"
+#include "port/rs2_text.h"
 
 typedef list<string>::iterator Istring;
 


### PR DESCRIPTION
## Summary
- Add `port/rs2_text` with `rs2_cp932_to_utf8` / `rs2_utf8_to_cp932` (iconv; no SDL on the check preset) and `rs2_text_icmp` for the closed `_mbsicmp` set.
- Mechanically replace the twelve live `_mbsicmp` calls in `CPlugin.cpp`, `CFileMode.cpp`, `CTreeElement.cpp`, `lib/texture.cpp`, and `lib/mesh.cpp`. On-disk `.rs2` CP932 is unchanged; no IME / `Imm*` / `CEditBox` work.
- `rs2_text_self_test` covers Japanese layout-name roundtrip, ASCII case-fold, and the CP932 trail-byte trap (`ア` vs `ヂ`). One paragraph on `docs/porting/charset-seams.md`.

Closes #75

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_text_self_test`)
- [ ] Confirm CI on this PR


Made with [Cursor](https://cursor.com)