### PR TITLE
Route CWave play through the rs2_audio stub (#96)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,9 +318,9 @@ add_test(NAME rs2_wav_pcm_distribution COMMAND rs2_wav_pcm_test
   "${CMAKE_SOURCE_DIR}/Distribution")
 set_tests_properties(rs2_wav_pcm_distribution PROPERTIES SKIP_RETURN_CODE 77)
 
-# CWave::Load maps Rs2WavPcm onto CWave fields (#86). No OpenAL / sound.cpp.
+# CWave::Load maps Rs2WavPcm onto CWave fields (#86). Play records intern handle (#96). No OpenAL / sound.cpp.
 add_executable(rs2_wave_load_test port/wave_load_test.cpp lib/wave.cpp port/wav_pcm.cpp
-  port/path.cpp)
+  port/path.cpp port/rs2_audio.cpp)
 target_include_directories(rs2_wave_load_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")
 target_include_directories(rs2_wave_load_test PRIVATE

--- a/docs/porting/audio-seams.md
+++ b/docs/porting/audio-seams.md
@@ -342,7 +342,7 @@ This is the portable stand-in for the [mmio* contract](#closed-mmio-set-wav-pars
 
 `CWave::Load` already yields `Rs2WavPcm` (#86). This slice interns that payload as an opaque buffer handle. Same format + bytes return the same handle. Non-PCM tag, empty payload, zero channels/rate, or 8/16-bit mismatch fail. Play records the handle on `rs2_audio_stub_last()`; stop / volume (hundredths of a dB) / 3D position (meters) overwrite that record. Listener pos / dir / distance factor live on `rs2_audio_stub_listener()`.
 
-The check preset links the stub only. There is no OpenAL, no DirectSound COM, and no `lib/sound.cpp` allowlist. `CreateBuffer` / `CWave::Play` still talk to the dsound stub until the next `#7` slice maps `CWave` onto these handles.
+The check preset links the stub only. There is no OpenAL, no DirectSound COM, and no `lib/sound.cpp` allowlist. `#96` maps `CWave::CreateBuffer` / `Play` / `Stop` / volume / 3D onto these handles.
 
 | DirectSound / `CWave` | `port/rs2_audio` | Later OpenAL |
 |-----------------------|------------------|--------------|
@@ -353,3 +353,15 @@ The check preset links the stub only. There is no OpenAL, no DirectSound COM, an
 | `SetListenerPos` / `Dir` / `Sens` | `rs2_audio_set_listener_*` | `alListener` + distance factor |
 
 ctest: `rs2_audio_self_test` (`port/rs2_audio_test.cpp --self-test`). Do not link OpenAL in the `check` preset.
+
+## CWave play path uses port/rs2_audio (#96)
+
+- **Issue**: [#96](https://github.com/lollipop-onl/railsim2-portable/issues/96) (parent [#7](https://github.com/lollipop-onl/railsim2-portable/issues/7))
+- **Entry**: `CWave::CreateBuffer` intern `m_pcm` via `rs2_audio_intern`; `Play` / `Stop` / `SetVolume` / `SetPos` call `rs2_audio_*` (signatures unchanged)
+- **Allowlist**: `lib/wave.cpp` is already in `port/native_sources.txt`
+
+`CreateBuffer` builds `Rs2WavPcm` from the WAVEFORMATEX + `m_pcm` payload and interns it. Intern failure (empty payload, non-PCM tag, broken fields) returns `FALSE`. DirectSound `CreateSoundBuffer` + `Lock` / `Unlock` still run when `svs.pDS` is set; they are not required for the portable play path. Without a DS device, intern success is enough for `Load` to return `TRUE`.
+
+`CWave::m_audio` holds the opaque handle. `Play(ms)` records it on `rs2_audio_stub_last()`; `Stop` / `SetVolume` (hundredths of a dB) / `SetPos` (meters) overwrite that record. Do not allowlist `lib/sound.cpp`, rewrite `CWaveStream` / `CSoundEffector` / `CWaveArray`, or link OpenAL in the `check` preset.
+
+ctest: `rs2_wave_load_self_test` (`port/wave_load_test.cpp --self-test`) checks that `CWave::Play` records the interned handle.

--- a/lib/wave.cpp
+++ b/lib/wave.cpp
@@ -6,6 +6,7 @@
 #include "sound.h"
 #include "wave.h"
 #include "wav_pcm.h"
+#include "rs2_audio.h"
 
 #include <cstring>
 
@@ -59,6 +60,7 @@ CWave::CWave(){
 	m_pSB = NULL;
 	m_p3D = NULL;
 	m_pFX = NULL;
+	m_audio = NULL;
 	m_BytesPerSec = 0;
 	m_nChannels = 0;
 	m_wBitsPerSample = 0;
@@ -162,7 +164,23 @@ BOOL CWave::Duplicate(CWave *pWav){
  *	len	: ウエーブサイズ
  */
 BOOL CWave::CreateBuffer(LPWAVEFORMATEX pFmt, DWORD len){
-	if(!svs.pDS) return FALSE;
+	m_audio = NULL;
+	Rs2WavPcm intern{};
+	if(pFmt){
+		intern.wFormatTag = pFmt->wFormatTag;
+		intern.nChannels = pFmt->nChannels;
+		intern.nSamplesPerSec = pFmt->nSamplesPerSec;
+		intern.nAvgBytesPerSec = pFmt->nAvgBytesPerSec;
+		intern.nBlockAlign = pFmt->nBlockAlign;
+		intern.wBitsPerSample = pFmt->wBitsPerSample;
+	}
+	intern.pcm = m_pcm;
+	if(!rs2_audio_intern(&intern, &m_audio)){
+		m_audio = NULL;
+		return FALSE;
+	}
+
+	if(!svs.pDS) return TRUE;
 	//	バッファの作成
 	DSBUFFERDESC desc;
 
@@ -255,6 +273,7 @@ void CWave::Free(){
 	RELEASE(m_p3D);
 	RELEASE(m_pFX);
 	RELEASE(m_pSB);
+	m_audio = NULL;
 	m_pcm.clear();
 	m_nChannels = 0;
 	m_wBitsPerSample = 0;
@@ -267,6 +286,7 @@ void CWave::Free(){
  *	ms	: 再生開始位置 [ms] (<0 でループ)
  */
 void CWave::Play(int ms){
+	if(m_audio) rs2_audio_play(m_audio, ms);
 	if(!m_pSB) return;
 
 	m_pSB->Stop();
@@ -284,6 +304,21 @@ void CWave::Play(int ms){
 #endif
 		Load((char *)m_strName.c_str());
 	}
+}
+
+void CWave::Stop(){
+	if(m_audio) rs2_audio_stop(m_audio);
+	if(m_pSB) m_pSB->Stop();
+}
+
+void CWave::SetVolume(LONG dB){
+	if(m_audio) rs2_audio_set_volume(m_audio, dB);
+	if(m_pSB) m_pSB->SetVolume(dB);
+}
+
+void CWave::SetPos(VEC3 v){
+	if(m_audio) rs2_audio_set_pos(m_audio, v.x, v.y, v.z);
+	if(svs.f3D && m_p3D) m_p3D->SetPosition(v.x, v.y, v.z, DS3D_IMMEDIATE);
 }
 
 /*

--- a/lib/wave.h
+++ b/lib/wave.h
@@ -26,6 +26,7 @@ public:
 	WORD		m_nChannels;	//	WAVE channels
 	WORD		m_wBitsPerSample;	//	WAVE bits
 	vector<unsigned char>	m_pcm;	//	PCM payload
+	const struct Rs2AudioBuffer *m_audio;	// interned PCM handle
 
 	CWave();
 	~CWave();
@@ -40,19 +41,19 @@ public:
 /*
  *	停止
  */
-	void Stop(){if(m_pSB) m_pSB->Stop();}
+	void Stop();
 /*
  *	音量の設定 
  *
  *	dB	: DSBVOLUME_MIN-DSBVOLUME_MAX(1/100dB単位)
  */
-	void SetVolume(LONG dB = DSBVOLUME_MAX){if(m_pSB) m_pSB->SetVolume(dB);}
+	void SetVolume(LONG dB = DSBVOLUME_MAX);
 /*
  *	3D定位の設定
  *
  *	v		: 位置(メートル)
  */
-	void SetPos(VEC3 v){if(svs.f3D && m_p3D) m_p3D->SetPosition(v.x, v.y, v.z, DS3D_IMMEDIATE);}
+	void SetPos(VEC3 v);
 /*
  *	音源の移動速度の設定
  *

--- a/port/wave_load_test.cpp
+++ b/port/wave_load_test.cpp
@@ -1,5 +1,6 @@
 #define RS2_PATH_NO_FOPEN_WRAP 1
-// CWave::Load field mapping vs the #81 PCM table. No OpenAL / no sound.cpp.
+// CWave::Load field mapping vs the #81 PCM table. Play records intern handle (#96).
+// No OpenAL / no sound.cpp.
 
 #include "headers.h"
 #include "debug.h"
@@ -7,6 +8,7 @@
 #include "sound.h"
 #include "wave.h"
 #include "wav_pcm.h"
+#include "rs2_audio.h"
 
 #include <cstdio>
 #include <cstring>
@@ -33,6 +35,14 @@ const unsigned char kMinWav[] = {
     'd',  'a',  't',  'a',  0x04, 0x00, 0x00, 0x00, 0x80, 0x80, 0x80, 0x80,
 };
 
+// PCM fmt + empty data payload: parse maps fields, intern fails (#96).
+const unsigned char kEmptyDataWav[] = {
+    'R',  'I',  'F',  'F',  0x24, 0x00, 0x00, 0x00, 'W',  'A',  'V',  'E',
+    'f',  'm',  't',  ' ',  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x22, 0x56, 0x00, 0x00, 0x22, 0x56, 0x00, 0x00, 0x01, 0x00, 0x08, 0x00,
+    'd',  'a',  't',  'a',  0x00, 0x00, 0x00, 0x00,
+};
+
 bool write_temp(const char *path, const unsigned char *b, std::size_t n) {
 	std::ofstream out(path, std::ios::binary);
 	if (!out) return false;
@@ -47,11 +57,12 @@ int self_test() {
 		return 1;
 	}
 
+	rs2_audio_backend_reset();
 	svs.pDS = NULL;
 	CWave w;
-	// No device: CreateBuffer fails, but Load must still map parser fields.
-	if (w.Load(const_cast<char *>(path))) {
-		std::fprintf(stderr, "wave_load: Load succeeded without pDS\n");
+	// No device: intern is enough for Load / Play (#96).
+	if (!w.Load(const_cast<char *>(path))) {
+		std::fprintf(stderr, "wave_load: Load intern failed\n");
 		std::remove(path);
 		return 1;
 	}
@@ -79,13 +90,37 @@ int self_test() {
 		return 1;
 	}
 
+	w.Play(100);
+	const Rs2AudioPlayRecord *rec = rs2_audio_stub_last();
+	if (!rec || rec->buffer == nullptr || rec->buffer != w.m_audio ||
+	    rec->playing != 1 || rec->ms != 100) {
+		std::fprintf(stderr, "wave_load: Play did not record interned handle\n");
+		std::remove(path);
+		return 1;
+	}
+
 	CWave bad;
 	if (bad.Load(const_cast<char *>("rs2_wave_load_missing.wav")) ||
-	    !bad.m_pcm.empty()) {
+	    !bad.m_pcm.empty() || bad.m_audio != nullptr) {
 		std::fprintf(stderr, "wave_load: missing file should fail unmapped\n");
 		std::remove(path);
 		return 1;
 	}
+
+	const char *empty_path = "rs2_wave_load_empty.wav";
+	if (!write_temp(empty_path, kEmptyDataWav, sizeof(kEmptyDataWav))) {
+		std::fprintf(stderr, "wave_load: cannot write %s\n", empty_path);
+		std::remove(path);
+		return 1;
+	}
+	CWave empty;
+	if (empty.Load(const_cast<char *>(empty_path)) || empty.m_audio != nullptr) {
+		std::fprintf(stderr, "wave_load: empty PCM intern should fail\n");
+		std::remove(empty_path);
+		std::remove(path);
+		return 1;
+	}
+	std::remove(empty_path);
 
 	std::remove(path);
 	std::printf("wave_load: self-test ok\n");
@@ -103,8 +138,8 @@ int distribution_test(const char *root) {
 
 	svs.pDS = NULL;
 	CWave w;
-	if (w.Load(const_cast<char *>(path.c_str()))) {
-		std::fprintf(stderr, "wave_load: Load succeeded without pDS\n");
+	if (!w.Load(const_cast<char *>(path.c_str()))) {
+		std::fprintf(stderr, "wave_load: Error.wav intern failed\n");
 		return 1;
 	}
 	// Inventory: Error.wav is 1 ch / 22050 Hz / 8-bit, data cksize 3307.


### PR DESCRIPTION
## Summary
- `CWave::CreateBuffer` interns `m_pcm` via `rs2_audio_intern` and fails on intern failure. DirectSound `Lock` remains when `svs.pDS` is set; intern success is enough without a DS device.
- `Play` / `Stop` / `SetVolume` / `SetPos` keep their signatures and call `rs2_audio_*`. `rs2_wave_load_self_test` asserts Play records the interned handle.
- Document the CWave swap entry in `docs/porting/audio-seams.md`. No OpenAL, no `lib/sound.cpp` allowlist, no CWaveStream / CSoundEffector / CWaveArray rewrite.

Closes #96

## Test plan
- [x] `./scripts/check.sh` (encoding-guard, cmake check, ctest)
- [x] `rs2_wave_load_self_test`: Load intern without pDS, Play records handle, empty PCM intern fails
- [x] `rs2_wave_load_distribution`: Error.wav fields still map


Made with [Cursor](https://cursor.com)