### PR TITLE
Intern FFP program handles and wire stub DrawPrimitiveUP (#92)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/path.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_text.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_state.cpp"
+  "${CMAKE_SOURCE_DIR}/port/ffp_fvf.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_glsl.cpp"
+  "${CMAKE_SOURCE_DIR}/port/ffp_program.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
   "${CMAKE_SOURCE_DIR}/lib/movie.cpp")
@@ -232,7 +234,12 @@ add_test(NAME rs2_config_plugin_load COMMAND rs2_config_plugin_test
 set_tests_properties(rs2_config_plugin_load PROPERTIES SKIP_RETURN_CODE 77)
 
 # Closed FVF stride / CPU VB / DrawPrimitiveUP ring (#74). No GL draw.
-add_executable(rs2_ffp_fvf_test port/ffp_fvf_test.cpp port/ffp_fvf.cpp port/ffp_state.cpp)
+add_executable(rs2_ffp_fvf_test
+  port/ffp_fvf_test.cpp
+  port/ffp_fvf.cpp
+  port/ffp_state.cpp
+  port/ffp_glsl.cpp
+  port/ffp_program.cpp)
 target_include_directories(rs2_ffp_fvf_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")
 target_include_directories(rs2_ffp_fvf_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
@@ -246,7 +253,9 @@ add_test(NAME rs2_ffp_fvf_self_test COMMAND rs2_ffp_fvf_test --self-test)
 add_executable(rs2_ffp_state_test
   port/ffp_state_test.cpp
   port/ffp_state.cpp
-  port/ffp_fvf.cpp)
+  port/ffp_fvf.cpp
+  port/ffp_glsl.cpp
+  port/ffp_program.cpp)
 target_include_directories(rs2_ffp_state_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")
 target_include_directories(rs2_ffp_state_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
@@ -261,7 +270,8 @@ add_executable(rs2_ffp_glsl_test
   port/ffp_glsl_test.cpp
   port/ffp_glsl.cpp
   port/ffp_state.cpp
-  port/ffp_fvf.cpp)
+  port/ffp_fvf.cpp
+  port/ffp_program.cpp)
 target_include_directories(rs2_ffp_glsl_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")
 target_include_directories(rs2_ffp_glsl_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
@@ -270,6 +280,22 @@ target_compile_options(rs2_ffp_glsl_test PRIVATE -Wall -Wextra)
 target_compile_definitions(rs2_ffp_glsl_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
 
 add_test(NAME rs2_ffp_glsl_self_test COMMAND rs2_ffp_glsl_test --self-test)
+
+# Interned FFP program handle + stub DrawPrimitiveUP (#92). No GL link.
+add_executable(rs2_ffp_program_test
+  port/ffp_program_test.cpp
+  port/ffp_program.cpp
+  port/ffp_glsl.cpp
+  port/ffp_state.cpp
+  port/ffp_fvf.cpp)
+target_include_directories(rs2_ffp_program_test SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_ffp_program_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_program_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_program_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_program_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
+
+add_test(NAME rs2_ffp_program_self_test COMMAND rs2_ffp_program_test --self-test)
 
 # CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
 add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -248,8 +248,9 @@ M3 required `D3DRS_*` / stage-0 / stage-1-env live in `port/ffp_state.*`. GLSL s
 | `rs2_ffp_set_render_state` / `rs2_ffp_set_texture_stage_state` | Shadow the closed core set. Unknown type, stage `> 1`, and deferrable stencil return `E_FAIL` (debug log). |
 | `rs2_ffp_shader_key(fvf)` | Pack closed FVF index + core toggles (lighting, alpha test, env-map TCI, blends) into `uint64_t`. Ambient / alpharef / fog distances stay on the snapshot as uniforms. Unknown / `FVF_S` returns `0`. |
 | `Rs2FfpUpRecord.shader_key` | Copied from `rs2_ffp_shader_key` at each `rs2_ffp_draw_primitive_up`. Later GL selects a variant from this field. |
+| `Rs2FfpUpRecord.program` | Interned handle from `rs2_ffp_program_for_key` (#92). Same key, same handle. |
 
-`IDirect3DDevice8::SetRenderState` / `GetRenderState` / `SetTextureStageState` in `port/stub/d3d8.h` call the shadow. `DrawPrimitiveUP` stays a no-op (record via `rs2_ffp_draw_primitive_up` only).
+`IDirect3DDevice8::SetRenderState` / `GetRenderState` / `SetTextureStageState` in `port/stub/d3d8.h` call the shadow. `DrawPrimitiveUP` calls `rs2_ffp_draw_primitive_up` and records `shader_key` plus the interned program handle.
 
 Stub `D3DRS_LIGHTING` / `D3DRS_AMBIENT` / `D3DRS_FOGVERTEXMODE` / `D3DRS_FOGTABLEMODE` use the real D3D8 numbers so the shadow can switch on type (the previous stub reused `7` / `27` / `36`).
 
@@ -269,8 +270,22 @@ Attribute locations are fixed across the 8 closed FVFs: `0` position, `1` rhw, `
 
 ctest: `rs2_ffp_glsl_self_test` (`port/ffp_glsl_test.cpp --self-test`).
 
+## Program cache / stub draw (port, #92)
+
+`rs2_ffp_glsl_for_key` strings are interned as an opaque program handle in `port/ffp_program.*`. There is still no GL context, program link, or VBO.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_program_for_key(key, &handle)` | Intern VS/FS for a packed `rs2_ffp_shader_key`. Same key returns the same handle. `key == 0` / unknown FVF / `FVF_S` fails. |
+| `rs2_ffp_program_vs` / `rs2_ffp_program_fs` | Interned NUL-terminated sources; must match `#88` for that key. |
+| `IDirect3DDevice8::DrawPrimitiveUP` | Calls `rs2_ffp_draw_primitive_up`. The UP record stores `shader_key` and the interned handle. Draw stays a CPU record. |
+
+`lib/graphic.cpp` / `lib/vertex.cpp` stay off the allowlist. SDL2 stays off the check preset. Real GL program link + VBO upload is the next `#5` slice.
+
+ctest: `rs2_ffp_program_self_test` (`port/ffp_program_test.cpp --self-test`).
+
 ## What #5 should implement next
 
-1. **M3 required tier (GL)** -- Link `rs2_ffp_glsl_for_key` strings to a GL program, wire `IDirect3DDevice8` draw to a dynamic VBO, and pick the variant from `rs2_ffp_shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), and GLSL source (#88) are already in `port/`. SDL2 stays off the check preset.
+1. **M3 required tier (GL)** -- Link interned `#88` VS/FS (`rs2_ffp_program_vs` / `_fs`) to a real GL program, upload `Rs2FfpUpRecord` through a dynamic VBO, and pick the variant from `Rs2FfpUpRecord.program` / `shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), and the program intern + stub draw hook (#92) are already in `port/`. SDL2 stays off the check preset.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_fvf.cpp
+++ b/port/ffp_fvf.cpp
@@ -185,6 +185,9 @@ HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *
 	UINT nvert = 0;
 	if (!vertex_count(prim_type, prim_count, &nvert)) return E_FAIL;
 	const UINT bytes = nvert * stride;
+	const std::uint64_t key = rs2_ffp_shader_key(g_fvf);
+	Rs2FfpProgramHandle program = nullptr;
+	if (!rs2_ffp_program_for_key(key, &program)) return E_FAIL;
 
 	UpSlot &slot = g_ring[g_head];
 	const auto *src = static_cast<const unsigned char *>(data);
@@ -195,7 +198,8 @@ HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *
 	slot.rec.stride = stride;
 	slot.rec.bytes = bytes;
 	slot.rec.vertices = slot.bytes.data();
-	slot.rec.shader_key = rs2_ffp_shader_key(g_fvf);
+	slot.rec.shader_key = key;
+	slot.rec.program = program;
 
 	g_head = (g_head + 1u) % kUpRing;
 	if (g_count < kUpRing) ++g_count;

--- a/port/ffp_fvf.h
+++ b/port/ffp_fvf.h
@@ -7,6 +7,8 @@
 
 #include <d3d8.h>
 
+#include "ffp_program.h"
+
 #ifndef RS2_FFP_ABSENT
 #define RS2_FFP_ABSENT (~0u)
 #endif
@@ -71,6 +73,7 @@ struct Rs2FfpUpRecord {
 	UINT bytes;
 	const void *vertices;
 	std::uint64_t shader_key;
+	Rs2FfpProgramHandle program;
 };
 
 void rs2_ffp_up_reset();

--- a/port/ffp_program.cpp
+++ b/port/ffp_program.cpp
@@ -1,0 +1,59 @@
+// Intern packed shader keys to GLSL VS/FS strings. No GL link.
+
+#include "ffp_program.h"
+
+#include "ffp_glsl.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+struct Rs2FfpProgram {
+	std::uint64_t key = 0;
+	std::string vs;
+	std::string fs;
+};
+
+namespace {
+
+constexpr std::size_t kSrcCap = 16384;
+
+std::unordered_map<std::uint64_t, std::unique_ptr<Rs2FfpProgram>> g_intern;
+
+}  // namespace
+
+bool rs2_ffp_program_for_key(std::uint64_t key, Rs2FfpProgramHandle *out) {
+	if (!out) return false;
+	*out = nullptr;
+	if (key == 0) return false;
+
+	const auto found = g_intern.find(key);
+	if (found != g_intern.end()) {
+		*out = found->second.get();
+		return true;
+	}
+
+	char vs[kSrcCap];
+	char fs[kSrcCap];
+	if (!rs2_ffp_glsl_for_key(key, vs, sizeof(vs), fs, sizeof(fs))) return false;
+
+	auto prog = std::make_unique<Rs2FfpProgram>();
+	prog->key = key;
+	prog->vs = vs;
+	prog->fs = fs;
+	*out = prog.get();
+	g_intern.emplace(key, std::move(prog));
+	return true;
+}
+
+std::uint64_t rs2_ffp_program_key(Rs2FfpProgramHandle handle) {
+	return handle ? handle->key : 0;
+}
+
+const char *rs2_ffp_program_vs(Rs2FfpProgramHandle handle) {
+	return handle ? handle->vs.c_str() : nullptr;
+}
+
+const char *rs2_ffp_program_fs(Rs2FfpProgramHandle handle) {
+	return handle ? handle->fs.c_str() : nullptr;
+}

--- a/port/ffp_program.h
+++ b/port/ffp_program.h
@@ -1,0 +1,19 @@
+// Intern rs2_ffp_shader_key -> VS/FS + opaque handle (#92, parent #5).
+// Same key returns the same handle. No GL context, program link, or VBO.
+
+#pragma once
+
+#include <cstdint>
+
+struct Rs2FfpProgram;
+
+// Opaque interned program. Null is invalid (key == 0 / unknown FVF).
+using Rs2FfpProgramHandle = const Rs2FfpProgram *;
+
+// Intern GLSL 330 core sources for a packed rs2_ffp_shader_key (#80 / #88).
+// key == 0 (unknown / FVF_S) or a key whose FVF index is not 0..7 fails.
+bool rs2_ffp_program_for_key(std::uint64_t key, Rs2FfpProgramHandle *out);
+
+std::uint64_t rs2_ffp_program_key(Rs2FfpProgramHandle handle);
+const char *rs2_ffp_program_vs(Rs2FfpProgramHandle handle);
+const char *rs2_ffp_program_fs(Rs2FfpProgramHandle handle);

--- a/port/ffp_program_test.cpp
+++ b/port/ffp_program_test.cpp
@@ -1,0 +1,164 @@
+// Interned FFP program handle + stub DrawPrimitiveUP self-test (#92).
+
+#include "ffp_fvf.h"
+#include "ffp_glsl.h"
+#include "ffp_program.h"
+#include "ffp_state.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+using Color = std::uint32_t;
+
+struct VtxTL {
+	float x, y, z, rhw;
+	Color d;
+};
+
+static_assert(sizeof(VtxTL) == 20, "Win32 D3DCOLOR packing");
+
+const DWORD kFvfs[] = {RS2_FVF_TL, RS2_FVF_TLX, RS2_FVF_L,  RS2_FVF_LX,
+                       RS2_FVF_LX2, RS2_FVF_N,   RS2_FVF_NX, RS2_FVF_NX2};
+
+constexpr std::size_t kCap = 8192;
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool intern_same_handle() {
+	rs2_ffp_state_reset();
+	const std::uint64_t key = rs2_ffp_shader_key(RS2_FVF_NX);
+	Rs2FfpProgramHandle a = nullptr;
+	Rs2FfpProgramHandle b = nullptr;
+	if (!expect(rs2_ffp_program_for_key(key, &a) && a != nullptr, "intern a"))
+		return false;
+	if (!expect(rs2_ffp_program_for_key(key, &b) && b == a, "same handle"))
+		return false;
+	if (!expect(rs2_ffp_program_key(a) == key, "handle key")) return false;
+	return true;
+}
+
+bool intern_unknown_fails() {
+	Rs2FfpProgramHandle h = reinterpret_cast<Rs2FfpProgramHandle>(1);
+	if (!expect(!rs2_ffp_program_for_key(0, &h) && h == nullptr, "key 0"))
+		return false;
+	h = reinterpret_cast<Rs2FfpProgramHandle>(1);
+	if (!expect(!rs2_ffp_program_for_key(~0ull, &h) && h == nullptr, "idx 15"))
+		return false;
+	rs2_ffp_state_reset();
+	if (!expect(rs2_ffp_shader_key(RS2_FVF_S) == 0, "FVF_S key")) return false;
+	h = reinterpret_cast<Rs2FfpProgramHandle>(1);
+	if (!expect(!rs2_ffp_program_for_key(rs2_ffp_shader_key(RS2_FVF_S), &h) &&
+	                h == nullptr,
+	            "FVF_S intern"))
+		return false;
+	if (!expect(!rs2_ffp_program_for_key(rs2_ffp_shader_key(RS2_FVF_NX), nullptr),
+	            "null out"))
+		return false;
+	return true;
+}
+
+bool intern_matches_glsl() {
+	rs2_ffp_state_reset();
+	char vs[kCap];
+	char fs[kCap];
+	for (int i = 0; i < 8; ++i) {
+		const std::uint64_t key = rs2_ffp_shader_key(kFvfs[i]);
+		Rs2FfpProgramHandle h = nullptr;
+		if (!expect(rs2_ffp_program_for_key(key, &h) && h != nullptr, "intern fvf"))
+			return false;
+		std::memset(vs, 0, sizeof(vs));
+		std::memset(fs, 0, sizeof(fs));
+		if (!expect(rs2_ffp_glsl_for_key(key, vs, sizeof(vs), fs, sizeof(fs)),
+		            "glsl #88"))
+			return false;
+		if (!expect(std::strcmp(rs2_ffp_program_vs(h), vs) == 0, "vs match"))
+			return false;
+		if (!expect(std::strcmp(rs2_ffp_program_fs(h), fs) == 0, "fs match"))
+			return false;
+	}
+	return true;
+}
+
+bool intern_forks_with_state() {
+	rs2_ffp_state_reset();
+	const std::uint64_t lit = rs2_ffp_shader_key(RS2_FVF_NX);
+	Rs2FfpProgramHandle a = nullptr;
+	if (!expect(rs2_ffp_program_for_key(lit, &a) && a != nullptr, "lit intern"))
+		return false;
+
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, FALSE) == S_OK,
+	            "lighting off"))
+		return false;
+	const std::uint64_t unlit = rs2_ffp_shader_key(RS2_FVF_NX);
+	Rs2FfpProgramHandle b = nullptr;
+	if (!expect(unlit != lit && rs2_ffp_program_for_key(unlit, &b) && b != a,
+	            "unlit distinct"))
+		return false;
+	return true;
+}
+
+bool stub_draw_records() {
+	rs2_ffp_state_reset();
+	rs2_ffp_up_reset();
+	VtxTL verts[2] = {{0, 0, 0, 1, 0xFFFFFFFFu}, {10, 5, 0, 1, 0xFF00FF00u}};
+
+	if (!expect(rs2_ffp_set_fvf(RS2_FVF_TL) == S_OK, "set FVF_TL")) return false;
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, FALSE) == S_OK,
+	            "up lighting"))
+		return false;
+
+	const std::uint64_t want = rs2_ffp_shader_key(RS2_FVF_TL);
+	Rs2FfpProgramHandle interned = nullptr;
+	if (!expect(want != 0 && rs2_ffp_program_for_key(want, &interned) &&
+	                interned != nullptr,
+	            "want intern"))
+		return false;
+
+	IDirect3DDevice8 dev;
+	if (!expect(dev.DrawPrimitiveUP(D3DPT_LINELIST, 1, verts, sizeof(VtxTL)) ==
+	                S_OK,
+	            "stub DrawPrimitiveUP"))
+		return false;
+
+	const Rs2FfpUpRecord *rec = rs2_ffp_up_last();
+	if (!expect(rec != nullptr, "up record")) return false;
+	if (!expect(rec->shader_key == want && rec->program == interned,
+	            "record key+handle"))
+		return false;
+	if (!expect(rec->fvf == RS2_FVF_TL && rec->prim_type == D3DPT_LINELIST &&
+	                rec->prim_count == 1,
+	            "record draw"))
+		return false;
+
+	if (!expect(rs2_ffp_set_render_state(D3DRS_LIGHTING, TRUE) == S_OK,
+	            "lighting restore"))
+		return false;
+	if (!expect(rec->shader_key == want && rec->program == interned &&
+	                rec->shader_key != rs2_ffp_shader_key(RS2_FVF_TL),
+	            "record frozen"))
+		return false;
+	return true;
+}
+
+int self_test() {
+	if (!intern_same_handle()) return 1;
+	if (!intern_unknown_fails()) return 1;
+	if (!intern_matches_glsl()) return 1;
+	if (!intern_forks_with_state()) return 1;
+	if (!stub_draw_records()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -223,6 +223,10 @@ HRESULT rs2_ffp_get_render_state(D3DRENDERSTATETYPE type, DWORD* value);
 HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
                                         DWORD value);
 
+// CPU UP ring + program intern (#74 / #92). Bodies in port/ffp_fvf.cpp.
+HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *data,
+                                  UINT stride);
+
 struct IDirect3DDevice8 : IUnknown {
   HRESULT SetRenderState(D3DRENDERSTATETYPE type, DWORD value) {
     return rs2_ffp_set_render_state(type, value);
@@ -241,8 +245,11 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetTexture(DWORD, IDirect3DTexture8*) { return S_OK; }
   HRESULT GetTexture(DWORD, IDirect3DBaseTexture8**) { return S_OK; }
   HRESULT DrawPrimitive(D3DPRIMITIVETYPE, UINT, UINT) { return S_OK; }
-  // CPU record: port/ffp_fvf.h (rs2_ffp_draw_primitive_up). Draw stays no-op.
-  HRESULT DrawPrimitiveUP(D3DPRIMITIVETYPE, UINT, const void*, UINT) { return S_OK; }
+  // CPU record + interned program handle. No GL link / VBO.
+  HRESULT DrawPrimitiveUP(D3DPRIMITIVETYPE type, UINT count, const void *data,
+                          UINT stride) {
+    return rs2_ffp_draw_primitive_up(type, count, data, stride);
+  }
   HRESULT DrawIndexedPrimitive(D3DPRIMITIVETYPE, UINT, UINT, UINT, UINT, const void*) { return S_OK; }
   HRESULT SetStreamSource(UINT, IDirect3DVertexBuffer8*, UINT) { return S_OK; }
   HRESULT SetVertexShader(DWORD) { return S_OK; }


### PR DESCRIPTION
## Summary
- Add `port/ffp_program.*` so a packed `rs2_ffp_shader_key` interns GLSL 330 core VS/FS behind an opaque handle; the same key returns the same handle.
- `key == 0` / unknown FVF / `FVF_S` fail. Stub `IDirect3DDevice8::DrawPrimitiveUP` calls `rs2_ffp_draw_primitive_up` and stores `shader_key` plus the interned handle on the UP record.
- Lock the entry in `docs/porting/ffp-render-states.md`. No GL context, program link, VBO, or SDL2 on the check preset.

Closes #92

## Test plan
- [x] `./scripts/check.sh` (encoding-guard, cmake check, ctest)
- [x] `rs2_ffp_program_self_test`: same key same handle, unknown key fails, interned sources match #88, stub DrawPrimitiveUP records key + handle


Made with [Cursor](https://cursor.com)