### PR TITLE
Allowlist game TUs after closed _mbsicmp swap (#87)

### DIFF
--- a/CFileMode.h
+++ b/CFileMode.h
@@ -25,7 +25,7 @@ private:
 public:
 	CLayoutInfo(char *fname){ m_FileName = fname; }
 	bool PreLoadSF(FILE *file);
-	bool operator<(const CLayoutInfo &rhs){ return m_FileName<rhs.m_FileName; }
+	bool operator<(const CLayoutInfo &rhs) const{ return m_FileName<rhs.m_FileName; }
 };
 
 //	”½•œŽq

--- a/CTreeDirElement.h
+++ b/CTreeDirElement.h
@@ -4,6 +4,7 @@
 #include "CTreeElement.h"
 
 class CPluginMode;
+class CPluginTree;
 
 /*
  *	ツリーディレクトリ要素

--- a/CTreeElement.h
+++ b/CTreeElement.h
@@ -6,6 +6,9 @@ const int TREE_ICON_MARGIN = 2;	//	文字余白
 
 class CPlugin;
 class CPluginListView;
+class CTreeDirElement;
+class CTreeFileElement;
+class CPluginTree;
 
 /*
  *	ツリー要素

--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -172,3 +172,13 @@ rg -n --glob '!build/**' --glob '!.git/**' --glob '!Distribution/**' --glob '!po
 Expect: Imm* in `lib/editbox.cpp` / `lib/editbox.h`, `lib/window.cpp`, and `lib/headers.h`'s `#include <imm.h>`. Live `_mbsicmp` is gone (stub + comments only).
 
 `./scripts/check.sh` must stay green.
+
+## Closed `_mbsicmp` replaced (`#87`)
+
+- **Issue**: [#87](https://github.com/lollipop-onl/railsim2-portable/issues/87) (parent [#9](https://github.com/lollipop-onl/railsim2-portable/issues/9); depends on [#75](https://github.com/lollipop-onl/railsim2-portable/issues/75))
+- **Entry**: `rs2_text_icmp` in `port/rs2_text.h` (added by #75)
+- **Allowlist**: `CPlugin.cpp`, `CFileMode.cpp`, `CTreeElement.cpp` are in `port/native_sources.txt`
+
+The twelve live `_mbsicmp` calls in the [closed compare set](#closed-_mbsicmp-set-compare) are gone. Those five files call `rs2_text_icmp` (CP932 decode, then ASCII A-Z fold). On-disk `.rs2` / plugin txt bytes stay CP932. IME (`Imm*`) is unchanged.
+
+`lib/texture.cpp` and `lib/mesh.cpp` still use `rs2_text_icmp` but stay off the allowlist: they fail on D3D/GDI / `rmxfguid.h`, not on `_mbsicmp`. Do not grow those drawing stubs in a charset slice. `rs2_text_self_test` keeps the #75 icmp cases (ASCII fold, trail-byte trap, layout name).

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -67,5 +67,8 @@ CStructPlugin.cpp
 CTrainPlugin.cpp
 CStationPlugin.cpp
 Capture.cpp
+CPlugin.cpp
+CFileMode.cpp
+CTreeElement.cpp
 lib/input.cpp
 lib/wave.cpp

--- a/port/rs2_text_test.cpp
+++ b/port/rs2_text_test.cpp
@@ -55,6 +55,7 @@ int self_test() {
 		return 1;
 	if (!expect(rs2_text_icmp("a.rs2", "b.rs2") < 0, "ascii icmp order")) return 1;
 	if (!expect(rs2_text_icmp("Foo", "Foo") == 0, "ascii icmp same")) return 1;
+	if (!expect(rs2_text_icmp(nullptr, "") == 0, "null vs empty")) return 1;
 
 	// Trail-byte trap: ƒA (0x8341) vs ƒa (0x8361). strcasecmp would fold 0x41/0x61.
 	const char kA[] = {'\x83', '\x41', 0};


### PR DESCRIPTION
## Summary
- `#75` already replaced the twelve live `_mbsicmp` calls with `rs2_text_icmp`. This slice allowlists the three game TUs that can compile without drawing stubs: `CPlugin.cpp`, `CFileMode.cpp`, `CTreeElement.cpp`.
- Mechanical compile-firewall only: forward-declare the tree types, mark `CLayoutInfo::operator<` `const` so libc++ `list::sort` accepts it. `lib/texture.cpp` / `lib/mesh.cpp` stay off the allowlist (D3D/GDI / `rmxfguid.h`).
- End section on `docs/porting/charset-seams.md` locks the replacement. One extra `rs2_text_icmp(nullptr, "")` case.

Closes #87

## Test plan
- [x] `./scripts/check.sh` green (includes `rs2_text_self_test`)
- [ ] Confirm CI on this PR


Made with [Cursor](https://cursor.com)