### PR TITLE
Route SystemCover Dialog/ErrorDialog off sync MessageBox (#97)

### DIFF
--- a/SystemCover.cpp
+++ b/SystemCover.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "CPixelbit.h"
+#include "CSimpleDialog.h"
 
 //	ì‡ïîíËêî
 const char *const DIALOG_TITLE = "RailSim II";
@@ -48,8 +49,8 @@ void Dialog(
 	va_start(vl, format);
 	vsprintf(g_FlashBuf[g_FlashBufSelect], format, vl);
 	va_end(vl);
-	MessageBox(GetActiveWindow(),
-		g_FlashBuf[g_FlashBufSelect], DIALOG_TITLE, MB_APPLMODAL);
+	EnqueueCommonDialog(new CSimpleDialog(
+		g_FlashBuf[g_FlashBufSelect], (char *)DIALOG_TITLE));
 }
 
 /*
@@ -64,11 +65,9 @@ void ErrorDialog(
 	va_start(vl, format);
 	vsprintf(g_FlashBuf[g_FlashBufSelect], format, vl);
 	va_end(vl);
+	fprintf(stderr, "ErrorDialog: %s\n", g_FlashBuf[g_FlashBufSelect]);
 	ShowCursor(TRUE);
 	DestroyWindow(svw.hWnd);
-	MessageBox(GetActiveWindow(),
-		g_FlashBuf[g_FlashBufSelect], DIALOG_TITLE, MB_APPLMODAL);
-	//PostQuitMessage(0);
 	ExitProcess(0);
 }
 

--- a/docs/porting/sync-dialog-seams.md
+++ b/docs/porting/sync-dialog-seams.md
@@ -182,3 +182,17 @@ Replace **this closed sync set** ? eight `MessageBox` sites, four `Get*FileName`
 4. Redesigning **`ErrorDialog`** as fatal shutdown, not an in-frame dialog.
 
 After `#12` planning, a reader should be able to answer: Ågswap these wrappers and Win32 calls, and every remaining sync modal is accounted for.Åh
+
+## Dialog / ErrorDialog replacement (#97)
+
+- **Issue**: [#97](https://github.com/lollipop-onl/railsim2-portable/issues/97) (parent [#12](https://github.com/lollipop-onl/railsim2-portable/issues/12))
+- **Entry**: `SystemCover.cpp` `Dialog` / `ErrorDialog` (void signatures unchanged)
+- **Allowlist**: `SystemCover.cpp` in `port/native_sources.txt`
+
+`Dialog` still formats into `g_FlashBuf`, then `EnqueueCommonDialog(new CSimpleDialog(text, DIALOG_TITLE))`. `CInterface::Init` copies the label into `std::string`, so the flash buffer may be reused after return. This is the same OK-only queue as the rest of the game; the caller does not block.
+
+`ErrorDialog` is not queued. It logs to stderr, then the existing teardown (`ShowCursor(TRUE)`, `DestroyWindow(svw.hWnd)`, `ExitProcess(0)`). `ExitProcess` is the port exit in `port/stub/windows.h` (no-op under the check firewall). No sync `MessageBox`.
+
+`RS2_ROUNDTRIP` keeps `port/rs2_roundtrip_stubs.cpp` `ErrorDialog` as log-only so `Sample.rs2` load can fail into `CSynErr` without process teardown.
+
+Do not change `YesNo` / `YesNoCancel` / `SelectFile` / `ShowLastError` / `ColorDialog`, or `lib/input.cpp` `MsgBox` / `MsgYesNo`. Those wrappers still compile through the firewall (`OPENFILENAME` / `CHOOSECOLOR` / `FormatMessage` stubs in `port/stub/windows.h` are compile-only; not a file-picker backend).

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -72,3 +72,4 @@ CFileMode.cpp
 CTreeElement.cpp
 lib/input.cpp
 lib/wave.cpp
+SystemCover.cpp

--- a/port/rs2_roundtrip_stubs.cpp
+++ b/port/rs2_roundtrip_stubs.cpp
@@ -159,6 +159,8 @@ char *FlashIn(char *format, ...) {
 	return g_flash_buf[g_flash_sel];
 }
 
+// Roundtrip harness: log only. Live ErrorDialog in SystemCover.cpp is fatal
+// (stderr + DestroyWindow + ExitProcess). Sample.rs2 must not tear down here.
 void ErrorDialog(char *format, ...) {
 	char buf[2048];
 	va_list vl;

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -382,6 +382,79 @@ typedef struct _RTL_CRITICAL_SECTION {
 #ifndef strcmpi
 #define strcmpi strcasecmp
 #endif
+#ifndef _strcmpi
+#define _strcmpi strcasecmp
+#endif
+
+typedef DWORD COLORREF;
+typedef HANDLE HLOCAL;
+typedef char* LPTSTR;
+
+#ifndef RGB
+#define RGB(r, g, b) \
+  ((COLORREF)(((BYTE)(r) | ((WORD)((BYTE)(g)) << 8)) | (((DWORD)(BYTE)(b)) << 16)))
+#endif
+#ifndef GetRValue
+#define GetRValue(rgb) ((BYTE)((rgb) & 0xff))
+#endif
+#ifndef GetGValue
+#define GetGValue(rgb) ((BYTE)(((WORD)(rgb) >> 8) & 0xff))
+#endif
+#ifndef GetBValue
+#define GetBValue(rgb) ((BYTE)(((rgb) >> 16) & 0xff))
+#endif
+
+#define OFN_OVERWRITEPROMPT 0x00000002
+#define OFN_HIDEREADONLY 0x00000004
+#define OFN_FILEMUSTEXIST 0x00001000
+
+typedef struct tagOPENFILENAMEA {
+  DWORD lStructSize;
+  HWND hwndOwner;
+  LPCSTR lpstrFilter;
+  DWORD nFilterIndex;
+  LPCSTR lpstrDefExt;
+  DWORD nMaxFile;
+  LPSTR lpstrFile;
+  DWORD Flags;
+} OPENFILENAMEA, OPENFILENAME, *LPOPENFILENAME;
+
+inline BOOL GetOpenFileNameA(OPENFILENAME *) { return FALSE; }
+inline BOOL GetSaveFileNameA(OPENFILENAME *) { return FALSE; }
+inline BOOL GetOpenFileName(OPENFILENAME *o) { return GetOpenFileNameA(o); }
+inline BOOL GetSaveFileName(OPENFILENAME *o) { return GetSaveFileNameA(o); }
+
+#define CC_RGBINIT 0x00000001
+#define CC_FULLOPEN 0x00000002
+
+typedef struct tagCHOOSECOLORA {
+  DWORD lStructSize;
+  HWND hwndOwner;
+  COLORREF rgbResult;
+  COLORREF *lpCustColors;
+  DWORD Flags;
+} CHOOSECOLORA, CHOOSECOLOR, *LPCHOOSECOLOR;
+
+inline BOOL ChooseColorA(CHOOSECOLOR *) { return FALSE; }
+inline BOOL ChooseColor(CHOOSECOLOR *c) { return ChooseColorA(c); }
+
+#define FORMAT_MESSAGE_ALLOCATE_BUFFER 0x00000100
+#define FORMAT_MESSAGE_IGNORE_INSERTS 0x00000200
+#define FORMAT_MESSAGE_FROM_SYSTEM 0x00001000
+#define LANG_NEUTRAL 0x00
+#define SUBLANG_DEFAULT 0x01
+#ifndef MAKELANGID
+#define MAKELANGID(p, s) ((WORD)((((WORD)(s)) << 10) | (WORD)(p)))
+#endif
+
+inline DWORD FormatMessageA(DWORD, LPCVOID, DWORD, DWORD, LPSTR, DWORD, va_list *) {
+  return 0;
+}
+inline DWORD FormatMessage(DWORD f, LPCVOID s, DWORD m, DWORD l, LPSTR b, DWORD n,
+                           va_list *a) {
+  return FormatMessageA(f, s, m, l, b, n, a);
+}
+inline HLOCAL LocalFree(HLOCAL) { return nullptr; }
 
 #define MB_APPLMODAL 0x00000000L
 #define MB_YESNO 0x00000004L


### PR DESCRIPTION
## Summary
- Replace `SystemCover.cpp` `Dialog` (void, OK-only) with `CSimpleDialog` + `EnqueueCommonDialog`; keep the existing flash-buffer format path.
- Replace `ErrorDialog` with stderr log + `ShowCursor` / `DestroyWindow` / `ExitProcess` (no sync `MessageBox`). Roundtrip keeps a log-only stub so `Sample.rs2` load can fail without tearing down the process.
- Allowlist `SystemCover.cpp` (`71/254`). CommDlg / `FormatMessage` stubs in `port/stub/windows.h` are compile-only so `YesNo` / `SelectFile` / `ShowLastError` still parse. Do not touch `lib/input.cpp` `MsgBox` / `MsgYesNo`.

Closes #97

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, native compile including `SystemCover.cpp`, 25/25 ctest, progress `71/254`)
- [x] `Dialog` / `ErrorDialog` no longer call `MessageBox`; `YesNo` / `YesNoCancel` / `SelectFile` / `ShowLastError` unchanged
- [ ] Cursor auto-review on this PR


Made with [Cursor](https://cursor.com)