### PR TITLE
Record UTF-8 TEXTINPUT composition/result in a port IME stub (#100)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_audio.cpp"
+  "${CMAKE_SOURCE_DIR}/port/rs2_ime.cpp"
   "${CMAKE_SOURCE_DIR}/lib/movie.cpp")
 
 target_include_directories(railsim2_native SYSTEM BEFORE PRIVATE
@@ -357,3 +358,12 @@ target_compile_features(rs2_audio_test PRIVATE cxx_std_17)
 target_compile_options(rs2_audio_test PRIVATE -Wall -Wextra)
 
 add_test(NAME rs2_audio_self_test COMMAND rs2_audio_test --self-test)
+
+# Stub IME / TEXTINPUT composition + result (#100). No SDL / Imm COM.
+add_executable(rs2_ime_test port/rs2_ime_test.cpp port/rs2_ime.cpp port/rs2_text.cpp)
+target_include_directories(rs2_ime_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ime_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ime_test PRIVATE -Wall -Wextra)
+target_link_libraries(rs2_ime_test PRIVATE Iconv::Iconv)
+
+add_test(NAME rs2_ime_self_test COMMAND rs2_ime_test --self-test)

--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -182,3 +182,22 @@ Expect: Imm* in `lib/editbox.cpp` / `lib/editbox.h`, `lib/window.cpp`, and `lib/
 The twelve live `_mbsicmp` calls in the [closed compare set](#closed-_mbsicmp-set-compare) are gone. Those five files call `rs2_text_icmp` (CP932 decode, then ASCII A-Z fold). On-disk `.rs2` / plugin txt bytes stay CP932. IME (`Imm*`) is unchanged.
 
 `lib/texture.cpp` and `lib/mesh.cpp` still use `rs2_text_icmp` but stay off the allowlist: they fail on D3D/GDI / `rmxfguid.h`, not on `_mbsicmp`. Do not grow those drawing stubs in a charset slice. `rs2_text_self_test` keeps the #75 icmp cases (ASCII fold, trail-byte trap, layout name).
+
+## Port IME / TEXTINPUT stub backend (`port/rs2_ime`)
+
+- **Issue**: [#100](https://github.com/lollipop-onl/railsim2-portable/issues/100) (parent [#9](https://github.com/lollipop-onl/railsim2-portable/issues/9); depends on [#75](https://github.com/lollipop-onl/railsim2-portable/issues/75) / [#87](https://github.com/lollipop-onl/railsim2-portable/issues/87))
+- **Entry**: `rs2_ime_composition_utf8` / `rs2_ime_result_utf8` / `rs2_ime_get_composition_string_a` in `port/rs2_ime.h`
+- **Backend hooks**: `rs2_ime_backend_*` (stub in `port/rs2_ime.cpp`; SDL2 later replaces composition + TEXTINPUT commit)
+
+Check preset records UTF-8 composition (`SDL_TEXTEDITING`) and result (`SDL_TEXTINPUT`) only. There is no Imm COM, no SDL2, and no `lib/editbox.cpp` / `lib/window.cpp` allowlist. `rs2_ime_get_composition_string_a` is the `ImmGetCompositionStringA` stand-in: `RS2_IME_GCS_COMPSTR` / `RS2_IME_GCS_RESULTSTR` (same numbers as Win32 `GCS_COMPSTR` / `GCS_RESULTSTR`) return CP932 via `rs2_utf8_to_cp932`. In-process getters stay UTF-8 ([charset-internal.md](charset-internal.md)).
+
+| Imm* / `CEditBox` | `port/rs2_ime` | Later SDL2 |
+|-------------------|----------------|------------|
+| `GCS_COMPSTR` -> `m_comp` | `rs2_ime_backend_set_composition` / `rs2_ime_composition_utf8` | `SDL_TEXTEDITING` |
+| `GCS_RESULTSTR` -> `CompEnd` | `rs2_ime_backend_commit` / `rs2_ime_result_utf8` | `SDL_TEXTINPUT` |
+| `ImmGetCompositionStringA` | `rs2_ime_get_composition_string_a` | same helper (CP932 at the Win32-compat edge) |
+| cancel / focus loss | `rs2_ime_backend_clear` | stop text input + empty both |
+
+A later IME PR still replaces `lib/editbox.cpp` + the `WM_IME_SETCONTEXT` hide in `lib/window.cpp` with these hooks. Do not rewrite `CEditCtrl` / list / tree rename here. Do not add SDL2 to the `check` preset.
+
+ctest: `rs2_ime_self_test` (`port/rs2_ime_test.cpp --self-test`) covers empty composition, ASCII commit, CP932 2-byte roundtrip, and clear.

--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -189,7 +189,7 @@ The twelve live `_mbsicmp` calls in the [closed compare set](#closed-_mbsicmp-se
 - **Entry**: `rs2_ime_composition_utf8` / `rs2_ime_result_utf8` / `rs2_ime_get_composition_string_a` in `port/rs2_ime.h`
 - **Backend hooks**: `rs2_ime_backend_*` (stub in `port/rs2_ime.cpp`; SDL2 later replaces composition + TEXTINPUT commit)
 
-Check preset records UTF-8 composition (`SDL_TEXTEDITING`) and result (`SDL_TEXTINPUT`) only. There is no Imm COM, no SDL2, and no `lib/editbox.cpp` / `lib/window.cpp` allowlist. `rs2_ime_get_composition_string_a` is the `ImmGetCompositionStringA` stand-in: `RS2_IME_GCS_COMPSTR` / `RS2_IME_GCS_RESULTSTR` (same numbers as Win32 `GCS_COMPSTR` / `GCS_RESULTSTR`) return CP932 via `rs2_utf8_to_cp932`. In-process getters stay UTF-8 ([charset-internal.md](charset-internal.md)).
+Check preset records UTF-8 composition (`SDL_TEXTEDITING`) and result (`SDL_TEXTINPUT`) only. There is no Imm COM, no SDL2, and no `lib/editbox.cpp` / `lib/window.cpp` allowlist. `rs2_ime_get_composition_string_a` is the `ImmGetCompositionStringA` stand-in: `RS2_IME_GCS_COMPSTR` (`0x0008`, Win32 `GCS_COMPSTR`) / `RS2_IME_GCS_RESULTSTR` (`0x0800`, Win32 `GCS_RESULTSTR`; not `0x1000` `GCS_RESULTCLAUSE`) return CP932 via `rs2_utf8_to_cp932`. In-process getters stay UTF-8 ([charset-internal.md](charset-internal.md)).
 
 | Imm* / `CEditBox` | `port/rs2_ime` | Later SDL2 |
 |-------------------|----------------|------------|

--- a/port/rs2_ime.cpp
+++ b/port/rs2_ime.cpp
@@ -1,0 +1,69 @@
+// Record-only IME / TEXTINPUT backend. No Imm COM, no SDL.
+
+#include "rs2_ime.h"
+
+#include "rs2_text.h"
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+
+namespace {
+
+std::string g_composition_utf8;
+std::string g_result_utf8;
+
+const char *as_cstr(const std::string &s) { return s.c_str(); }
+
+int copy_cp932(const std::string &utf8, void *buf, unsigned buf_size) {
+	const std::string cp932 = rs2_utf8_to_cp932(utf8.c_str());
+	const unsigned n = static_cast<unsigned>(cp932.size());
+	if (!buf || buf_size == 0) return static_cast<int>(n);
+	const unsigned copy = std::min(n, buf_size);
+	if (copy > 0) std::memcpy(buf, cp932.data(), copy);
+	return static_cast<int>(copy);
+}
+
+}  // namespace
+
+void rs2_ime_backend_reset() {
+	g_composition_utf8.clear();
+	g_result_utf8.clear();
+}
+
+void rs2_ime_backend_set_composition(const char *utf8) {
+	g_composition_utf8 = utf8 ? utf8 : "";
+}
+
+void rs2_ime_backend_commit(const char *utf8) {
+	g_result_utf8 = utf8 ? utf8 : "";
+	g_composition_utf8.clear();
+}
+
+void rs2_ime_backend_clear() { rs2_ime_backend_reset(); }
+
+void rs2_ime_stub_set_composition(const char *utf8) {
+	rs2_ime_backend_set_composition(utf8);
+}
+
+void rs2_ime_stub_commit(const char *utf8) { rs2_ime_backend_commit(utf8); }
+
+void rs2_ime_stub_clear() { rs2_ime_backend_clear(); }
+
+void rs2_ime_reset() { rs2_ime_backend_reset(); }
+
+const char *rs2_ime_composition_utf8() { return as_cstr(g_composition_utf8); }
+
+const char *rs2_ime_result_utf8() { return as_cstr(g_result_utf8); }
+
+int rs2_ime_get_composition_string_a(unsigned dw_index, void *buf,
+                                     unsigned buf_size) {
+	switch (dw_index) {
+	case RS2_IME_GCS_COMPSTR:
+		return copy_cp932(g_composition_utf8, buf, buf_size);
+	case RS2_IME_GCS_RESULTSTR:
+		return copy_cp932(g_result_utf8, buf, buf_size);
+	default:
+		return 0;
+	}
+}

--- a/port/rs2_ime.h
+++ b/port/rs2_ime.h
@@ -12,7 +12,7 @@
 // Same numbers as <imm.h>; stub/imm.h does not define these yet.
 enum {
 	RS2_IME_GCS_COMPSTR = 0x0008,
-	RS2_IME_GCS_RESULTSTR = 0x1000
+	RS2_IME_GCS_RESULTSTR = 0x0800
 };
 
 // --- thin backend (stub here; SDL_TEXTINPUT later) ---

--- a/port/rs2_ime.h
+++ b/port/rs2_ime.h
@@ -1,0 +1,42 @@
+// Stub IME / TEXTINPUT backend (#100, parent #9).
+// See docs/porting/charset-seams.md. Check preset links this stub only.
+// A later SDL2 TU can replace rs2_ime_backend_* without changing composition
+// / result / ImmGetCompositionStringA-equivalent call shapes.
+//
+// In-process text is UTF-8. ImmGetCompositionStringA-equivalent returns
+// CP932 via rs2_text (Win32-compat boundary).
+
+#pragma once
+
+// Win32 ImmGetCompositionString dwIndex values used by CEditBox.
+// Same numbers as <imm.h>; stub/imm.h does not define these yet.
+enum {
+	RS2_IME_GCS_COMPSTR = 0x0008,
+	RS2_IME_GCS_RESULTSTR = 0x1000
+};
+
+// --- thin backend (stub here; SDL_TEXTINPUT later) ---
+
+void rs2_ime_backend_reset();
+void rs2_ime_backend_set_composition(const char *utf8);
+void rs2_ime_backend_commit(const char *utf8);
+void rs2_ime_backend_clear();
+
+// Injected TEXTINPUT / composition for the stub / ctest. SDL backend can no-op
+// these.
+void rs2_ime_stub_set_composition(const char *utf8);
+void rs2_ime_stub_commit(const char *utf8);
+void rs2_ime_stub_clear();
+
+void rs2_ime_reset();
+
+// UTF-8 views (in-process ADR). Never null; empty when none.
+const char *rs2_ime_composition_utf8();
+const char *rs2_ime_result_utf8();
+
+// ImmGetCompositionStringA-equivalent: CP932 bytes for COMPSTR / RESULTSTR.
+// buf == NULL or buf_size == 0 -> required byte count (no NUL).
+// Otherwise copy min(n, buf_size) bytes (no NUL) and return copied count.
+// Unknown index returns 0.
+int rs2_ime_get_composition_string_a(unsigned dw_index, void *buf,
+                                     unsigned buf_size);

--- a/port/rs2_ime_test.cpp
+++ b/port/rs2_ime_test.cpp
@@ -1,0 +1,134 @@
+// IME / TEXTINPUT stub backend self-test (#100). No Imm COM, no SDL.
+
+#include "rs2_ime.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool bytes_eq(const void *got, unsigned n, const char *want, unsigned want_n) {
+	if (n != want_n) return false;
+	if (n == 0) return true;
+	return std::memcmp(got, want, n) == 0;
+}
+
+int self_test() {
+	rs2_ime_reset();
+
+	// Empty composition / result after reset.
+	if (!expect(std::strcmp(rs2_ime_composition_utf8(), "") == 0,
+	            "empty composition utf8"))
+		return 1;
+	if (!expect(std::strcmp(rs2_ime_result_utf8(), "") == 0, "empty result utf8"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPSTR, nullptr,
+	                                            0) == 0,
+	            "empty COMPSTR size"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_RESULTSTR, nullptr,
+	                                            0) == 0,
+	            "empty RESULTSTR size"))
+		return 1;
+
+	char buf[16];
+	std::memset(buf, 0x7f, sizeof(buf));
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPSTR, buf, 8) ==
+	                0,
+	            "empty COMPSTR copy"))
+		return 1;
+
+	// ASCII commit (TEXTINPUT). Composition clears; result is identity CP932.
+	rs2_ime_stub_set_composition("ab");
+	if (!expect(std::strcmp(rs2_ime_composition_utf8(), "ab") == 0,
+	            "ascii composition"))
+		return 1;
+	rs2_ime_stub_commit("abc");
+	if (!expect(std::strcmp(rs2_ime_composition_utf8(), "") == 0,
+	            "commit clears composition"))
+		return 1;
+	if (!expect(std::strcmp(rs2_ime_result_utf8(), "abc") == 0, "ascii result utf8"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_RESULTSTR, nullptr,
+	                                            0) == 3,
+	            "ascii RESULTSTR size"))
+		return 1;
+	std::memset(buf, 0, sizeof(buf));
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_RESULTSTR, buf, 16) ==
+	                    3 &&
+	                bytes_eq(buf, 3, "abc", 3),
+	            "ascii RESULTSTR bytes"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPSTR, nullptr, 0) ==
+	                0,
+	            "ascii COMPSTR empty after commit"))
+		return 1;
+
+	// CP932 2-byte roundtrip: katakana A (UTF-8 e3 82 a2 <-> CP932 83 41).
+	const char kAUtf8[] = {'\xe3', '\x82', '\xa2', 0};
+	const char kACp932[] = {'\x83', '\x41'};
+	rs2_ime_stub_set_composition(kAUtf8);
+	if (!expect(std::strcmp(rs2_ime_composition_utf8(), kAUtf8) == 0,
+	            "cp932 composition utf8"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPSTR, nullptr,
+	                                            0) == 2,
+	            "cp932 COMPSTR size"))
+		return 1;
+	std::memset(buf, 0, sizeof(buf));
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPSTR, buf, 16) ==
+	                    2 &&
+	                bytes_eq(buf, 2, kACp932, 2),
+	            "cp932 COMPSTR bytes"))
+		return 1;
+
+	rs2_ime_stub_commit(kAUtf8);
+	if (!expect(std::strcmp(rs2_ime_composition_utf8(), "") == 0,
+	            "cp932 commit clears composition"))
+		return 1;
+	if (!expect(std::strcmp(rs2_ime_result_utf8(), kAUtf8) == 0,
+	            "cp932 result utf8"))
+		return 1;
+	std::memset(buf, 0, sizeof(buf));
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_RESULTSTR, buf, 16) ==
+	                    2 &&
+	                bytes_eq(buf, 2, kACp932, 2),
+	            "cp932 RESULTSTR bytes"))
+		return 1;
+
+	// Clear drops both composition and result.
+	rs2_ime_stub_clear();
+	if (!expect(std::strcmp(rs2_ime_composition_utf8(), "") == 0 &&
+	                std::strcmp(rs2_ime_result_utf8(), "") == 0,
+	            "clear utf8"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPSTR, nullptr,
+	                                            0) == 0 &&
+	                rs2_ime_get_composition_string_a(RS2_IME_GCS_RESULTSTR, nullptr,
+	                                                 0) == 0,
+	            "clear CP932 sizes"))
+		return 1;
+
+	if (!expect(rs2_ime_get_composition_string_a(0xFFFF, nullptr, 0) == 0,
+	            "unknown index"))
+		return 1;
+
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc >= 2 && std::strcmp(argv[1], "--self-test") == 0) {
+		const int rc = self_test();
+		if (rc == 0) std::printf("rs2_ime_test: ok\n");
+		return rc;
+	}
+	std::fprintf(stderr, "usage: rs2_ime_test --self-test\n");
+	return 2;
+}

--- a/port/rs2_ime_test.cpp
+++ b/port/rs2_ime_test.cpp
@@ -21,6 +21,13 @@ bool bytes_eq(const void *got, unsigned n, const char *want, unsigned want_n) {
 int self_test() {
 	rs2_ime_reset();
 
+	// Win32 <imm.h>: GCS_COMPSTR=0x0008, GCS_RESULTSTR=0x0800.
+	// 0x1000 is GCS_RESULTCLAUSE, not result text.
+	if (!expect(RS2_IME_GCS_COMPSTR == 0x0008 &&
+	                RS2_IME_GCS_RESULTSTR == 0x0800,
+	            "Win32 GCS_COMPSTR / GCS_RESULTSTR numbers"))
+		return 1;
+
 	// Empty composition / result after reset.
 	if (!expect(std::strcmp(rs2_ime_composition_utf8(), "") == 0,
 	            "empty composition utf8"))
@@ -116,6 +123,9 @@ int self_test() {
 
 	if (!expect(rs2_ime_get_composition_string_a(0xFFFF, nullptr, 0) == 0,
 	            "unknown index"))
+		return 1;
+	if (!expect(rs2_ime_get_composition_string_a(0x1000, nullptr, 0) == 0,
+	            "GCS_RESULTCLAUSE is not RESULTSTR"))
 		return 1;
 
 	return 0;


### PR DESCRIPTION
## Summary
- Add `port/rs2_ime` check-preset stub: UTF-8 composition (`TEXTEDITING`) and result (`TEXTINPUT`), with `rs2_ime_backend_*` as the later SDL2 swap point.
- `rs2_ime_get_composition_string_a` is the `ImmGetCompositionStringA` stand-in and returns CP932 via `rs2_text`. No SDL2 on check; `lib/editbox.cpp` / `lib/window.cpp` untouched.
- ctest `rs2_ime_self_test` covers empty composition, ASCII commit, CP932 2-byte roundtrip, and clear. Backend entry documented at the end of `docs/porting/charset-seams.md`.

Closes #100.

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, cmake check preset, 26 ctests including `rs2_ime_self_test`)
- [ ] CI `check` workflow on this PR
- [ ] Confirm no SDL2 / DirectX / `lib/editbox.cpp` / `lib/window.cpp` in the diff


Made with [Cursor](https://cursor.com)