### PR TITLE
Generate GLSL 330 core from rs2_ffp_shader_key (#88)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/path.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_text.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_state.cpp"
+  "${CMAKE_SOURCE_DIR}/port/ffp_glsl.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
   "${CMAKE_SOURCE_DIR}/lib/movie.cpp")
@@ -254,6 +255,21 @@ target_compile_options(rs2_ffp_state_test PRIVATE -Wall -Wextra)
 target_compile_definitions(rs2_ffp_state_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
 
 add_test(NAME rs2_ffp_state_self_test COMMAND rs2_ffp_state_test --self-test)
+
+# M3 core FVF x state key -> GLSL 330 core (#88). No GL context / draw.
+add_executable(rs2_ffp_glsl_test
+  port/ffp_glsl_test.cpp
+  port/ffp_glsl.cpp
+  port/ffp_state.cpp
+  port/ffp_fvf.cpp)
+target_include_directories(rs2_ffp_glsl_test SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_ffp_glsl_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_glsl_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_glsl_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_glsl_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
+
+add_test(NAME rs2_ffp_glsl_self_test COMMAND rs2_ffp_glsl_test --self-test)
 
 # CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
 add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -240,7 +240,7 @@ Stride, attribute offsets, CPU vertex buffers, and `DrawPrimitiveUP` ring record
 
 ## State shadow / shader key (port, #80)
 
-M3 required `D3DRS_*` / stage-0 / stage-1-env live in `port/ffp_state.*`. There is no GLSL and no GL link.
+M3 required `D3DRS_*` / stage-0 / stage-1-env live in `port/ffp_state.*`. GLSL source is #88 (`port/ffp_glsl.*`). There is no GL link.
 
 | API | Role |
 |-----|------|
@@ -255,8 +255,22 @@ Stub `D3DRS_LIGHTING` / `D3DRS_AMBIENT` / `D3DRS_FOGVERTEXMODE` / `D3DRS_FOGTABL
 
 ctest: `rs2_ffp_state_self_test` (`port/ffp_state_test.cpp --self-test`).
 
+## GLSL source (port, #88)
+
+M3 required FVF x core-state keys become GLSL 330 core VS/FS strings in `port/ffp_glsl.*`. No GL context, VBO, or draw.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_glsl_for_key(key, vs, vs_cap, fs, fs_cap)` | Decode `rs2_ffp_shader_key` bits and write `#version 330 core` sources. `key == 0` (unknown / `FVF_S`) or FVF index `> 7` fails. |
+
+Each variant bakes `#define RS2_FFP_*` for the FVF index, lighting, alpha test + func, env-map TCI (`RS2_FFP_TCI_CAMERASPACE`), blend enable + src/dest, and stage 0/1 color ops. Ambient / alpharef / fog distances stay uniforms (not key bits). Stencil / `FVF_S` are not generated.
+
+Attribute locations are fixed across the 8 closed FVFs: `0` position, `1` rhw, `2` normal, `3` diffuse, `4` tex0, `5` tex1. Unused locations are omitted.
+
+ctest: `rs2_ffp_glsl_self_test` (`port/ffp_glsl_test.cpp --self-test`).
+
 ## What #5 should implement next
 
-1. **M3 required tier (GL)** -- Wire `IDirect3DDevice8` draw to a dynamic VBO and pick a shader variant from `rs2_ffp_shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74) and the state shadow (#80) are already in `port/`.
+1. **M3 required tier (GL)** -- Link `rs2_ffp_glsl_for_key` strings to a GL program, wire `IDirect3DDevice8` draw to a dynamic VBO, and pick the variant from `rs2_ffp_shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), and GLSL source (#88) are already in `port/`. SDL2 stays off the check preset.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_glsl.cpp
+++ b/port/ffp_glsl.cpp
@@ -1,0 +1,341 @@
+// GLSL 330 core strings from rs2_ffp_shader_key bits. No GL link.
+
+#include "ffp_glsl.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace {
+
+// Pack order must match rs2_ffp_shader_key in ffp_state.cpp.
+constexpr unsigned kKeyBits =
+    4 + 1 + 1 + 1 + 2 + 2 + 1 + 1 + 4 + 1 + 4 + 1 + 4 + 4 + 1 + 1 + 1 + 4 + 4 +
+    2 + 2 + 4 + 2 + 2 + 2 + 1;
+static_assert(kKeyBits <= 64, "shader key overflow");
+
+struct KeyFields {
+	unsigned fvf;
+	unsigned lighting;
+	unsigned specular;
+	unsigned normalize;
+	unsigned shademode;
+	unsigned cullmode;
+	unsigned zenable;
+	unsigned zwrite;
+	unsigned zfunc;
+	unsigned alphatest;
+	unsigned alphafunc;
+	unsigned alphablend;
+	unsigned srcblend;
+	unsigned destblend;
+	unsigned diffuse_src;
+	unsigned ambient_src;
+	unsigned fogenable;
+	unsigned s0_colorop;
+	unsigned s0_alphaop;
+	unsigned s0_textransform;
+	unsigned s0_magfilter;
+	unsigned s1_colorop;
+	unsigned s1_colorarg1;
+	unsigned s1_colorarg2;
+	unsigned s1_textransform;
+	unsigned tci_cam;
+};
+
+struct FvfBits {
+	unsigned has_rhw;
+	unsigned has_normal;
+	unsigned has_tex0;
+	unsigned has_tex1;
+};
+
+const FvfBits kFvf[8] = {
+    {1, 0, 0, 0}, {1, 0, 1, 0}, {0, 0, 0, 0}, {0, 0, 1, 0},
+    {0, 0, 1, 1}, {0, 1, 0, 0}, {0, 1, 1, 0}, {0, 1, 1, 1},
+};
+
+bool decode_key(std::uint64_t key, KeyFields *out) {
+	if (!out || key == 0) return false;
+	unsigned bit = 0;
+	const auto get = [&](unsigned n) -> unsigned {
+		if (n == 0 || bit >= 64 || n > 64u - bit) return 0;
+		const unsigned v =
+		    static_cast<unsigned>((key >> bit) & ((1ull << n) - 1ull));
+		bit += n;
+		return v;
+	};
+
+	KeyFields f{};
+	f.fvf = get(4);
+	f.lighting = get(1);
+	f.specular = get(1);
+	f.normalize = get(1);
+	f.shademode = get(2);
+	f.cullmode = get(2);
+	f.zenable = get(1);
+	f.zwrite = get(1);
+	f.zfunc = get(4);
+	f.alphatest = get(1);
+	f.alphafunc = get(4);
+	f.alphablend = get(1);
+	f.srcblend = get(4);
+	f.destblend = get(4);
+	f.diffuse_src = get(1);
+	f.ambient_src = get(1);
+	f.fogenable = get(1);
+	f.s0_colorop = get(4);
+	f.s0_alphaop = get(4);
+	f.s0_textransform = get(2);
+	f.s0_magfilter = get(2);
+	f.s1_colorop = get(4);
+	f.s1_colorarg1 = get(2);
+	f.s1_colorarg2 = get(2);
+	f.s1_textransform = get(2);
+	f.tci_cam = get(1);
+	(void)bit;
+	if (f.fvf > 7) return false;
+	*out = f;
+	return true;
+}
+
+void add_define(std::string *o, const char *name, unsigned v) {
+	char line[96];
+	std::snprintf(line, sizeof(line), "#define %s %u\n", name, v);
+	*o += line;
+}
+
+void emit_defines(std::string *o, const KeyFields &f, const FvfBits &a) {
+	*o += "#version 330 core\n";
+	add_define(o, "RS2_FFP_FVF", f.fvf);
+	add_define(o, "RS2_FFP_HAS_RHW", a.has_rhw);
+	add_define(o, "RS2_FFP_HAS_NORMAL", a.has_normal);
+	add_define(o, "RS2_FFP_HAS_TEX0", a.has_tex0);
+	add_define(o, "RS2_FFP_HAS_TEX1", a.has_tex1);
+	add_define(o, "RS2_FFP_LIGHTING", f.lighting);
+	add_define(o, "RS2_FFP_SPECULAR", f.specular);
+	add_define(o, "RS2_FFP_NORMALIZE", f.normalize);
+	add_define(o, "RS2_FFP_SHADEMODE", f.shademode);
+	add_define(o, "RS2_FFP_CULLMODE", f.cullmode);
+	add_define(o, "RS2_FFP_ZENABLE", f.zenable);
+	add_define(o, "RS2_FFP_ZWRITE", f.zwrite);
+	add_define(o, "RS2_FFP_ZFUNC", f.zfunc);
+	add_define(o, "RS2_FFP_ALPHATEST", f.alphatest);
+	add_define(o, "RS2_FFP_ALPHAFUNC", f.alphafunc);
+	add_define(o, "RS2_FFP_ALPHABLEND", f.alphablend);
+	add_define(o, "RS2_FFP_SRCBLEND", f.srcblend);
+	add_define(o, "RS2_FFP_DESTBLEND", f.destblend);
+	add_define(o, "RS2_FFP_DIFFUSE_SRC", f.diffuse_src);
+	add_define(o, "RS2_FFP_AMBIENT_SRC", f.ambient_src);
+	add_define(o, "RS2_FFP_FOGENABLE", f.fogenable);
+	add_define(o, "RS2_FFP_S0_COLOROP", f.s0_colorop);
+	add_define(o, "RS2_FFP_S0_ALPHAOP", f.s0_alphaop);
+	add_define(o, "RS2_FFP_S0_TEXTRANSFORM", f.s0_textransform);
+	add_define(o, "RS2_FFP_S0_MAGFILTER", f.s0_magfilter);
+	add_define(o, "RS2_FFP_S1_COLOROP", f.s1_colorop);
+	add_define(o, "RS2_FFP_S1_COLORARG1", f.s1_colorarg1);
+	add_define(o, "RS2_FFP_S1_COLORARG2", f.s1_colorarg2);
+	add_define(o, "RS2_FFP_S1_TEXTRANSFORM", f.s1_textransform);
+	add_define(o, "RS2_FFP_TCI_CAMERASPACE", f.tci_cam);
+}
+
+void emit_vs(std::string *o) {
+	*o += R"GLSL(
+layout(location = 0) in vec3 a_position;
+#if RS2_FFP_HAS_RHW
+layout(location = 1) in float a_rhw;
+#endif
+#if RS2_FFP_HAS_NORMAL
+layout(location = 2) in vec3 a_normal;
+#endif
+layout(location = 3) in vec4 a_diffuse;
+#if RS2_FFP_HAS_TEX0
+layout(location = 4) in vec2 a_tex0;
+#endif
+#if RS2_FFP_HAS_TEX1
+layout(location = 5) in vec2 a_tex1;
+#endif
+
+uniform mat4 u_world;
+uniform mat4 u_view;
+uniform mat4 u_proj;
+uniform vec4 u_viewport;
+uniform mat4 u_tex0_xform;
+uniform mat4 u_tex1_xform;
+uniform vec4 u_ambient;
+uniform vec3 u_light_dir;
+uniform vec3 u_light_color;
+uniform vec4 u_material_diffuse;
+uniform vec4 u_material_ambient;
+
+out vec4 v_color;
+#if RS2_FFP_HAS_TEX0
+out vec2 v_tex0;
+#endif
+#if RS2_FFP_HAS_TEX1 || RS2_FFP_TCI_CAMERASPACE || RS2_FFP_S1_COLOROP != 1
+out vec2 v_tex1;
+#endif
+
+void main() {
+#if RS2_FFP_HAS_RHW
+	vec2 ndc = vec2(
+	    (a_position.x - u_viewport.x) / u_viewport.z * 2.0 - 1.0,
+	    1.0 - (a_position.y - u_viewport.y) / u_viewport.w * 2.0);
+	gl_Position = vec4(ndc * a_rhw, a_position.z * a_rhw, a_rhw);
+#else
+	gl_Position = u_proj * u_view * u_world * vec4(a_position, 1.0);
+#endif
+
+	vec4 diff = a_diffuse;
+#if RS2_FFP_DIFFUSE_SRC == 0
+	diff = u_material_diffuse;
+#endif
+
+#if RS2_FFP_LIGHTING && RS2_FFP_HAS_NORMAL
+	vec3 n = mat3(u_world) * a_normal;
+#if RS2_FFP_NORMALIZE
+	n = normalize(n);
+#endif
+	vec3 L = normalize(u_light_dir);
+	float ndl = max(dot(n, L), 0.0);
+	vec3 amb = u_ambient.rgb;
+#if RS2_FFP_AMBIENT_SRC == 1
+	amb *= a_diffuse.rgb;
+#else
+	amb *= u_material_ambient.rgb;
+#endif
+	v_color = vec4(diff.rgb * (amb + u_light_color * ndl), diff.a);
+#if RS2_FFP_SPECULAR
+	vec3 r = reflect(-L, n);
+	v_color.rgb += u_light_color * pow(max(dot(r, vec3(0.0, 0.0, 1.0)), 0.0), 16.0);
+#endif
+#else
+	v_color = diff;
+#endif
+
+#if RS2_FFP_HAS_TEX0
+#if RS2_FFP_S0_TEXTRANSFORM == 2
+	v_tex0 = (u_tex0_xform * vec4(a_tex0, 0.0, 1.0)).xy;
+#else
+	v_tex0 = a_tex0;
+#endif
+#endif
+
+#if RS2_FFP_TCI_CAMERASPACE && RS2_FFP_HAS_NORMAL
+	vec3 cn = normalize(mat3(u_view * u_world) * a_normal);
+#if RS2_FFP_S1_TEXTRANSFORM == 2
+	v_tex1 = (u_tex1_xform * vec4(cn.xy, 0.0, 1.0)).xy;
+#else
+	v_tex1 = cn.xy * 0.5 + 0.5;
+#endif
+#elif RS2_FFP_HAS_TEX1
+	v_tex1 = a_tex1;
+#elif RS2_FFP_TCI_CAMERASPACE || RS2_FFP_S1_COLOROP != 1
+	v_tex1 = vec2(0.0);
+#endif
+}
+)GLSL";
+}
+
+void emit_fs(std::string *o) {
+	*o += R"GLSL(
+in vec4 v_color;
+#if RS2_FFP_HAS_TEX0
+in vec2 v_tex0;
+uniform sampler2D u_tex0;
+#endif
+#if RS2_FFP_HAS_TEX1 || RS2_FFP_TCI_CAMERASPACE || RS2_FFP_S1_COLOROP != 1
+in vec2 v_tex1;
+uniform sampler2D u_tex1;
+#endif
+uniform float u_alpharef;
+uniform vec4 u_fog_color;
+out vec4 o_color;
+
+void main() {
+	vec4 color = v_color;
+#if RS2_FFP_HAS_TEX0
+	vec4 t0 = texture(u_tex0, v_tex0);
+#if RS2_FFP_S0_COLOROP == 4
+	color.rgb = t0.rgb * color.rgb;
+#endif
+#if RS2_FFP_S0_ALPHAOP == 4
+	color.a = t0.a * color.a;
+#endif
+#endif
+
+#if RS2_FFP_S1_COLOROP != 1
+	vec4 t1 = texture(u_tex1, v_tex1);
+	vec3 arg1 = t1.rgb;
+	vec3 arg2 = color.rgb;
+#if RS2_FFP_S1_COLORARG1 == 1
+	arg1 = color.rgb;
+#elif RS2_FFP_S1_COLORARG1 == 0
+	arg1 = v_color.rgb;
+#endif
+#if RS2_FFP_S1_COLORARG2 == 2
+	arg2 = t1.rgb;
+#elif RS2_FFP_S1_COLORARG2 == 0
+	arg2 = v_color.rgb;
+#endif
+#if RS2_FFP_S1_COLOROP == 4
+	color.rgb = arg1 * arg2;
+#elif RS2_FFP_S1_COLOROP == 11
+	color.rgb = arg1 + arg2 - arg1 * arg2;
+#endif
+#endif
+
+#if RS2_FFP_ALPHATEST
+#if RS2_FFP_ALPHAFUNC == 8
+	/* D3DCMP_ALWAYS: no discard */
+#elif RS2_FFP_ALPHAFUNC == 5
+	if (!(color.a > u_alpharef)) discard;
+#elif RS2_FFP_ALPHAFUNC == 7
+	if (!(color.a >= u_alpharef)) discard;
+#elif RS2_FFP_ALPHAFUNC == 2
+	if (!(color.a < u_alpharef)) discard;
+#elif RS2_FFP_ALPHAFUNC == 4
+	if (!(color.a <= u_alpharef)) discard;
+#elif RS2_FFP_ALPHAFUNC == 3
+	if (!(color.a == u_alpharef)) discard;
+#elif RS2_FFP_ALPHAFUNC == 6
+	if (!(color.a != u_alpharef)) discard;
+#elif RS2_FFP_ALPHAFUNC == 1
+	discard;
+#else
+	if (!(color.a > u_alpharef)) discard;
+#endif
+#endif
+
+#if RS2_FFP_FOGENABLE
+	color.rgb = mix(color.rgb, u_fog_color.rgb, u_fog_color.a);
+#endif
+	o_color = color;
+}
+)GLSL";
+}
+
+bool write_out(const std::string &src, char *buf, std::size_t cap) {
+	if (!buf || cap == 0 || src.empty() || src.size() + 1 > cap) return false;
+	std::memcpy(buf, src.c_str(), src.size() + 1);
+	return true;
+}
+
+}  // namespace
+
+bool rs2_ffp_glsl_for_key(std::uint64_t key, char *vs, std::size_t vs_cap,
+                          char *fs, std::size_t fs_cap) {
+	KeyFields fields{};
+	if (!decode_key(key, &fields)) return false;
+	const FvfBits attrs = kFvf[fields.fvf];
+
+	std::string vs_src;
+	std::string fs_src;
+	vs_src.reserve(4096);
+	fs_src.reserve(4096);
+	emit_defines(&vs_src, fields, attrs);
+	emit_vs(&vs_src);
+	emit_defines(&fs_src, fields, attrs);
+	emit_fs(&fs_src);
+	return write_out(vs_src, vs, vs_cap) && write_out(fs_src, fs, fs_cap);
+}

--- a/port/ffp_glsl.h
+++ b/port/ffp_glsl.h
@@ -1,0 +1,16 @@
+// M3 core FVF x rs2_ffp_shader_key -> GLSL 330 core VS/FS (#88, parent #5).
+// No GL context, VBO, or draw. Deferrable stencil / FVF_S stay rejected.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Decode a packed rs2_ffp_shader_key (#80) and write NUL-terminated
+// GLSL 330 core vertex / fragment sources.
+//
+// key == 0 (unknown FVF / FVF_S) or a key whose FVF index is not 0..7
+// fails. Insufficient cap or a null buffer also fails.
+// Ambient / alpharef / fog distances are uniforms, not key bits.
+bool rs2_ffp_glsl_for_key(std::uint64_t key, char *vs, std::size_t vs_cap,
+                          char *fs, std::size_t fs_cap);

--- a/port/ffp_glsl_test.cpp
+++ b/port/ffp_glsl_test.cpp
@@ -1,0 +1,240 @@
+// M3 core key -> GLSL 330 core self-test (#88). No GL context.
+
+#include "ffp_fvf.h"
+#include "ffp_glsl.h"
+#include "ffp_state.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+const DWORD kFvfs[] = {RS2_FVF_TL, RS2_FVF_TLX, RS2_FVF_L,  RS2_FVF_LX,
+                       RS2_FVF_LX2, RS2_FVF_N,   RS2_FVF_NX, RS2_FVF_NX2};
+
+constexpr std::size_t kCap = 8192;
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool contains(const char *s, const char *needle) {
+	return s && needle && std::strstr(s, needle) != nullptr;
+}
+
+bool each_fvf_nonempty() {
+	rs2_ffp_state_reset();
+	char vs[kCap];
+	char fs[kCap];
+	for (int i = 0; i < 8; ++i) {
+		const std::uint64_t key = rs2_ffp_shader_key(kFvfs[i]);
+		if (!expect(key != 0, "fvf key")) return false;
+		std::memset(vs, 0, sizeof(vs));
+		std::memset(fs, 0, sizeof(fs));
+		if (!expect(rs2_ffp_glsl_for_key(key, vs, sizeof(vs), fs, sizeof(fs)),
+		            "glsl ok"))
+			return false;
+		if (!expect(vs[0] != '\0' && fs[0] != '\0', "non-empty")) return false;
+		if (!expect(contains(vs, "#version 330 core") &&
+		                contains(fs, "#version 330 core"),
+		            "version"))
+			return false;
+		char fvf_def[32];
+		std::snprintf(fvf_def, sizeof(fvf_def), "#define RS2_FFP_FVF %d", i);
+		if (!expect(contains(vs, fvf_def) && contains(fs, fvf_def), "fvf define"))
+			return false;
+	}
+	return true;
+}
+
+bool golden_nx_defaults() {
+	rs2_ffp_state_reset();
+	const std::uint64_t key = rs2_ffp_shader_key(RS2_FVF_NX);
+	char vs[kCap];
+	char fs[kCap];
+	if (!expect(rs2_ffp_glsl_for_key(key, vs, sizeof(vs), fs, sizeof(fs)),
+	            "nx glsl"))
+		return false;
+
+	if (!expect(contains(vs, "#define RS2_FFP_FVF 6"), "nx fvf")) return false;
+	if (!expect(contains(vs, "#define RS2_FFP_HAS_NORMAL 1"), "nx normal"))
+		return false;
+	if (!expect(contains(vs, "#define RS2_FFP_HAS_TEX0 1"), "nx tex0"))
+		return false;
+	if (!expect(contains(vs, "#define RS2_FFP_HAS_RHW 0"), "nx no rhw"))
+		return false;
+	if (!expect(contains(vs, "#define RS2_FFP_LIGHTING 1"), "nx lighting"))
+		return false;
+	if (!expect(contains(vs, "a_normal") && contains(vs, "u_light_dir"),
+	            "nx light math"))
+		return false;
+	if (!expect(contains(fs, "#define RS2_FFP_ALPHATEST 0"), "nx no atest"))
+		return false;
+	if (!expect(contains(fs, "#define RS2_FFP_ALPHABLEND 1"), "nx blend on"))
+		return false;
+	if (!expect(contains(fs, "#define RS2_FFP_SRCBLEND 5"), "nx srcblend"))
+		return false;
+	if (!expect(contains(fs, "#define RS2_FFP_DESTBLEND 6"), "nx destblend"))
+		return false;
+	if (!expect(contains(fs, "#define RS2_FFP_TCI_CAMERASPACE 0"), "nx no tci"))
+		return false;
+	if (!expect(contains(vs, "#version 330 core"), "nx version")) return false;
+	return true;
+}
+
+bool toggles_fork_source() {
+	rs2_ffp_state_reset();
+	char base_vs[kCap];
+	char base_fs[kCap];
+	const std::uint64_t base = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(rs2_ffp_glsl_for_key(base, base_vs, sizeof(base_vs), base_fs,
+	                                 sizeof(base_fs)),
+	            "base glsl"))
+		return false;
+
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, FALSE) == S_OK,
+	            "lighting off"))
+		return false;
+	char lit_vs[kCap];
+	char lit_fs[kCap];
+	const std::uint64_t lit = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(lit != base, "lighting key")) return false;
+	if (!expect(rs2_ffp_glsl_for_key(lit, lit_vs, sizeof(lit_vs), lit_fs,
+	                                 sizeof(lit_fs)),
+	            "lit glsl"))
+		return false;
+	if (!expect(contains(lit_vs, "#define RS2_FFP_LIGHTING 0"), "lighting 0"))
+		return false;
+	if (!expect(std::strcmp(base_vs, lit_vs) != 0, "lighting forks vs"))
+		return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_render_state(D3DRS_ALPHATESTENABLE, TRUE) == S_OK &&
+	                rs2_ffp_set_render_state(D3DRS_ALPHAFUNC, D3DCMP_GREATER) ==
+	                    S_OK,
+	            "alpha test"))
+		return false;
+	char at_vs[kCap];
+	char at_fs[kCap];
+	const std::uint64_t atest = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(rs2_ffp_glsl_for_key(atest, at_vs, sizeof(at_vs), at_fs,
+	                                 sizeof(at_fs)),
+	            "atest glsl"))
+		return false;
+	if (!expect(contains(at_fs, "#define RS2_FFP_ALPHATEST 1"), "atest define"))
+		return false;
+	if (!expect(contains(at_fs, "#define RS2_FFP_ALPHAFUNC 5"), "alphafunc"))
+		return false;
+	if (!expect(contains(at_fs, "discard"), "atest discard")) return false;
+	if (!expect(std::strcmp(base_fs, at_fs) != 0, "atest forks fs"))
+		return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_texture_stage_state(
+	                1, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACENORMAL) ==
+	                S_OK,
+	            "tci"))
+		return false;
+	char tci_vs[kCap];
+	char tci_fs[kCap];
+	const std::uint64_t tci = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(rs2_ffp_glsl_for_key(tci, tci_vs, sizeof(tci_vs), tci_fs,
+	                                 sizeof(tci_fs)),
+	            "tci glsl"))
+		return false;
+	if (!expect(contains(tci_vs, "#define RS2_FFP_TCI_CAMERASPACE 1"),
+	            "tci define"))
+		return false;
+	if (!expect(contains(tci_vs, "u_view"), "tci camera")) return false;
+	if (!expect(std::strcmp(base_vs, tci_vs) != 0, "tci forks vs"))
+		return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_set_render_state(D3DRS_DESTBLEND, D3DBLEND_ONE) == S_OK,
+	            "add blend"))
+		return false;
+	char add_vs[kCap];
+	char add_fs[kCap];
+	const std::uint64_t add = rs2_ffp_shader_key(RS2_FVF_NX);
+	if (!expect(rs2_ffp_glsl_for_key(add, add_vs, sizeof(add_vs), add_fs,
+	                                 sizeof(add_fs)),
+	            "blend glsl"))
+		return false;
+	if (!expect(contains(add_fs, "#define RS2_FFP_DESTBLEND 2"), "dest one"))
+		return false;
+	if (!expect(std::strcmp(base_fs, add_fs) != 0, "blend forks fs"))
+		return false;
+	return true;
+}
+
+bool fvf_attrs_ok() {
+	rs2_ffp_state_reset();
+	char vs[kCap];
+	char fs[kCap];
+	const std::uint64_t tl = rs2_ffp_shader_key(RS2_FVF_TL);
+	if (!expect(rs2_ffp_glsl_for_key(tl, vs, sizeof(vs), fs, sizeof(fs)),
+	            "tl glsl"))
+		return false;
+	if (!expect(contains(vs, "#define RS2_FFP_HAS_RHW 1"), "tl rhw"))
+		return false;
+	if (!expect(contains(vs, "#define RS2_FFP_HAS_NORMAL 0"), "tl no n"))
+		return false;
+	if (!expect(contains(vs, "a_rhw"), "tl a_rhw")) return false;
+
+	const std::uint64_t nx2 = rs2_ffp_shader_key(RS2_FVF_NX2);
+	if (!expect(rs2_ffp_glsl_for_key(nx2, vs, sizeof(vs), fs, sizeof(fs)),
+	            "nx2 glsl"))
+		return false;
+	if (!expect(contains(vs, "#define RS2_FFP_HAS_TEX1 1"), "nx2 tex1"))
+		return false;
+	return true;
+}
+
+bool unknown_fails() {
+	char vs[kCap];
+	char fs[kCap];
+	if (!expect(!rs2_ffp_glsl_for_key(0, vs, sizeof(vs), fs, sizeof(fs)),
+	            "key 0"))
+		return false;
+	if (!expect(!rs2_ffp_glsl_for_key(~0ull, vs, sizeof(vs), fs, sizeof(fs)),
+	            "idx 15"))
+		return false;
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_shader_key(RS2_FVF_S) == 0, "FVF_S key")) return false;
+	if (!expect(!rs2_ffp_glsl_for_key(rs2_ffp_shader_key(RS2_FVF_S), vs,
+	                                  sizeof(vs), fs, sizeof(fs)),
+	            "FVF_S glsl"))
+		return false;
+
+	const std::uint64_t key = rs2_ffp_shader_key(RS2_FVF_NX);
+	char tiny[8];
+	if (!expect(!rs2_ffp_glsl_for_key(key, tiny, sizeof(tiny), fs, sizeof(fs)),
+	            "tiny vs"))
+		return false;
+	if (!expect(!rs2_ffp_glsl_for_key(key, vs, sizeof(vs), tiny, sizeof(tiny)),
+	            "tiny fs"))
+		return false;
+	if (!expect(!rs2_ffp_glsl_for_key(key, nullptr, sizeof(vs), fs, sizeof(fs)),
+	            "null vs"))
+		return false;
+	return true;
+}
+
+int self_test() {
+	if (!each_fvf_nonempty()) return 1;
+	if (!golden_nx_defaults()) return 1;
+	if (!toggles_fork_source()) return 1;
+	if (!fvf_attrs_ok()) return 1;
+	if (!unknown_fails()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}


### PR DESCRIPTION
## Summary
- Add `port/ffp_glsl.*` so a packed `rs2_ffp_shader_key` (#80) becomes GLSL 330 core VS/FS strings for the 8 M3 FVFs.
- Bake lighting / alpha test / env-map TCI / blend as `#define RS2_FFP_*`; reject `key == 0` / `FVF_S` / unknown FVF index. No GL context, VBO, or draw.
- Lock the entry in `docs/porting/ffp-render-states.md` and add `rs2_ffp_glsl_self_test`.

Closes #88

## Test plan
- [x] `./scripts/check.sh` (encoding-guard, cmake check, ctest)
- [x] `rs2_ffp_glsl_self_test`: each FVF non-empty `#version 330 core`, golden NX substrings, lighting/atest/TCI/blend fork source, unknown key fails


Made with [Cursor](https://cursor.com)