### PR TITLE
Add PCM-only RIFF WAVE parser in port/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,3 +261,14 @@ target_compile_options(rs2_text_test PRIVATE -Wall -Wextra)
 target_link_libraries(rs2_text_test PRIVATE Iconv::Iconv)
 
 add_test(NAME rs2_text_self_test COMMAND rs2_text_test --self-test)
+
+# PCM-only RIFF WAVE parser (#81). Does not swap CWave::Load or link OpenAL.
+add_executable(rs2_wav_pcm_test port/wav_pcm_test.cpp port/wav_pcm.cpp)
+target_include_directories(rs2_wav_pcm_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_wav_pcm_test PRIVATE cxx_std_17)
+target_compile_options(rs2_wav_pcm_test PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_wav_pcm_self_test COMMAND rs2_wav_pcm_test --self-test)
+add_test(NAME rs2_wav_pcm_distribution COMMAND rs2_wav_pcm_test
+  "${CMAKE_SOURCE_DIR}/Distribution")
+set_tests_properties(rs2_wav_pcm_distribution PROPERTIES SKIP_RETURN_CODE 77)

--- a/docs/porting/audio-seams.md
+++ b/docs/porting/audio-seams.md
@@ -313,4 +313,14 @@ rg -n --glob '!build/**' --glob '!.git/**' --glob '!Distribution/**' --glob '!po
 
 Expect: `lib/sound.cpp` / `sound.h`, `lib/wave.cpp` / `wave.h`, `lib/wave_stream.cpp` / `wave_stream.h`, `lib/headers.h` typedefs, `lib/main.cpp` init, `RailSim2.cpp` / `CGameMode.cpp` listener, `CConfigMode.cpp` `svs.pDS` check, `CWaveArray` / `CSoundEffector` / skin / rail wrappers, and dead `lib/music.cpp`. No `waveIn*` / `waveOut*`.
 
-`./scripts/check.sh` must stay green (docs only).
+`./scripts/check.sh` must stay green. `rs2_wav_pcm_self_test` / `rs2_wav_pcm_distribution` cover the PCM field table (#81).
+
+## Port PCM parser (`port/wav_pcm`)
+
+- **Issue**: [#81](https://github.com/lollipop-onl/railsim2-portable/issues/81) (parent [#7](https://github.com/lollipop-onl/railsim2-portable/issues/7))
+- **Entry**: `rs2_wav_pcm_parse` / `rs2_wav_pcm_parse_file` in `port/wav_pcm.h`
+- **Result**: `Rs2WavPcm` holds `wFormatTag`, `nChannels`, `nSamplesPerSec`, `nAvgBytesPerSec`, `nBlockAlign`, `wBitsPerSample`, and the raw `data` payload
+
+This is the portable stand-in for the [mmio* contract](#closed-mmio-set-wav-parser). It requires RIFF form `WAVE`, accepts only `wFormatTag == WAVE_FORMAT_PCM` (1), and copies `fmt ` + `data` fields from the [minimum field table](#minimum-fields-a-replacement-parser-must-honor). Other chunks (`fact`, `LIST`, pad bytes) are skipped; extra `fmt` bytes (`cbSize`) are ignored. Non-PCM, truncated RIFF, missing `fmt` / `data`, or a short `data` payload fail with `bool` + reason string.
+
+`CWave::Load` still calls `mmio*`. A later `#7` slice should call this API from `Load` and leave `lib/wave.cpp` off the allowlist until then. Do not link OpenAL in the `check` preset.

--- a/port/wav_pcm.cpp
+++ b/port/wav_pcm.cpp
@@ -1,0 +1,145 @@
+// PCM-only RIFF WAVE / fmt / data reader. Skips fact and other extra chunks.
+
+#include "wav_pcm.h"
+
+#include <cstring>
+#include <fstream>
+#include <iterator>
+
+namespace {
+
+bool fail(std::string *err, const char *msg) {
+	if (err) {
+		*err = msg;
+	}
+	return false;
+}
+
+bool read_u16(const unsigned char *p, std::size_t n, std::size_t off,
+              std::uint16_t *out) {
+	if (off + 2 > n) {
+		return false;
+	}
+	*out = static_cast<std::uint16_t>(p[off] | (static_cast<unsigned>(p[off + 1]) << 8));
+	return true;
+}
+
+bool read_u32(const unsigned char *p, std::size_t n, std::size_t off,
+              std::uint32_t *out) {
+	if (off + 4 > n) {
+		return false;
+	}
+	*out = static_cast<std::uint32_t>(p[off]) |
+	       (static_cast<std::uint32_t>(p[off + 1]) << 8) |
+	       (static_cast<std::uint32_t>(p[off + 2]) << 16) |
+	       (static_cast<std::uint32_t>(p[off + 3]) << 24);
+	return true;
+}
+
+bool id_is(const unsigned char *p, const char *four) {
+	return std::memcmp(p, four, 4) == 0;
+}
+
+}  // namespace
+
+bool rs2_wav_pcm_parse(const void *bytes, std::size_t size, Rs2WavPcm *out,
+                       std::string *err) {
+	if (!out) {
+		return fail(err, "null output");
+	}
+	*out = Rs2WavPcm{};
+	if (!bytes) {
+		return fail(err, "null buffer");
+	}
+	const auto *p = static_cast<const unsigned char *>(bytes);
+	if (size < 12) {
+		return fail(err, "truncated RIFF header");
+	}
+	if (!id_is(p, "RIFF") || !id_is(p + 8, "WAVE")) {
+		return fail(err, "not a RIFF WAVE");
+	}
+
+	std::uint32_t riff_size = 0;
+	if (!read_u32(p, size, 4, &riff_size)) {
+		return fail(err, "truncated RIFF size");
+	}
+	const std::size_t form_end = static_cast<std::size_t>(8) + riff_size;
+	if (form_end < 12 || form_end > size) {
+		return fail(err, "truncated RIFF");
+	}
+
+	bool have_fmt = false;
+	bool have_data = false;
+	Rs2WavPcm wav{};
+	std::size_t off = 12;
+	while (off + 8 <= form_end) {
+		const unsigned char *cid = p + off;
+		std::uint32_t cksize = 0;
+		if (!read_u32(p, size, off + 4, &cksize)) {
+			return fail(err, "truncated chunk header");
+		}
+		const std::size_t payload = off + 8;
+		if (cksize > form_end - payload) {
+			return fail(err, "truncated chunk");
+		}
+
+		if (id_is(cid, "fmt ")) {
+			if (cksize < 16) {
+				return fail(err, "fmt chunk too small");
+			}
+			if (!read_u16(p, size, payload, &wav.wFormatTag) ||
+			    !read_u16(p, size, payload + 2, &wav.nChannels) ||
+			    !read_u32(p, size, payload + 4, &wav.nSamplesPerSec) ||
+			    !read_u32(p, size, payload + 8, &wav.nAvgBytesPerSec) ||
+			    !read_u16(p, size, payload + 12, &wav.nBlockAlign) ||
+			    !read_u16(p, size, payload + 14, &wav.wBitsPerSample)) {
+				return fail(err, "truncated fmt");
+			}
+			have_fmt = true;
+		} else if (id_is(cid, "data")) {
+			wav.pcm.assign(p + payload, p + payload + cksize);
+			have_data = true;
+		}
+
+		off = payload + cksize;
+		if ((cksize & 1u) != 0) {
+			off++;
+		}
+	}
+
+	if (!have_fmt) {
+		return fail(err, "fmt is not found");
+	}
+	if (wav.wFormatTag != RS2_WAV_FORMAT_PCM) {
+		return fail(err, "is not PCM format");
+	}
+	if (wav.nChannels == 0 || wav.nSamplesPerSec == 0 || wav.nBlockAlign == 0 ||
+	    wav.wBitsPerSample == 0) {
+		return fail(err, "broken fmt fields");
+	}
+	if (!have_data) {
+		return fail(err, "data is not found");
+	}
+
+	*out = std::move(wav);
+	if (err) {
+		err->clear();
+	}
+	return true;
+}
+
+bool rs2_wav_pcm_parse_file(const char *path, Rs2WavPcm *out, std::string *err) {
+	if (!path) {
+		return fail(err, "null path");
+	}
+	std::ifstream in(path, std::ios::binary);
+	if (!in) {
+		if (err) {
+			*err = std::string("cannot open ") + path;
+		}
+		return false;
+	}
+	const std::string bytes((std::istreambuf_iterator<char>(in)),
+	                        std::istreambuf_iterator<char>());
+	return rs2_wav_pcm_parse(bytes.data(), bytes.size(), out, err);
+}

--- a/port/wav_pcm.h
+++ b/port/wav_pcm.h
@@ -1,0 +1,27 @@
+// PCM-only RIFF WAVE reader for the closed mmio* contract (#81, parent #7).
+// See docs/porting/audio-seams.md. Does not replace CWave::Load.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifndef RS2_WAV_FORMAT_PCM
+#define RS2_WAV_FORMAT_PCM 1
+#endif
+
+struct Rs2WavPcm {
+	std::uint16_t wFormatTag;
+	std::uint16_t nChannels;
+	std::uint32_t nSamplesPerSec;
+	std::uint32_t nAvgBytesPerSec;
+	std::uint16_t nBlockAlign;
+	std::uint16_t wBitsPerSample;
+	std::vector<unsigned char> pcm;
+};
+
+bool rs2_wav_pcm_parse(const void *bytes, std::size_t size, Rs2WavPcm *out,
+                       std::string *err);
+bool rs2_wav_pcm_parse_file(const char *path, Rs2WavPcm *out, std::string *err);

--- a/port/wav_pcm_test.cpp
+++ b/port/wav_pcm_test.cpp
@@ -1,0 +1,180 @@
+// PCM WAV parser self-test (#81). Embedded blob + one Distribution file.
+
+#include "wav_pcm.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+const int kSkip = 77;
+
+bool expect(bool ok, const char *label) {
+	if (!ok) {
+		std::fprintf(stderr, "self-test: %s\n", label);
+	}
+	return ok;
+}
+
+void put_u16(std::vector<unsigned char> *b, std::uint16_t v) {
+	b->push_back(static_cast<unsigned char>(v & 0xff));
+	b->push_back(static_cast<unsigned char>((v >> 8) & 0xff));
+}
+
+void put_u32(std::vector<unsigned char> *b, std::uint32_t v) {
+	b->push_back(static_cast<unsigned char>(v & 0xff));
+	b->push_back(static_cast<unsigned char>((v >> 8) & 0xff));
+	b->push_back(static_cast<unsigned char>((v >> 16) & 0xff));
+	b->push_back(static_cast<unsigned char>((v >> 24) & 0xff));
+}
+
+void put_id(std::vector<unsigned char> *b, const char *four) {
+	b->insert(b->end(), four, four + 4);
+}
+
+// Minimal 8-bit mono 22050 Hz PCM, matching shipped Distribution assets.
+std::vector<unsigned char> make_pcm_wav(std::uint16_t tag, bool with_fact,
+                                        const unsigned char *pcm, std::size_t pcm_n) {
+	std::vector<unsigned char> fmt;
+	put_u16(&fmt, tag);
+	put_u16(&fmt, 1);
+	put_u32(&fmt, 22050);
+	put_u32(&fmt, 22050);
+	put_u16(&fmt, 1);
+	put_u16(&fmt, 8);
+
+	std::vector<unsigned char> body;
+	put_id(&body, "fmt ");
+	put_u32(&body, static_cast<std::uint32_t>(fmt.size()));
+	body.insert(body.end(), fmt.begin(), fmt.end());
+	if (with_fact) {
+		put_id(&body, "fact");
+		put_u32(&body, 4);
+		put_u32(&body, static_cast<std::uint32_t>(pcm_n));
+	}
+	put_id(&body, "data");
+	put_u32(&body, static_cast<std::uint32_t>(pcm_n));
+	body.insert(body.end(), pcm, pcm + pcm_n);
+	if ((pcm_n & 1u) != 0) {
+		body.push_back(0);
+	}
+
+	std::vector<unsigned char> out;
+	put_id(&out, "RIFF");
+	put_u32(&out, static_cast<std::uint32_t>(4 + body.size()));
+	put_id(&out, "WAVE");
+	out.insert(out.end(), body.begin(), body.end());
+	return out;
+}
+
+// Hard-coded 48-byte PCM blob (no fact). 4 samples at 8-bit midpoint.
+const unsigned char kMinWav[] = {
+    'R',  'I',  'F',  'F',  0x28, 0x00, 0x00, 0x00, 'W',  'A',  'V',  'E',
+    'f',  'm',  't',  ' ',  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x22, 0x56, 0x00, 0x00, 0x22, 0x56, 0x00, 0x00, 0x01, 0x00, 0x08, 0x00,
+    'd',  'a',  't',  'a',  0x04, 0x00, 0x00, 0x00, 0x80, 0x80, 0x80, 0x80,
+};
+
+bool fields_match(const Rs2WavPcm &w, std::uint16_t ch, std::uint32_t rate,
+                  std::uint16_t bits, std::uint16_t align, std::uint32_t avg,
+                  std::size_t pcm_n, const char *label) {
+	if (w.wFormatTag != RS2_WAV_FORMAT_PCM || w.nChannels != ch ||
+	    w.nSamplesPerSec != rate || w.wBitsPerSample != bits ||
+	    w.nBlockAlign != align || w.nAvgBytesPerSec != avg || w.pcm.size() != pcm_n) {
+		std::fprintf(stderr,
+		             "self-test: %s fields tag=%u ch=%u rate=%u avg=%u align=%u bits=%u "
+		             "pcm=%zu\n",
+		             label, w.wFormatTag, w.nChannels, w.nSamplesPerSec, w.nAvgBytesPerSec,
+		             w.nBlockAlign, w.wBitsPerSample, w.pcm.size());
+		return false;
+	}
+	return true;
+}
+
+int self_test() {
+	Rs2WavPcm w;
+	std::string err;
+
+	if (!rs2_wav_pcm_parse(kMinWav, sizeof(kMinWav), &w, &err)) {
+		std::fprintf(stderr, "self-test: min blob: %s\n", err.c_str());
+		return 1;
+	}
+	if (!fields_match(w, 1, 22050, 8, 1, 22050, 4, "min blob")) return 1;
+	if (!expect(w.pcm[0] == 0x80 && w.pcm[3] == 0x80, "min blob samples")) return 1;
+
+	const unsigned char samples[] = {0x80, 0x7f, 0x81};
+	auto with_fact = make_pcm_wav(RS2_WAV_FORMAT_PCM, true, samples, sizeof(samples));
+	if (!rs2_wav_pcm_parse(with_fact.data(), with_fact.size(), &w, &err)) {
+		std::fprintf(stderr, "self-test: fact skip: %s\n", err.c_str());
+		return 1;
+	}
+	if (!fields_match(w, 1, 22050, 8, 1, 22050, 3, "fact skip")) return 1;
+	if (!expect(w.pcm[1] == 0x7f, "fact skip payload")) return 1;
+
+	if (!expect(!rs2_wav_pcm_parse(nullptr, 0, &w, &err), "null buffer")) return 1;
+
+	const unsigned char not_riff[] = {'A', 'V', 'I', ' ', 0, 0, 0, 0};
+	if (!expect(!rs2_wav_pcm_parse(not_riff, sizeof(not_riff), &w, &err), "not RIFF"))
+		return 1;
+
+	auto ieee = make_pcm_wav(3, false, samples, sizeof(samples));
+	if (!expect(!rs2_wav_pcm_parse(ieee.data(), ieee.size(), &w, &err) &&
+	                err.find("PCM") != std::string::npos,
+	            "reject non-PCM"))
+		return 1;
+
+	auto missing_data = make_pcm_wav(RS2_WAV_FORMAT_PCM, false, samples, sizeof(samples));
+	// Drop the data chunk (last 8 + 3 + pad).
+	missing_data.resize(12 + 8 + 16);
+	missing_data[4] = static_cast<unsigned char>(4 + 8 + 16);
+	if (!expect(!rs2_wav_pcm_parse(missing_data.data(), missing_data.size(), &w, &err),
+	            "missing data"))
+		return 1;
+
+	auto trunc = make_pcm_wav(RS2_WAV_FORMAT_PCM, false, samples, sizeof(samples));
+	trunc.resize(trunc.size() - 2);
+	if (!expect(!rs2_wav_pcm_parse(trunc.data(), trunc.size(), &w, &err),
+	            "truncated data"))
+		return 1;
+
+	return 0;
+}
+
+int distribution_test(const char *root) {
+	std::string path = std::string(root) +
+	                   "/jp/RailSim2/Skin/Default_Blue/Error.wav";
+	Rs2WavPcm w;
+	std::string err;
+	if (!rs2_wav_pcm_parse_file(path.c_str(), &w, &err)) {
+		std::fprintf(stderr, "distribution: %s: %s\n", path.c_str(), err.c_str());
+		return 1;
+	}
+	// Inventory: shipped UI waves are 1 ch / 22050 Hz / 8-bit PCM. Error.wav
+	// data cksize is 3307 (odd, so a pad byte follows).
+	if (!fields_match(w, 1, 22050, 8, 1, 22050, 3307, "Error.wav")) return 1;
+	std::printf("wav_pcm: %s fields ok pcm=%zu\n", path.c_str(), w.pcm.size());
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	if (argc < 2) {
+		std::fprintf(stderr, "usage: rs2_wav_pcm_test --self-test | <Distribution>\n");
+		return 2;
+	}
+	int st = self_test();
+	if (st) return st;
+
+	std::string jp = std::string(argv[1]) + "/jp/RailSim2/Skin/Default_Blue/Error.wav";
+	FILE *f = std::fopen(jp.c_str(), "rb");
+	if (!f) {
+		std::fprintf(stderr, "skip: %s missing\n", jp.c_str());
+		return kSkip;
+	}
+	std::fclose(f);
+	return distribution_test(argv[1]);
+}


### PR DESCRIPTION
## Summary
- Add `port/wav_pcm.*`: PCM-only RIFF `WAVE` / `fmt ` / `data` reader that returns `nChannels`, `nSamplesPerSec`, `nAvgBytesPerSec`, `nBlockAlign`, `wBitsPerSample`, and the raw payload. Non-PCM, truncated chunks, and missing `fmt` / `data` fail with `bool` + reason.
- `rs2_wav_pcm_test` covers an embedded 8-bit mono 22050 Hz blob (plus a `fact`-chunk skip) and `Distribution/jp/.../Error.wav` field match. Does not swap `CWave::Load` or link OpenAL.
- Document the parser entry at the end of `docs/porting/audio-seams.md`.

Closes #81

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_wav_pcm_self_test` and `rs2_wav_pcm_distribution`)
- [ ] CI check preset on this PR


Made with [Cursor](https://cursor.com)