### PR TITLE
Intern PCM into a stub audio buffer handle (#93)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/ffp_program.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
+  "${CMAKE_SOURCE_DIR}/port/rs2_audio.cpp"
   "${CMAKE_SOURCE_DIR}/lib/movie.cpp")
 
 target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
@@ -348,3 +349,11 @@ target_compile_options(rs2_input_test PRIVATE -Wall -Wextra)
 target_compile_definitions(rs2_input_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
 
 add_test(NAME rs2_input_self_test COMMAND rs2_input_test --self-test)
+
+# Stub PCM buffer intern + play/stop/volume/3D/listener (#93). No OpenAL.
+add_executable(rs2_audio_test port/rs2_audio_test.cpp port/rs2_audio.cpp port/wav_pcm.cpp)
+target_include_directories(rs2_audio_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_audio_test PRIVATE cxx_std_17)
+target_compile_options(rs2_audio_test PRIVATE -Wall -Wextra)
+
+add_test(NAME rs2_audio_self_test COMMAND rs2_audio_test --self-test)

--- a/docs/porting/audio-seams.md
+++ b/docs/porting/audio-seams.md
@@ -333,3 +333,23 @@ This is the portable stand-in for the [mmio* contract](#closed-mmio-set-wav-pars
 - **Allowlist**: `lib/wave.cpp` is in `port/native_sources.txt`
 
 `mmioOpen` / `mmioDescend` / `mmioRead` / `mmioAscend` / `mmioClose` are gone from `Load` and `CreateBuffer`. Non-PCM, broken RIFF, missing `fmt ` / `data`, or a file that cannot be opened still return `FALSE`. On a successful parse, `Rs2WavPcm` maps to `m_BytesPerSec` (`nAvgBytesPerSec`), `m_nChannels`, `m_wBitsPerSample`, and `m_pcm` (raw `data` payload). `CreateBuffer` still fills the DirectSound secondary buffer with `Lock` / `Unlock` from that payload; `lib/sound.cpp` and `port/stub/dsound.h` COM are unchanged. `rs2_wave_load_self_test` / `rs2_wave_load_distribution` check the mapping against the #81 field table. Do not link OpenAL in the `check` preset.
+
+## Port audio stub backend (`port/rs2_audio`)
+
+- **Issue**: [#93](https://github.com/lollipop-onl/railsim2-portable/issues/93) (parent [#7](https://github.com/lollipop-onl/railsim2-portable/issues/7))
+- **Entry**: `rs2_audio_intern` / `rs2_audio_play` / `rs2_audio_stop` / `rs2_audio_set_volume` / `rs2_audio_set_pos` / `rs2_audio_set_listener_*` in `port/rs2_audio.h`
+- **Backend hooks**: `rs2_audio_backend_*` (stub in `port/rs2_audio.cpp`; OpenAL later replaces intern upload + play/stop/volume/3D/listener)
+
+`CWave::Load` already yields `Rs2WavPcm` (#86). This slice interns that payload as an opaque buffer handle. Same format + bytes return the same handle. Non-PCM tag, empty payload, zero channels/rate, or 8/16-bit mismatch fail. Play records the handle on `rs2_audio_stub_last()`; stop / volume (hundredths of a dB) / 3D position (meters) overwrite that record. Listener pos / dir / distance factor live on `rs2_audio_stub_listener()`.
+
+The check preset links the stub only. There is no OpenAL, no DirectSound COM, and no `lib/sound.cpp` allowlist. `CreateBuffer` / `CWave::Play` still talk to the dsound stub until the next `#7` slice maps `CWave` onto these handles.
+
+| DirectSound / `CWave` | `port/rs2_audio` | Later OpenAL |
+|-----------------------|------------------|--------------|
+| `CreateSoundBuffer` + `Lock` PCM | `rs2_audio_intern` | `alBuffer` from interned PCM |
+| `Play(ms)` / `Stop` | `rs2_audio_play` / `rs2_audio_stop` | `alSource` play/stop + offset |
+| `SetVolume` | `rs2_audio_set_volume` | `AL_GAIN` from hundredths of a dB |
+| `SetPos` | `rs2_audio_set_pos` | `AL_POSITION` |
+| `SetListenerPos` / `Dir` / `Sens` | `rs2_audio_set_listener_*` | `alListener` + distance factor |
+
+ctest: `rs2_audio_self_test` (`port/rs2_audio_test.cpp --self-test`). Do not link OpenAL in the `check` preset.

--- a/port/rs2_audio.cpp
+++ b/port/rs2_audio.cpp
@@ -1,0 +1,187 @@
+// Record-only audio backend. No OpenAL, no DirectSound COM.
+
+#include "rs2_audio.h"
+
+#include <memory>
+#include <vector>
+
+struct Rs2AudioBuffer {
+	Rs2WavPcm pcm;
+	int playing = 0;
+	int ms = 0;
+	int volume_db = 0;
+	float x = 0.f;
+	float y = 0.f;
+	float z = 0.f;
+};
+
+namespace {
+
+std::vector<std::unique_ptr<Rs2AudioBuffer>> g_intern;
+Rs2AudioPlayRecord g_last{};
+Rs2AudioListener g_listener{
+    0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1.f,
+};
+
+bool pcm_fields_ok(const Rs2WavPcm *pcm) {
+	if (!pcm) return false;
+	if (pcm->wFormatTag != RS2_WAV_FORMAT_PCM) return false;
+	if (pcm->nChannels == 0 || pcm->nSamplesPerSec == 0) return false;
+	if (pcm->wBitsPerSample != 8 && pcm->wBitsPerSample != 16) return false;
+	const std::uint16_t align = static_cast<std::uint16_t>(
+	    (pcm->wBitsPerSample / 8u) * pcm->nChannels);
+	if (align == 0 || pcm->nBlockAlign != align) return false;
+	if (pcm->nAvgBytesPerSec != pcm->nSamplesPerSec * align) return false;
+	if (pcm->pcm.empty()) return false;
+	if (pcm->pcm.size() % align != 0) return false;
+	return true;
+}
+
+bool pcm_same(const Rs2WavPcm &a, const Rs2WavPcm &b) {
+	return a.wFormatTag == b.wFormatTag && a.nChannels == b.nChannels &&
+	       a.nSamplesPerSec == b.nSamplesPerSec &&
+	       a.nAvgBytesPerSec == b.nAvgBytesPerSec &&
+	       a.nBlockAlign == b.nBlockAlign &&
+	       a.wBitsPerSample == b.wBitsPerSample && a.pcm == b.pcm;
+}
+
+Rs2AudioBuffer *mutable_buf(Rs2AudioBufferHandle buf) {
+	for (auto &owned : g_intern) {
+		if (owned.get() == buf) return owned.get();
+	}
+	return nullptr;
+}
+
+void snapshot(const Rs2AudioBuffer *b) {
+	g_last = Rs2AudioPlayRecord{};
+	if (!b) return;
+	g_last.buffer = b;
+	g_last.playing = b->playing;
+	g_last.ms = b->ms;
+	g_last.volume_db = b->volume_db;
+	g_last.x = b->x;
+	g_last.y = b->y;
+	g_last.z = b->z;
+}
+
+}  // namespace
+
+void rs2_audio_backend_reset() {
+	g_intern.clear();
+	g_last = Rs2AudioPlayRecord{};
+	g_listener = Rs2AudioListener{
+	    0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1.f,
+	};
+}
+
+bool rs2_audio_backend_intern(const Rs2WavPcm *pcm, Rs2AudioBufferHandle *out) {
+	if (!out) return false;
+	*out = nullptr;
+	if (!pcm_fields_ok(pcm)) return false;
+
+	for (const auto &owned : g_intern) {
+		if (pcm_same(owned->pcm, *pcm)) {
+			*out = owned.get();
+			return true;
+		}
+	}
+
+	auto buf = std::make_unique<Rs2AudioBuffer>();
+	buf->pcm = *pcm;
+	*out = buf.get();
+	g_intern.emplace_back(std::move(buf));
+	return true;
+}
+
+void rs2_audio_backend_play(Rs2AudioBufferHandle buf, int ms) {
+	Rs2AudioBuffer *b = mutable_buf(buf);
+	if (!b) return;
+	b->playing = 1;
+	b->ms = ms;
+	snapshot(b);
+}
+
+void rs2_audio_backend_stop(Rs2AudioBufferHandle buf) {
+	Rs2AudioBuffer *b = mutable_buf(buf);
+	if (!b) return;
+	b->playing = 0;
+	snapshot(b);
+}
+
+void rs2_audio_backend_set_volume(Rs2AudioBufferHandle buf, int db) {
+	Rs2AudioBuffer *b = mutable_buf(buf);
+	if (!b) return;
+	b->volume_db = db;
+	snapshot(b);
+}
+
+void rs2_audio_backend_set_pos(Rs2AudioBufferHandle buf, float x, float y,
+                               float z) {
+	Rs2AudioBuffer *b = mutable_buf(buf);
+	if (!b) return;
+	b->x = x;
+	b->y = y;
+	b->z = z;
+	snapshot(b);
+}
+
+void rs2_audio_backend_set_listener_pos(float x, float y, float z) {
+	g_listener.px = x;
+	g_listener.py = y;
+	g_listener.pz = z;
+}
+
+void rs2_audio_backend_set_listener_dir(float dx, float dy, float dz, float ux,
+                                        float uy, float uz) {
+	g_listener.dx = dx;
+	g_listener.dy = dy;
+	g_listener.dz = dz;
+	g_listener.ux = ux;
+	g_listener.uy = uy;
+	g_listener.uz = uz;
+}
+
+void rs2_audio_backend_set_listener_sens(float f) {
+	g_listener.distance_factor = f;
+}
+
+bool rs2_audio_intern(const Rs2WavPcm *pcm, Rs2AudioBufferHandle *out) {
+	return rs2_audio_backend_intern(pcm, out);
+}
+
+const Rs2WavPcm *rs2_audio_buffer_pcm(Rs2AudioBufferHandle buf) {
+	return buf ? &buf->pcm : nullptr;
+}
+
+void rs2_audio_play(Rs2AudioBufferHandle buf, int ms) {
+	rs2_audio_backend_play(buf, ms);
+}
+
+void rs2_audio_stop(Rs2AudioBufferHandle buf) {
+	rs2_audio_backend_stop(buf);
+}
+
+void rs2_audio_set_volume(Rs2AudioBufferHandle buf, int db) {
+	rs2_audio_backend_set_volume(buf, db);
+}
+
+void rs2_audio_set_pos(Rs2AudioBufferHandle buf, float x, float y, float z) {
+	rs2_audio_backend_set_pos(buf, x, y, z);
+}
+
+void rs2_audio_set_listener_pos(float x, float y, float z) {
+	rs2_audio_backend_set_listener_pos(x, y, z);
+}
+
+void rs2_audio_set_listener_dir(float dx, float dy, float dz, float ux, float uy,
+                                float uz) {
+	rs2_audio_backend_set_listener_dir(dx, dy, dz, ux, uy, uz);
+}
+
+void rs2_audio_set_listener_sens(float f) {
+	rs2_audio_backend_set_listener_sens(f);
+}
+
+const Rs2AudioPlayRecord *rs2_audio_stub_last() { return &g_last; }
+
+const Rs2AudioListener *rs2_audio_stub_listener() { return &g_listener; }

--- a/port/rs2_audio.h
+++ b/port/rs2_audio.h
@@ -1,0 +1,63 @@
+// Stub audio backend: intern PCM into a buffer handle (#93, parent #7).
+// See docs/porting/audio-seams.md. Check preset links this stub only.
+// A later OpenAL TU can replace rs2_audio_backend_* without changing intern
+// or CWave play / stop / volume / 3D / listener call shapes.
+
+#pragma once
+
+#include "wav_pcm.h"
+
+struct Rs2AudioBuffer;
+
+// Opaque interned PCM buffer. Null is invalid (bad PCM / null args).
+using Rs2AudioBufferHandle = const Rs2AudioBuffer *;
+
+// Last play / stop / volume / 3D record. Check stub only; OpenAL will drive
+// a real source from the same handle.
+struct Rs2AudioPlayRecord {
+	Rs2AudioBufferHandle buffer;
+	int playing;    // 1 after play, 0 after stop
+	int ms;         // Play(ms): <0 looping from 0, else start offset
+	int volume_db;  // hundredths of a dB; 0 is DS-style max
+	float x, y, z;  // source position, meters
+};
+
+struct Rs2AudioListener {
+	float px, py, pz;  // listener position, meters
+	float dx, dy, dz;  // forward
+	float ux, uy, uz;  // up
+	float distance_factor;
+};
+
+// Intern Load-ready PCM (Rs2WavPcm after #81 / #86). Same format + payload
+// returns the same handle. Non-PCM, empty payload, or broken fields fail.
+bool rs2_audio_intern(const Rs2WavPcm *pcm, Rs2AudioBufferHandle *out);
+
+const Rs2WavPcm *rs2_audio_buffer_pcm(Rs2AudioBufferHandle buf);
+
+// Playback / 3D / listener (stub records; OpenAL later)
+void rs2_audio_play(Rs2AudioBufferHandle buf, int ms);
+void rs2_audio_stop(Rs2AudioBufferHandle buf);
+void rs2_audio_set_volume(Rs2AudioBufferHandle buf, int db);
+void rs2_audio_set_pos(Rs2AudioBufferHandle buf, float x, float y, float z);
+void rs2_audio_set_listener_pos(float x, float y, float z);
+void rs2_audio_set_listener_dir(float dx, float dy, float dz, float ux, float uy,
+                                float uz);
+void rs2_audio_set_listener_sens(float f);
+
+const Rs2AudioPlayRecord *rs2_audio_stub_last();
+const Rs2AudioListener *rs2_audio_stub_listener();
+
+// --- thin backend (stub here; OpenAL later) ---
+
+void rs2_audio_backend_reset();
+bool rs2_audio_backend_intern(const Rs2WavPcm *pcm, Rs2AudioBufferHandle *out);
+void rs2_audio_backend_play(Rs2AudioBufferHandle buf, int ms);
+void rs2_audio_backend_stop(Rs2AudioBufferHandle buf);
+void rs2_audio_backend_set_volume(Rs2AudioBufferHandle buf, int db);
+void rs2_audio_backend_set_pos(Rs2AudioBufferHandle buf, float x, float y,
+                               float z);
+void rs2_audio_backend_set_listener_pos(float x, float y, float z);
+void rs2_audio_backend_set_listener_dir(float dx, float dy, float dz, float ux,
+                                        float uy, float uz);
+void rs2_audio_backend_set_listener_sens(float f);

--- a/port/rs2_audio_test.cpp
+++ b/port/rs2_audio_test.cpp
@@ -1,0 +1,142 @@
+// Audio stub backend self-test (#93). No OpenAL, no DirectSound COM.
+
+#include "rs2_audio.h"
+#include "wav_pcm.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+// Hard-coded 48-byte PCM blob (no fact). 4 samples at 8-bit midpoint.
+const unsigned char kMinWav[] = {
+    'R',  'I',  'F',  'F',  0x28, 0x00, 0x00, 0x00, 'W',  'A',  'V',  'E',
+    'f',  'm',  't',  ' ',  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x22, 0x56, 0x00, 0x00, 0x22, 0x56, 0x00, 0x00, 0x01, 0x00, 0x08, 0x00,
+    'd',  'a',  't',  'a',  0x04, 0x00, 0x00, 0x00, 0x80, 0x80, 0x80, 0x80,
+};
+
+bool load_min(Rs2WavPcm *out) {
+	std::string err;
+	return rs2_wav_pcm_parse(kMinWav, sizeof(kMinWav), out, &err);
+}
+
+int self_test() {
+	rs2_audio_backend_reset();
+
+	Rs2WavPcm pcm{};
+	if (!expect(load_min(&pcm), "parse min wav")) return 1;
+
+	Rs2AudioBufferHandle a = nullptr;
+	if (!expect(rs2_audio_intern(&pcm, &a) && a != nullptr, "intern a"))
+		return 1;
+	const Rs2WavPcm *stored = rs2_audio_buffer_pcm(a);
+	if (!expect(stored && stored->pcm.size() == 4 && stored->pcm[0] == 0x80,
+	            "intern payload"))
+		return 1;
+	if (!expect(stored->nSamplesPerSec == 22050 && stored->nChannels == 1 &&
+	                stored->wBitsPerSample == 8,
+	            "intern fmt"))
+		return 1;
+
+	Rs2AudioBufferHandle b = nullptr;
+	if (!expect(rs2_audio_intern(&pcm, &b) && b == a, "same handle")) return 1;
+
+	pcm.pcm[0] = 0x7f;
+	Rs2AudioBufferHandle c = nullptr;
+	if (!expect(rs2_audio_intern(&pcm, &c) && c != nullptr && c != a,
+	            "distinct pcm"))
+		return 1;
+
+	rs2_audio_play(a, 100);
+	const Rs2AudioPlayRecord *rec = rs2_audio_stub_last();
+	if (!expect(rec && rec->buffer == a && rec->playing == 1 && rec->ms == 100,
+	            "play records handle"))
+		return 1;
+
+	rs2_audio_stop(a);
+	rec = rs2_audio_stub_last();
+	if (!expect(rec && rec->buffer == a && rec->playing == 0 && rec->ms == 100,
+	            "stop overwrite"))
+		return 1;
+
+	rs2_audio_set_volume(a, -500);
+	rec = rs2_audio_stub_last();
+	if (!expect(rec && rec->buffer == a && rec->volume_db == -500,
+	            "volume overwrite"))
+		return 1;
+
+	rs2_audio_set_pos(a, 1.5f, 2.25f, -3.f);
+	rec = rs2_audio_stub_last();
+	if (!expect(rec && rec->buffer == a && rec->x == 1.5f && rec->y == 2.25f &&
+	                rec->z == -3.f,
+	            "3D overwrite"))
+		return 1;
+
+	rs2_audio_play(a, -1);
+	rec = rs2_audio_stub_last();
+	if (!expect(rec && rec->playing == 1 && rec->ms == -1, "play looping"))
+		return 1;
+
+	rs2_audio_set_listener_pos(10.f, 0.f, 5.f);
+	rs2_audio_set_listener_dir(0.f, 0.f, 1.f, 0.f, 1.f, 0.f);
+	rs2_audio_set_listener_sens(10.f);
+	const Rs2AudioListener *lis = rs2_audio_stub_listener();
+	if (!expect(lis && lis->px == 10.f && lis->pz == 5.f &&
+	                lis->distance_factor == 10.f && lis->dz == 1.f &&
+	                lis->uy == 1.f,
+	            "listener overwrite"))
+		return 1;
+
+	Rs2WavPcm bad = pcm;
+	bad.pcm.clear();
+	Rs2AudioBufferHandle h = reinterpret_cast<Rs2AudioBufferHandle>(1);
+	if (!expect(!rs2_audio_intern(&bad, &h) && h == nullptr, "empty pcm"))
+		return 1;
+
+	bad = pcm;
+	bad.wFormatTag = 2;
+	h = reinterpret_cast<Rs2AudioBufferHandle>(1);
+	if (!expect(!rs2_audio_intern(&bad, &h) && h == nullptr, "non-pcm tag"))
+		return 1;
+
+	bad = pcm;
+	bad.nChannels = 0;
+	h = reinterpret_cast<Rs2AudioBufferHandle>(1);
+	if (!expect(!rs2_audio_intern(&bad, &h) && h == nullptr, "zero channels"))
+		return 1;
+
+	h = reinterpret_cast<Rs2AudioBufferHandle>(1);
+	if (!expect(!rs2_audio_intern(nullptr, &h) && h == nullptr, "null pcm"))
+		return 1;
+	if (!expect(!rs2_audio_intern(&pcm, nullptr), "null out")) return 1;
+
+	const Rs2AudioPlayRecord *frozen = rs2_audio_stub_last();
+	if (!expect(frozen && frozen->buffer == a && frozen->playing == 1,
+	            "bad intern leaves last"))
+		return 1;
+
+	rs2_audio_play(nullptr, 0);
+	if (!expect(rs2_audio_stub_last()->buffer == a, "null play ignored"))
+		return 1;
+
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test") == 0) {
+		const int rc = self_test();
+		if (rc == 0) std::printf("rs2_audio_test: ok\n");
+		return rc;
+	}
+	std::fprintf(stderr, "usage: rs2_audio_test --self-test\n");
+	return 2;
+}


### PR DESCRIPTION
## Summary
- Add `port/rs2_audio.*` so Load-ready PCM (`Rs2WavPcm`) interns behind an opaque buffer handle; the same format + payload returns the same handle.
- Check stub records play / stop / volume / 3D position / listener. Broken PCM (non-PCM tag, empty payload, zero channels) fails. No OpenAL, no DirectSound COM, no `lib/sound.cpp` allowlist.
- Lock the backend entry in `docs/porting/audio-seams.md`. OpenAL stays off the check preset.

Closes #93

## Test plan
- [x] `./scripts/check.sh` (encoding-guard, cmake check, ctest)
- [x] `rs2_audio_self_test`: valid PCM intern, play records handle, stop/volume/3D overwrite, bad PCM fails


Made with [Cursor](https://cursor.com)