### PR TITLE
Add M3 core FFP render-state shadow and shader key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/path.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_text.cpp"
+  "${CMAKE_SOURCE_DIR}/port/ffp_state.cpp"
   "${CMAKE_SOURCE_DIR}/lib/movie.cpp")
 
 target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
@@ -45,6 +46,7 @@ target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
 target_include_directories(railsim2_native PRIVATE
   "${CMAKE_SOURCE_DIR}"
   "${CMAKE_SOURCE_DIR}/lib"
+  "${CMAKE_SOURCE_DIR}/port"
 )
 
 target_compile_options(railsim2_native PRIVATE
@@ -82,6 +84,7 @@ set(RS2_ROUNDTRIP_SOURCES
   port/rs2_float_lexeme.cpp
   port/path.cpp
   port/rs2_text.cpp
+  port/ffp_state.cpp
   CSaveFile.cpp
   Script.cpp
   md5.cpp
@@ -226,7 +229,7 @@ add_test(NAME rs2_config_plugin_load COMMAND rs2_config_plugin_test
 set_tests_properties(rs2_config_plugin_load PROPERTIES SKIP_RETURN_CODE 77)
 
 # Closed FVF stride / CPU VB / DrawPrimitiveUP ring (#74). No GL draw.
-add_executable(rs2_ffp_fvf_test port/ffp_fvf_test.cpp port/ffp_fvf.cpp)
+add_executable(rs2_ffp_fvf_test port/ffp_fvf_test.cpp port/ffp_fvf.cpp port/ffp_state.cpp)
 target_include_directories(rs2_ffp_fvf_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")
 target_include_directories(rs2_ffp_fvf_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
@@ -235,6 +238,20 @@ target_compile_options(rs2_ffp_fvf_test PRIVATE -Wall -Wextra)
 target_compile_definitions(rs2_ffp_fvf_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
 
 add_test(NAME rs2_ffp_fvf_self_test COMMAND rs2_ffp_fvf_test --self-test)
+
+# M3 core D3DRS / D3DTSS shadow + shader key (#80). No GLSL / GL.
+add_executable(rs2_ffp_state_test
+  port/ffp_state_test.cpp
+  port/ffp_state.cpp
+  port/ffp_fvf.cpp)
+target_include_directories(rs2_ffp_state_test SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_ffp_state_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_state_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_state_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_state_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
+
+add_test(NAME rs2_ffp_state_self_test COMMAND rs2_ffp_state_test --self-test)
 
 # CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
 add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -238,8 +238,25 @@ rg -n 'SetVertexShader\(' --glob '*.{cpp,h}' --glob '!port/stub/**'
 
 Stride, attribute offsets, CPU vertex buffers, and `DrawPrimitiveUP` ring records are in [`ffp-vertex-layer.md`](ffp-vertex-layer.md) (`port/ffp_fvf.*`). `FVF_S` stays rejected. GLSL / render-state emulation is a later `#5` slice.
 
+## State shadow / shader key (port, #80)
+
+M3 required `D3DRS_*` / stage-0 / stage-1-env live in `port/ffp_state.*`. There is no GLSL and no GL link.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_state_reset` / `rs2_ffp_state_get` | `InitRenderState` snapshot (lighting on, ambient `0xff808080`, Gouraud, CCW, Z read/write, SRCALPHA/INVSRCALPHA, stage 0 MODULATE + point filter, stage 1 DISABLE) |
+| `rs2_ffp_set_render_state` / `rs2_ffp_set_texture_stage_state` | Shadow the closed core set. Unknown type, stage `> 1`, and deferrable stencil return `E_FAIL` (debug log). |
+| `rs2_ffp_shader_key(fvf)` | Pack closed FVF index + core toggles (lighting, alpha test, env-map stage, blends). Ambient / fog distances stay on the snapshot as uniforms. Unknown / `FVF_S` returns `0`. |
+| `Rs2FfpUpRecord.shader_key` | Copied from `rs2_ffp_shader_key` at each `rs2_ffp_draw_primitive_up`. Later GL selects a variant from this field. |
+
+`IDirect3DDevice8::SetRenderState` / `GetRenderState` / `SetTextureStageState` in `port/stub/d3d8.h` call the shadow. `DrawPrimitiveUP` stays a no-op (record via `rs2_ffp_draw_primitive_up` only).
+
+Stub `D3DRS_LIGHTING` / `D3DRS_AMBIENT` / `D3DRS_FOGVERTEXMODE` / `D3DRS_FOGTABLEMODE` use the real D3D8 numbers so the shadow can switch on type (the previous stub reused `7` / `27` / `36`).
+
+ctest: `rs2_ffp_state_self_test` (`port/ffp_state_test.cpp --self-test`).
+
 ## What #5 should implement next
 
-1. **M3 required tier** ? Implement the core `D3DRS_*` / stage-0 / stage-1-env / FVF shader matrix rows above until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF stride / CPU VB / UP *record* already live in `port/ffp_fvf` (#74); wire `IDirect3DDevice8` and upload the ring to a dynamic VBO.
-2. **Deferrable tier** ? Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
-3. **Do not expand** ? No new render states in game code without updating this document; unknown FVF/state combos should assert in debug builds ([adr-backend.md](adr-backend.md)).
+1. **M3 required tier (GL)** -- Wire `IDirect3DDevice8` draw to a dynamic VBO and pick a shader variant from `rs2_ffp_shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74) and the state shadow (#80) are already in `port/`.
+2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
+3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -246,7 +246,7 @@ M3 required `D3DRS_*` / stage-0 / stage-1-env live in `port/ffp_state.*`. There 
 |-----|------|
 | `rs2_ffp_state_reset` / `rs2_ffp_state_get` | `InitRenderState` snapshot (lighting on, ambient `0xff808080`, Gouraud, CCW, Z read/write, SRCALPHA/INVSRCALPHA, stage 0 MODULATE + point filter, stage 1 DISABLE) |
 | `rs2_ffp_set_render_state` / `rs2_ffp_set_texture_stage_state` | Shadow the closed core set. Unknown type, stage `> 1`, and deferrable stencil return `E_FAIL` (debug log). |
-| `rs2_ffp_shader_key(fvf)` | Pack closed FVF index + core toggles (lighting, alpha test, env-map stage, blends). Ambient / fog distances stay on the snapshot as uniforms. Unknown / `FVF_S` returns `0`. |
+| `rs2_ffp_shader_key(fvf)` | Pack closed FVF index + core toggles (lighting, alpha test, env-map TCI, blends) into `uint64_t`. Ambient / alpharef / fog distances stay on the snapshot as uniforms. Unknown / `FVF_S` returns `0`. |
 | `Rs2FfpUpRecord.shader_key` | Copied from `rs2_ffp_shader_key` at each `rs2_ffp_draw_primitive_up`. Later GL selects a variant from this field. |
 
 `IDirect3DDevice8::SetRenderState` / `GetRenderState` / `SetTextureStageState` in `port/stub/d3d8.h` call the shadow. `DrawPrimitiveUP` stays a no-op (record via `rs2_ffp_draw_primitive_up` only).

--- a/port/ffp_fvf.cpp
+++ b/port/ffp_fvf.cpp
@@ -2,6 +2,8 @@
 
 #include "ffp_fvf.h"
 
+#include "ffp_state.h"
+
 #include <cstring>
 #include <vector>
 
@@ -193,6 +195,7 @@ HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *
 	slot.rec.stride = stride;
 	slot.rec.bytes = bytes;
 	slot.rec.vertices = slot.bytes.data();
+	slot.rec.shader_key = rs2_ffp_shader_key(g_fvf);
 
 	g_head = (g_head + 1u) % kUpRing;
 	if (g_count < kUpRing) ++g_count;

--- a/port/ffp_fvf.h
+++ b/port/ffp_fvf.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <d3d8.h>
 
 #ifndef RS2_FFP_ABSENT
@@ -68,6 +70,7 @@ struct Rs2FfpUpRecord {
 	UINT stride;
 	UINT bytes;
 	const void *vertices;
+	std::uint64_t shader_key;
 };
 
 void rs2_ffp_up_reset();

--- a/port/ffp_state.cpp
+++ b/port/ffp_state.cpp
@@ -360,9 +360,17 @@ std::uint64_t rs2_ffp_shader_key(DWORD fvf) {
 	const Rs2FfpTexStage &s0 = g_snap.stage[0];
 	const Rs2FfpTexStage &s1 = g_snap.stage[1];
 
+	// alpharef stays a snapshot uniform (live value is 0). Packing it as 8
+	// bits overflowed uint64_t and made the TCI put a <<64 UB.
+	constexpr unsigned kKeyBits =
+	    4 + 1 + 1 + 1 + 2 + 2 + 1 + 1 + 4 + 1 + 4 + 1 + 4 + 4 + 1 + 1 + 1 +
+	    4 + 4 + 2 + 2 + 4 + 2 + 2 + 2 + 1;
+	static_assert(kKeyBits <= 64, "shader key overflow");
+
 	std::uint64_t k = 0;
 	unsigned bit = 0;
 	const auto put = [&](std::uint64_t v, unsigned n) {
+		if (n == 0 || bit >= 64 || n > 64u - bit) return;
 		k |= (v & ((1ull << n) - 1ull)) << bit;
 		bit += n;
 	};
@@ -378,7 +386,6 @@ std::uint64_t rs2_ffp_shader_key(DWORD fvf) {
 	put(rs.zfunc, 4);
 	put(rs.alphatest ? 1u : 0u, 1);
 	put(rs.alphafunc, 4);
-	put(rs.alpharef, 8);
 	put(rs.alphablend ? 1u : 0u, 1);
 	put(rs.srcblend, 4);
 	put(rs.destblend, 4);

--- a/port/ffp_state.cpp
+++ b/port/ffp_state.cpp
@@ -1,0 +1,399 @@
+// M3 core render-state shadow. Unknown / deferred states fail loudly.
+
+#include "ffp_state.h"
+
+#include "ffp_fvf.h"
+
+#include <cstdio>
+
+namespace {
+
+Rs2FfpSnapshot g_snap{};
+
+void apply_init_defaults(Rs2FfpSnapshot *s) {
+	s->rs.lighting = TRUE;
+	s->rs.ambient = 0xff808080u;
+	s->rs.specular = TRUE;
+	s->rs.cullmode = D3DCULL_CCW;
+	s->rs.shademode = D3DSHADE_GOURAUD;
+	s->rs.normalize = TRUE;
+	s->rs.zenable = TRUE;
+	s->rs.zwrite = TRUE;
+	s->rs.zfunc = D3DCMP_LESSEQUAL;
+	s->rs.alphatest = FALSE;
+	s->rs.alphafunc = D3DCMP_ALWAYS;
+	s->rs.alpharef = 0;
+	s->rs.alphablend = TRUE;
+	s->rs.srcblend = D3DBLEND_SRCALPHA;
+	s->rs.destblend = D3DBLEND_INVSRCALPHA;
+	s->rs.diffuse_src = D3DMCS_COLOR1;
+	s->rs.ambient_src = D3DMCS_MATERIAL;
+	s->rs.fogenable = FALSE;
+	s->rs.fogcolor = 0;
+	s->rs.fogvertexmode = D3DFOG_NONE;
+	s->rs.fogtablemode = D3DFOG_NONE;
+	s->rs.fogstart = 0;
+	s->rs.fogend = 0;
+
+	for (int i = 0; i < 2; ++i) {
+		Rs2FfpTexStage &st = s->stage[i];
+		st.colorop = (i == 0) ? D3DTOP_MODULATE : D3DTOP_DISABLE;
+		st.colorarg1 = D3DTA_TEXTURE;
+		st.colorarg2 = (i == 0) ? D3DTA_DIFFUSE : D3DTA_CURRENT;
+		st.alphaop = (i == 0) ? D3DTOP_MODULATE : D3DTOP_DISABLE;
+		st.alphaarg1 = D3DTA_TEXTURE;
+		st.alphaarg2 = (i == 0) ? D3DTA_DIFFUSE : D3DTA_CURRENT;
+		st.magfilter = D3DTEXF_POINT;
+		st.minfilter = D3DTEXF_POINT;
+		st.mipfilter = D3DTEXF_POINT;
+		st.addressu = D3DTADDRESS_WRAP;
+		st.addressv = D3DTADDRESS_WRAP;
+		st.textransform = D3DTTFF_DISABLE;
+		st.texcoordindex = D3DTSS_TCI_PASSTHRU;
+	}
+}
+
+struct InitOnce {
+	InitOnce() { apply_init_defaults(&g_snap); }
+};
+
+const InitOnce kInit;
+
+HRESULT unknown_fail(const char *what, unsigned long v) {
+#ifndef NDEBUG
+	std::fprintf(stderr, "ffp_state: unknown %s 0x%lx\n", what, v);
+#else
+	(void)what;
+	(void)v;
+#endif
+	return E_FAIL;
+}
+
+unsigned fvf_index(DWORD fvf) {
+	switch (fvf) {
+	case RS2_FVF_TL:
+		return 0;
+	case RS2_FVF_TLX:
+		return 1;
+	case RS2_FVF_L:
+		return 2;
+	case RS2_FVF_LX:
+		return 3;
+	case RS2_FVF_LX2:
+		return 4;
+	case RS2_FVF_N:
+		return 5;
+	case RS2_FVF_NX:
+		return 6;
+	case RS2_FVF_NX2:
+		return 7;
+	default:
+		return 0xF;
+	}
+}
+
+}  // namespace
+
+void rs2_ffp_state_reset() { apply_init_defaults(&g_snap); }
+
+const Rs2FfpSnapshot *rs2_ffp_state_get() { return &g_snap; }
+
+HRESULT rs2_ffp_set_render_state(D3DRENDERSTATETYPE type, DWORD value) {
+	switch (type) {
+	case D3DRS_LIGHTING:
+		g_snap.rs.lighting = value;
+		return S_OK;
+	case D3DRS_AMBIENT:
+		g_snap.rs.ambient = value;
+		return S_OK;
+	case D3DRS_SPECULARENABLE:
+		g_snap.rs.specular = value;
+		return S_OK;
+	case D3DRS_CULLMODE:
+		g_snap.rs.cullmode = value;
+		return S_OK;
+	case D3DRS_SHADEMODE:
+		g_snap.rs.shademode = value;
+		return S_OK;
+	case D3DRS_NORMALIZENORMALS:
+		g_snap.rs.normalize = value;
+		return S_OK;
+	case D3DRS_ZENABLE:
+		g_snap.rs.zenable = value;
+		return S_OK;
+	case D3DRS_ZWRITEENABLE:
+		g_snap.rs.zwrite = value;
+		return S_OK;
+	case D3DRS_ZFUNC:
+		g_snap.rs.zfunc = value;
+		return S_OK;
+	case D3DRS_ALPHATESTENABLE:
+		g_snap.rs.alphatest = value;
+		return S_OK;
+	case D3DRS_ALPHAFUNC:
+		g_snap.rs.alphafunc = value;
+		return S_OK;
+	case D3DRS_ALPHAREF:
+		g_snap.rs.alpharef = value;
+		return S_OK;
+	case D3DRS_ALPHABLENDENABLE:
+		g_snap.rs.alphablend = value;
+		return S_OK;
+	case D3DRS_SRCBLEND:
+		g_snap.rs.srcblend = value;
+		return S_OK;
+	case D3DRS_DESTBLEND:
+		g_snap.rs.destblend = value;
+		return S_OK;
+	case D3DRS_DIFFUSEMATERIALSOURCE:
+		g_snap.rs.diffuse_src = value;
+		return S_OK;
+	case D3DRS_AMBIENTMATERIALSOURCE:
+		g_snap.rs.ambient_src = value;
+		return S_OK;
+	case D3DRS_FOGENABLE:
+		g_snap.rs.fogenable = value;
+		return S_OK;
+	case D3DRS_FOGCOLOR:
+		g_snap.rs.fogcolor = value;
+		return S_OK;
+	case D3DRS_FOGVERTEXMODE:
+		g_snap.rs.fogvertexmode = value;
+		return S_OK;
+	case D3DRS_FOGTABLEMODE:
+		g_snap.rs.fogtablemode = value;
+		return S_OK;
+	case D3DRS_FOGSTART:
+		g_snap.rs.fogstart = value;
+		return S_OK;
+	case D3DRS_FOGEND:
+		g_snap.rs.fogend = value;
+		return S_OK;
+	default:
+		return unknown_fail("D3DRS", static_cast<unsigned long>(type));
+	}
+}
+
+HRESULT rs2_ffp_get_render_state(D3DRENDERSTATETYPE type, DWORD *value) {
+	if (!value) return E_FAIL;
+	switch (type) {
+	case D3DRS_LIGHTING:
+		*value = g_snap.rs.lighting;
+		return S_OK;
+	case D3DRS_AMBIENT:
+		*value = g_snap.rs.ambient;
+		return S_OK;
+	case D3DRS_SPECULARENABLE:
+		*value = g_snap.rs.specular;
+		return S_OK;
+	case D3DRS_CULLMODE:
+		*value = g_snap.rs.cullmode;
+		return S_OK;
+	case D3DRS_SHADEMODE:
+		*value = g_snap.rs.shademode;
+		return S_OK;
+	case D3DRS_NORMALIZENORMALS:
+		*value = g_snap.rs.normalize;
+		return S_OK;
+	case D3DRS_ZENABLE:
+		*value = g_snap.rs.zenable;
+		return S_OK;
+	case D3DRS_ZWRITEENABLE:
+		*value = g_snap.rs.zwrite;
+		return S_OK;
+	case D3DRS_ZFUNC:
+		*value = g_snap.rs.zfunc;
+		return S_OK;
+	case D3DRS_ALPHATESTENABLE:
+		*value = g_snap.rs.alphatest;
+		return S_OK;
+	case D3DRS_ALPHAFUNC:
+		*value = g_snap.rs.alphafunc;
+		return S_OK;
+	case D3DRS_ALPHAREF:
+		*value = g_snap.rs.alpharef;
+		return S_OK;
+	case D3DRS_ALPHABLENDENABLE:
+		*value = g_snap.rs.alphablend;
+		return S_OK;
+	case D3DRS_SRCBLEND:
+		*value = g_snap.rs.srcblend;
+		return S_OK;
+	case D3DRS_DESTBLEND:
+		*value = g_snap.rs.destblend;
+		return S_OK;
+	case D3DRS_DIFFUSEMATERIALSOURCE:
+		*value = g_snap.rs.diffuse_src;
+		return S_OK;
+	case D3DRS_AMBIENTMATERIALSOURCE:
+		*value = g_snap.rs.ambient_src;
+		return S_OK;
+	case D3DRS_FOGENABLE:
+		*value = g_snap.rs.fogenable;
+		return S_OK;
+	case D3DRS_FOGCOLOR:
+		*value = g_snap.rs.fogcolor;
+		return S_OK;
+	case D3DRS_FOGVERTEXMODE:
+		*value = g_snap.rs.fogvertexmode;
+		return S_OK;
+	case D3DRS_FOGTABLEMODE:
+		*value = g_snap.rs.fogtablemode;
+		return S_OK;
+	case D3DRS_FOGSTART:
+		*value = g_snap.rs.fogstart;
+		return S_OK;
+	case D3DRS_FOGEND:
+		*value = g_snap.rs.fogend;
+		return S_OK;
+	default:
+		*value = 0;
+		return unknown_fail("D3DRS", static_cast<unsigned long>(type));
+	}
+}
+
+HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
+                                        DWORD value) {
+	if (stage > 1) return unknown_fail("stage", static_cast<unsigned long>(stage));
+	Rs2FfpTexStage &st = g_snap.stage[stage];
+	switch (type) {
+	case D3DTSS_COLOROP:
+		st.colorop = value;
+		return S_OK;
+	case D3DTSS_COLORARG1:
+		st.colorarg1 = value;
+		return S_OK;
+	case D3DTSS_COLORARG2:
+		st.colorarg2 = value;
+		return S_OK;
+	case D3DTSS_ALPHAOP:
+		st.alphaop = value;
+		return S_OK;
+	case D3DTSS_ALPHAARG1:
+		st.alphaarg1 = value;
+		return S_OK;
+	case D3DTSS_ALPHAARG2:
+		st.alphaarg2 = value;
+		return S_OK;
+	case D3DTSS_MAGFILTER:
+		st.magfilter = value;
+		return S_OK;
+	case D3DTSS_MINFILTER:
+		st.minfilter = value;
+		return S_OK;
+	case D3DTSS_MIPFILTER:
+		st.mipfilter = value;
+		return S_OK;
+	case D3DTSS_ADDRESSU:
+		st.addressu = value;
+		return S_OK;
+	case D3DTSS_ADDRESSV:
+		st.addressv = value;
+		return S_OK;
+	case D3DTSS_TEXTURETRANSFORMFLAGS:
+		st.textransform = value;
+		return S_OK;
+	case D3DTSS_TEXCOORDINDEX:
+		st.texcoordindex = value;
+		return S_OK;
+	default:
+		return unknown_fail("D3DTSS", static_cast<unsigned long>(type));
+	}
+}
+
+HRESULT rs2_ffp_get_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
+                                        DWORD *value) {
+	if (!value || stage > 1)
+		return unknown_fail("stage", static_cast<unsigned long>(stage));
+	const Rs2FfpTexStage &st = g_snap.stage[stage];
+	switch (type) {
+	case D3DTSS_COLOROP:
+		*value = st.colorop;
+		return S_OK;
+	case D3DTSS_COLORARG1:
+		*value = st.colorarg1;
+		return S_OK;
+	case D3DTSS_COLORARG2:
+		*value = st.colorarg2;
+		return S_OK;
+	case D3DTSS_ALPHAOP:
+		*value = st.alphaop;
+		return S_OK;
+	case D3DTSS_ALPHAARG1:
+		*value = st.alphaarg1;
+		return S_OK;
+	case D3DTSS_ALPHAARG2:
+		*value = st.alphaarg2;
+		return S_OK;
+	case D3DTSS_MAGFILTER:
+		*value = st.magfilter;
+		return S_OK;
+	case D3DTSS_MINFILTER:
+		*value = st.minfilter;
+		return S_OK;
+	case D3DTSS_MIPFILTER:
+		*value = st.mipfilter;
+		return S_OK;
+	case D3DTSS_ADDRESSU:
+		*value = st.addressu;
+		return S_OK;
+	case D3DTSS_ADDRESSV:
+		*value = st.addressv;
+		return S_OK;
+	case D3DTSS_TEXTURETRANSFORMFLAGS:
+		*value = st.textransform;
+		return S_OK;
+	case D3DTSS_TEXCOORDINDEX:
+		*value = st.texcoordindex;
+		return S_OK;
+	default:
+		*value = 0;
+		return unknown_fail("D3DTSS", static_cast<unsigned long>(type));
+	}
+}
+
+std::uint64_t rs2_ffp_shader_key(DWORD fvf) {
+	const unsigned idx = fvf_index(fvf);
+	if (idx > 7) return 0;
+
+	const Rs2FfpRs &rs = g_snap.rs;
+	const Rs2FfpTexStage &s0 = g_snap.stage[0];
+	const Rs2FfpTexStage &s1 = g_snap.stage[1];
+
+	std::uint64_t k = 0;
+	unsigned bit = 0;
+	const auto put = [&](std::uint64_t v, unsigned n) {
+		k |= (v & ((1ull << n) - 1ull)) << bit;
+		bit += n;
+	};
+
+	put(idx, 4);
+	put(rs.lighting ? 1u : 0u, 1);
+	put(rs.specular ? 1u : 0u, 1);
+	put(rs.normalize ? 1u : 0u, 1);
+	put(rs.shademode, 2);
+	put(rs.cullmode, 2);
+	put(rs.zenable ? 1u : 0u, 1);
+	put(rs.zwrite ? 1u : 0u, 1);
+	put(rs.zfunc, 4);
+	put(rs.alphatest ? 1u : 0u, 1);
+	put(rs.alphafunc, 4);
+	put(rs.alpharef, 8);
+	put(rs.alphablend ? 1u : 0u, 1);
+	put(rs.srcblend, 4);
+	put(rs.destblend, 4);
+	put(rs.diffuse_src, 1);
+	put(rs.ambient_src, 1);
+	put(rs.fogenable ? 1u : 0u, 1);
+	put(s0.colorop, 4);
+	put(s0.alphaop, 4);
+	put(s0.textransform, 2);
+	put(s0.magfilter, 2);
+	put(s1.colorop, 4);
+	put(s1.colorarg1, 2);
+	put(s1.colorarg2, 2);
+	put(s1.textransform, 2);
+	put((s1.texcoordindex & D3DTSS_TCI_CAMERASPACENORMAL) ? 1u : 0u, 1);
+	(void)bit;
+	return k;
+}

--- a/port/ffp_state.h
+++ b/port/ffp_state.h
@@ -65,6 +65,6 @@ HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE ty
 HRESULT rs2_ffp_get_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
                                         DWORD *value);
 
-// Packed FVF + core-state key. Ambient / fog distances stay as uniforms
-// on the snapshot, not variant bits. Unknown / deferred FVF returns 0.
+// Packed FVF + core-state key. Ambient / alpharef / fog distances stay as
+// uniforms on the snapshot, not variant bits. Unknown / deferred FVF returns 0.
 std::uint64_t rs2_ffp_shader_key(DWORD fvf);

--- a/port/ffp_state.h
+++ b/port/ffp_state.h
@@ -1,0 +1,70 @@
+// M3 core D3DRS / D3DTSS shadow + FVF+state shader key (#80, parent #5).
+// No GLSL / GL. Deferrable stencil / flare / particle / FVF_S stay rejected.
+
+#pragma once
+
+#include <d3d8.h>
+
+#include <cstdint>
+
+struct Rs2FfpTexStage {
+	DWORD colorop;
+	DWORD colorarg1;
+	DWORD colorarg2;
+	DWORD alphaop;
+	DWORD alphaarg1;
+	DWORD alphaarg2;
+	DWORD magfilter;
+	DWORD minfilter;
+	DWORD mipfilter;
+	DWORD addressu;
+	DWORD addressv;
+	DWORD textransform;
+	DWORD texcoordindex;
+};
+
+struct Rs2FfpRs {
+	DWORD lighting;
+	DWORD ambient;
+	DWORD specular;
+	DWORD cullmode;
+	DWORD shademode;
+	DWORD normalize;
+	DWORD zenable;
+	DWORD zwrite;
+	DWORD zfunc;
+	DWORD alphatest;
+	DWORD alphafunc;
+	DWORD alpharef;
+	DWORD alphablend;
+	DWORD srcblend;
+	DWORD destblend;
+	DWORD diffuse_src;
+	DWORD ambient_src;
+	DWORD fogenable;
+	DWORD fogcolor;
+	DWORD fogvertexmode;
+	DWORD fogtablemode;
+	DWORD fogstart;
+	DWORD fogend;
+};
+
+struct Rs2FfpSnapshot {
+	Rs2FfpRs rs;
+	Rs2FfpTexStage stage[2];
+};
+
+// Restore InitRenderState defaults (lib/graphic.cpp).
+void rs2_ffp_state_reset();
+const Rs2FfpSnapshot *rs2_ffp_state_get();
+
+HRESULT rs2_ffp_set_render_state(D3DRENDERSTATETYPE type, DWORD value);
+HRESULT rs2_ffp_get_render_state(D3DRENDERSTATETYPE type, DWORD *value);
+HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
+                                        DWORD value);
+HRESULT rs2_ffp_get_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
+                                        DWORD *value);
+
+// Packed FVF + core-state key. Ambient / fog distances stay as uniforms
+// on the snapshot, not variant bits. Unknown / deferred FVF returns 0.
+std::uint64_t rs2_ffp_shader_key(DWORD fvf);

--- a/port/ffp_state_test.cpp
+++ b/port/ffp_state_test.cpp
@@ -128,12 +128,28 @@ bool key_toggles_ok() {
 	const std::uint64_t env = rs2_ffp_shader_key(RS2_FVF_NX);
 	if (!expect(env != base && env != atest, "env-map changes key")) return false;
 
+	// TCI/env-map must fork the key by itself, not only via COLOROP/args.
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_texture_stage_state(
+	                1, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACENORMAL) == S_OK,
+	            "tci only"))
+		return false;
+	const std::uint64_t tci = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(tci != base && tci != 0, "TCI changes key")) return false;
+
 	// Ambient is a uniform; it must not fork the shader variant key.
 	rs2_ffp_state_reset();
 	if (!expect(rs2_ffp_set_render_state(D3DRS_AMBIENT, 0xff112233u) == S_OK,
 	            "ambient"))
 		return false;
 	if (!expect(rs2_ffp_shader_key(RS2_FVF_NX) == base, "ambient not in key"))
+		return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_render_state(D3DRS_ALPHAREF, 0x80) == S_OK,
+	            "alpharef"))
+		return false;
+	if (!expect(rs2_ffp_shader_key(RS2_FVF_NX) == base, "alpharef not in key"))
 		return false;
 	return true;
 }

--- a/port/ffp_state_test.cpp
+++ b/port/ffp_state_test.cpp
@@ -1,0 +1,203 @@
+// M3 core FFP state shadow / shader-key self-test (#80).
+
+#include "ffp_fvf.h"
+#include "ffp_state.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+using Color = std::uint32_t;
+
+struct VtxTL {
+	float x, y, z, rhw;
+	Color d;
+};
+
+static_assert(sizeof(VtxTL) == 20, "Win32 D3DCOLOR packing");
+
+const DWORD kFvfs[] = {RS2_FVF_TL, RS2_FVF_TLX, RS2_FVF_L,  RS2_FVF_LX,
+                       RS2_FVF_LX2, RS2_FVF_N,   RS2_FVF_NX, RS2_FVF_NX2};
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool defaults_ok() {
+	rs2_ffp_state_reset();
+	const Rs2FfpSnapshot *s = rs2_ffp_state_get();
+	if (!expect(s != nullptr, "snapshot")) return false;
+	if (!expect(s->rs.lighting == TRUE && s->rs.ambient == 0xff808080u &&
+	                s->rs.specular == TRUE && s->rs.shademode == D3DSHADE_GOURAUD &&
+	                s->rs.cullmode == D3DCULL_CCW && s->rs.normalize == TRUE &&
+	                s->rs.zenable == TRUE && s->rs.zwrite == TRUE &&
+	                s->rs.zfunc == D3DCMP_LESSEQUAL && s->rs.alphatest == FALSE &&
+	                s->rs.alphablend == TRUE && s->rs.srcblend == D3DBLEND_SRCALPHA &&
+	                s->rs.destblend == D3DBLEND_INVSRCALPHA &&
+	                s->rs.fogenable == FALSE,
+	            "InitRenderState rs"))
+		return false;
+	if (!expect(s->stage[0].colorop == D3DTOP_MODULATE &&
+	                s->stage[0].colorarg1 == D3DTA_TEXTURE &&
+	                s->stage[0].colorarg2 == D3DTA_DIFFUSE &&
+	                s->stage[0].alphaop == D3DTOP_MODULATE &&
+	                s->stage[0].magfilter == D3DTEXF_POINT &&
+	                s->stage[1].colorop == D3DTOP_DISABLE &&
+	                s->stage[1].texcoordindex == D3DTSS_TCI_PASSTHRU,
+	            "InitRenderState tss"))
+		return false;
+
+	DWORD lighting = 0;
+	if (!expect(rs2_ffp_get_render_state(D3DRS_LIGHTING, &lighting) == S_OK &&
+	                lighting == TRUE,
+	            "get lighting"))
+		return false;
+	return true;
+}
+
+bool hook_and_unknown_ok() {
+	rs2_ffp_state_reset();
+	IDirect3DDevice8 dev;
+	if (!expect(dev.SetRenderState(D3DRS_LIGHTING, FALSE) == S_OK, "hook set rs"))
+		return false;
+	DWORD lighting = TRUE;
+	if (!expect(dev.GetRenderState(D3DRS_LIGHTING, &lighting) == S_OK &&
+	                lighting == FALSE,
+	            "hook get rs"))
+		return false;
+	if (!expect(dev.SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_MODULATE) ==
+	                S_OK,
+	            "hook tss"))
+		return false;
+
+	if (!expect(dev.SetRenderState(D3DRS_STENCILENABLE, TRUE) != S_OK,
+	            "stencil deferred"))
+		return false;
+	if (!expect(dev.SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_MODULATE) !=
+	                S_OK,
+	            "stage 2 unknown"))
+		return false;
+	if (!expect(rs2_ffp_set_render_state(static_cast<D3DRENDERSTATETYPE>(999), 0) !=
+	                S_OK,
+	            "unknown D3DRS"))
+		return false;
+	return true;
+}
+
+bool key_toggles_ok() {
+	rs2_ffp_state_reset();
+	const std::uint64_t base = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(base != 0, "base key")) return false;
+	if (!expect(rs2_ffp_shader_key(RS2_FVF_NX) == base, "key stable")) return false;
+	if (!expect(rs2_ffp_shader_key(RS2_FVF_S) == 0, "FVF_S rejected")) return false;
+
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, FALSE) == S_OK,
+	            "lighting off"))
+		return false;
+	const std::uint64_t lit_off = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(lit_off != base && lit_off != 0, "lighting changes key")) return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_render_state(D3DRS_ALPHATESTENABLE, TRUE) == S_OK &&
+	                rs2_ffp_set_render_state(D3DRS_ALPHAFUNC, D3DCMP_GREATER) ==
+	                    S_OK &&
+	                rs2_ffp_set_render_state(D3DRS_ALPHAREF, 0) == S_OK,
+	            "alpha test"))
+		return false;
+	const std::uint64_t atest = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(atest != base && atest != lit_off, "alpha test changes key"))
+		return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_texture_stage_state(1, D3DTSS_COLOROP,
+	                                               D3DTOP_MODULATE) == S_OK &&
+	                rs2_ffp_set_texture_stage_state(1, D3DTSS_COLORARG1,
+	                                               D3DTA_TEXTURE) == S_OK &&
+	                rs2_ffp_set_texture_stage_state(1, D3DTSS_COLORARG2,
+	                                               D3DTA_CURRENT) == S_OK &&
+	                rs2_ffp_set_texture_stage_state(
+	                    1, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2) == S_OK &&
+	                rs2_ffp_set_texture_stage_state(
+	                    1, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACENORMAL) ==
+	                    S_OK,
+	            "env stage"))
+		return false;
+	const std::uint64_t env = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(env != base && env != atest, "env-map changes key")) return false;
+
+	// Ambient is a uniform; it must not fork the shader variant key.
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_render_state(D3DRS_AMBIENT, 0xff112233u) == S_OK,
+	            "ambient"))
+		return false;
+	if (!expect(rs2_ffp_shader_key(RS2_FVF_NX) == base, "ambient not in key"))
+		return false;
+	return true;
+}
+
+bool fvf_keys_ok() {
+	rs2_ffp_state_reset();
+	std::uint64_t keys[8];
+	for (int i = 0; i < 8; ++i) {
+		keys[i] = rs2_ffp_shader_key(kFvfs[i]);
+		if (!expect(keys[i] != 0, "fvf key")) return false;
+		if (!expect(rs2_ffp_shader_key(kFvfs[i]) == keys[i], "fvf key stable"))
+			return false;
+	}
+	for (int i = 0; i < 8; ++i) {
+		for (int j = i + 1; j < 8; ++j) {
+			if (!expect(keys[i] != keys[j], "fvf keys distinct")) return false;
+		}
+	}
+	return true;
+}
+
+bool up_snapshot_ok() {
+	rs2_ffp_state_reset();
+	rs2_ffp_up_reset();
+	VtxTL verts[2] = {{0, 0, 0, 1, 0xFFFFFFFFu}, {10, 5, 0, 1, 0xFF00FF00u}};
+
+	if (!expect(rs2_ffp_set_fvf(RS2_FVF_TL) == S_OK, "set FVF_TL")) return false;
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, FALSE) == S_OK,
+	            "up lighting"))
+		return false;
+	const std::uint64_t want = rs2_ffp_shader_key(RS2_FVF_TL);
+	if (!expect(rs2_ffp_draw_primitive_up(D3DPT_LINELIST, 1, verts, sizeof(VtxTL)) ==
+	                S_OK,
+	            "up record"))
+		return false;
+
+	const Rs2FfpUpRecord *rec = rs2_ffp_up_last();
+	if (!expect(rec != nullptr && rec->shader_key == want && want != 0,
+	            "up holds key"))
+		return false;
+
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, TRUE) == S_OK,
+	            "lighting restore"))
+		return false;
+	if (!expect(rec->shader_key == want && rec->shader_key !=
+	                                          rs2_ffp_shader_key(RS2_FVF_TL),
+	            "up key frozen"))
+		return false;
+	return true;
+}
+
+int self_test() {
+	if (!defaults_ok()) return 1;
+	if (!hook_and_unknown_ok()) return 1;
+	if (!key_toggles_ok()) return 1;
+	if (!fvf_keys_ok()) return 1;
+	if (!up_snapshot_ok()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -50,23 +50,24 @@ typedef DWORD D3DTEXTURETRANSFORMFLAGS;
 #define D3DCULL_CW 2
 #define D3DCULL_CCW 3
 
-#define D3DRS_LIGHTING 7
-#define D3DRS_AMBIENT 27
-#define D3DRS_SPECULARENABLE 29
-#define D3DRS_CULLMODE 22
-#define D3DRS_SHADEMODE 9
-#define D3DRS_NORMALIZENORMALS 21
+// D3D8 enumerants (unique so the FFP shadow can switch on type).
 #define D3DRS_ZENABLE 7
+#define D3DRS_SHADEMODE 9
 #define D3DRS_ZWRITEENABLE 14
-#define D3DRS_ALPHABLENDENABLE 27
 #define D3DRS_SRCBLEND 19
 #define D3DRS_DESTBLEND 20
+#define D3DRS_NORMALIZENORMALS 21
+#define D3DRS_CULLMODE 22
+#define D3DRS_SPECULARENABLE 29
+#define D3DRS_ALPHABLENDENABLE 27
 #define D3DRS_FOGENABLE 28
 #define D3DRS_FOGCOLOR 34
-#define D3DRS_FOGVERTEXMODE 35
-#define D3DRS_FOGTABLEMODE 36
+#define D3DRS_FOGTABLEMODE 35
 #define D3DRS_FOGSTART 36
 #define D3DRS_FOGEND 37
+#define D3DRS_LIGHTING 137
+#define D3DRS_AMBIENT 139
+#define D3DRS_FOGVERTEXMODE 140
 #define D3DRS_FOGDENSITY 38
 #define D3DRS_STENCILENABLE 52
 #define D3DRS_STENCILREF 57
@@ -216,13 +217,22 @@ typedef IDirect3DTexture8* LPDIRECT3DTEXTURE8;
 typedef IDirect3DSurface8* LPDIRECT3DSURFACE8;
 typedef IDirect3DVertexBuffer8* LPDIRECT3DVERTEXBUFFER8;
 
+// M3 core FFP shadow (#80). Bodies in port/ffp_state.cpp.
+HRESULT rs2_ffp_set_render_state(D3DRENDERSTATETYPE type, DWORD value);
+HRESULT rs2_ffp_get_render_state(D3DRENDERSTATETYPE type, DWORD* value);
+HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
+                                        DWORD value);
+
 struct IDirect3DDevice8 : IUnknown {
-  HRESULT SetRenderState(D3DRENDERSTATETYPE, DWORD) { return S_OK; }
-  HRESULT GetRenderState(D3DRENDERSTATETYPE, DWORD* state) {
-    if (state) *state = 0;
-    return S_OK;
+  HRESULT SetRenderState(D3DRENDERSTATETYPE type, DWORD value) {
+    return rs2_ffp_set_render_state(type, value);
   }
-  HRESULT SetTextureStageState(DWORD, D3DTEXTURESTAGESTATETYPE, DWORD) { return S_OK; }
+  HRESULT GetRenderState(D3DRENDERSTATETYPE type, DWORD* state) {
+    return rs2_ffp_get_render_state(type, state);
+  }
+  HRESULT SetTextureStageState(DWORD stage, D3DTEXTURESTAGESTATETYPE type, DWORD value) {
+    return rs2_ffp_set_texture_stage_state(stage, type, value);
+  }
   HRESULT SetTransform(D3DTRANSFORMSTATETYPE, const void*) { return S_OK; }
   HRESULT SetMaterial(const void*) { return S_OK; }
   HRESULT SetLight(DWORD, const void*) { return S_OK; }


### PR DESCRIPTION
## Summary
- Implement `port/ffp_state.*` to shadow the M3-required `D3DRS_*` / stage-0 / stage-1-env set (`InitRenderState` defaults) and pack a stable FVF+state shader key. Unknown / deferred states (`FVF_S`, stencil, stage > 1) return `E_FAIL`.
- Hook `IDirect3DDevice8::SetRenderState` / `GetRenderState` / `SetTextureStageState` in `port/stub/d3d8.h`. Draw stays a no-op. Each `DrawPrimitiveUP` ring record now stores the shader key from the current snapshot.
- Unique-ize colliding stub `D3DRS_*` numbers (`LIGHTING`/`AMBIENT`/`FOGVERTEXMODE`/`FOGTABLEMODE`) so the shadow can switch on type. `rs2_ffp_state_self_test` covers defaults, toggles, all 8 FVFs, and UP association.

Closes #80

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_ffp_state_self_test` and `rs2_ffp_fvf_self_test`)
- [ ] CI check preset on this PR


Made with [Cursor](https://cursor.com)