### PR TITLE
Route CEditBox Imm* through rs2_ime (#102)

### DIFF
--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -198,6 +198,17 @@ Check preset records UTF-8 composition (`SDL_TEXTEDITING`) and result (`SDL_TEXT
 | `ImmGetCompositionStringA` | `rs2_ime_get_composition_string_a` | same helper (CP932 at the Win32-compat edge) |
 | cancel / focus loss | `rs2_ime_backend_clear` | stop text input + empty both |
 
-A later IME PR still replaces `lib/editbox.cpp` + the `WM_IME_SETCONTEXT` hide in `lib/window.cpp` with these hooks. Do not rewrite `CEditCtrl` / list / tree rename here. Do not add SDL2 to the `check` preset.
+A later IME PR still replaces the `WM_IME_SETCONTEXT` hide in `lib/window.cpp` with these hooks. `lib/editbox.cpp` now calls `rs2_ime_*` (#102). Do not rewrite `CEditCtrl` / list / tree rename here. Do not add SDL2 to the `check` preset.
 
 ctest: `rs2_ime_self_test` (`port/rs2_ime_test.cpp --self-test`) covers empty composition, ASCII commit, CP932 2-byte roundtrip, and clear.
+
+## CEditBox Imm* routed through `port/rs2_ime` (`#102`)
+
+- **Issue**: [#102](https://github.com/lollipop-onl/railsim2-portable/issues/102) (parent [#9](https://github.com/lollipop-onl/railsim2-portable/issues/9); depends on [#100](https://github.com/lollipop-onl/railsim2-portable/issues/100))
+- **Entry**: `rs2_ime_composition_utf8` / `rs2_ime_result_utf8` / `rs2_ime_get_composition_string_a` / `rs2_ime_set_open` / `rs2_ime_is_open` in `port/rs2_ime.h`
+
+`CEditBox` no longer calls Imm*. `Create` / `Release` use a dummy `m_hImc` session token and `rs2_ime_set_open` for the `imm` argument (`-1` off, `>0` on, `0` leave). `IsFEPOpen` is `rs2_ime_is_open`. `GetCompStr` / `GetResultStr` copy UTF-8 into `m_comp` (ADR in-process text); `CompEnd` still inserts `m_comp` into `m_str`. `ScanInput` / `Render` / `GetFEPCursorPos` call `rs2_ime_get_composition_string_a` with `RS2_IME_GCS_COMPCLAUSE` / `COMPATTR` / `CURSORPOS`, which return 0 in the record-only stub (no clause underlines). `lib/window.cpp` `WM_IME_SETCONTEXT` / `ImmGetDefaultIMEWnd` is unchanged.
+
+`lib/editbox.cpp` stays off the allowlist: a check compile of that TU fails on leftover clipboard / common-dialog symbols and an include-order miss of `RS2_FLOAT_FMT` from `SystemCover.h`, not on Imm*. Follow-up (not this slice): `GMEM_DDESHARE` / `GMEM_MOVEABLE` / `lstrcpy` / `CF_TEXT` (`ClipCopy` / `ClipPaste`), `wsprintf` (`SelectFile`), and `#include "rs2_float.h"` before `SystemCover.h`. Do not add SDL2 to `check`. Do not rewrite `CEditCtrl` / list / tree rename. Game sources stay CP932.
+
+ctest: `rs2_ime_self_test` also covers open-status on/off and zero-size COMPATTR / COMPCLAUSE / CURSORPOS.

--- a/lib/editbox.cpp
+++ b/lib/editbox.cpp
@@ -14,6 +14,7 @@
 #include "mesh.h"
 #include "object.h"
 #include "editbox.h"
+#include "rs2_ime.h"
 #include "../Const.h"
 #include "../Macro.h"
 #include "../SystemCover.h"
@@ -60,8 +61,8 @@ CEditBox::~CEditBox(){
 void CEditBox::Create(int x, int y, int w, int max, string pre, int imm){
 	Release(imm);
 	ms_Active = true;
-	m_hImc = ImmGetContext(svw.hWnd);
-	if(imm) ImmSetOpenStatus(m_hImc, imm>0);
+	m_hImc = (HIMC)1;
+	if(imm) rs2_ime_set_open(imm>0);
 	m_comp = "";
 	pre = EliminateTabAndCRLF(pre);
 	m_x = x;
@@ -83,10 +84,17 @@ void CEditBox::Create(int x, int y, int w, int max, string pre, int imm){
 void CEditBox::Release(int imm){
 	ms_Active = false;
 	if(m_hImc){
-		if(imm) ImmSetOpenStatus(m_hImc, imm>0);
-		ImmReleaseContext(svw.hWnd, m_hImc);
+		if(imm) rs2_ime_set_open(imm>0);
 		m_hImc = 0;
 	}
+}
+
+BOOL CEditBox::IsFEPOpen(){
+	return rs2_ime_is_open();
+}
+
+int CEditBox::GetFEPCursorPos(){
+	return rs2_ime_get_composition_string_a(RS2_IME_GCS_CURSORPOS, NULL, 0);
 }
 
 /*
@@ -97,10 +105,10 @@ int CEditBox::ScanInput(){
 	if(CheckKeyDown()<0) return EDIT_PROC;
 
 	BOOL is_comp = FALSE;
-	if(ImmGetCompositionString(m_hImc, GCS_COMPCLAUSE, NULL, 0)>0){
+	if(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPCLAUSE, NULL, 0)>0){
 		char attr = -1;
-		ImmGetCompositionString(m_hImc, GCS_COMPATTR, &attr, 1);
-		if(attr!=ATTR_INPUT) is_comp = TRUE;
+		rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPATTR, &attr, 1);
+		if(attr!=RS2_IME_ATTR_INPUT) is_comp = TRUE;
 	}
 	BOOL comp_end = m_old_iscomp && !is_comp;
 	m_old_iscomp = is_comp;
@@ -181,12 +189,12 @@ void CEditBox::Render(){
 	m_show = m_str;
 	if(IsComp()){
 		//	ïœä∑íÜÇ»ÇÁ
-		int size = ImmGetCompositionString(m_hImc, GCS_COMPCLAUSE, NULL, 0);
+		int size = rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPCLAUSE, NULL, 0);
 		int n = size/sizeof(int), *pClause = new int[n];
-		ImmGetCompositionString(m_hImc, GCS_COMPCLAUSE, pClause, size);
-		size = ImmGetCompositionString(m_hImc, GCS_COMPATTR, NULL, 0);
+		rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPCLAUSE, pClause, size);
+		size = rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPATTR, NULL, 0);
 		char *pAttr = new char[size];
-		ImmGetCompositionString(m_hImc, GCS_COMPATTR, pAttr, size);
+		rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPATTR, pAttr, size);
 
 		string tmpstr(&m_str[0], &m_str[m_pos]);
 		m_show.insert(m_pos, m_comp);
@@ -200,7 +208,7 @@ void CEditBox::Render(){
 
 		for(i = 0; i<n-1; i++){
 			D3DCOLOR col = g_Skin->m_EditCtrlData.
-				m_ConvertClauseColor[pAttr[pClause[i]]==ATTR_TARGET_CONVERTED];
+				m_ConvertClauseColor[pAttr[pClause[i]]==RS2_IME_ATTR_TARGET_CONVERTED];
 			int tx = m_x+((m_pos+pClause[i])*svf.size/2)+1, ty = m_y+svf.size-2;
 			int tx2 = m_x+((m_pos+pClause[i+1])*svf.size/2)-1;
 			Draw2DLine(tx, ty, tx2, ty, col);
@@ -460,12 +468,7 @@ void CEditBox::Clip(){
  *	str	: ï∂éöóÒÇÃäiî[êÊ
  */
 void CEditBox::GetCompStr(string &str){
-	LONG size = ImmGetCompositionString(m_hImc, GCS_COMPSTR, NULL, 0);
-	char *pBuf = new char[size+1];
-	ImmGetCompositionString(m_hImc, GCS_COMPSTR, pBuf, size);
-	pBuf[size] = 0;
-	str = pBuf;
-	delete pBuf;
+	str = rs2_ime_composition_utf8();
 }
 
 /*
@@ -474,12 +477,7 @@ void CEditBox::GetCompStr(string &str){
  *	str	: ï∂éöóÒÇÃäiî[êÊ
  */
 void CEditBox::GetResultStr(string &str){
-	LONG size = ImmGetCompositionString(m_hImc, GCS_RESULTSTR, NULL, 0);
-	char *pBuf = new char[size+1];
-	ImmGetCompositionString(m_hImc, GCS_RESULTSTR, pBuf, size);
-	pBuf[size] = 0;
-	str = pBuf;
-	delete pBuf;
+	str = rs2_ime_result_utf8();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/editbox.h
+++ b/lib/editbox.h
@@ -74,9 +74,7 @@ public:
 	 *
 	 *	戻り値：TRUE＝FEP起動中、FALSE＝非起動中
 	 */
-	BOOL IsFEPOpen(){
-		return ImmGetOpenStatus(m_hImc);
-	}
+	BOOL IsFEPOpen();
 	/*
 	 *	変換中であるかを取得
 	 *
@@ -89,9 +87,7 @@ public:
 	/*
 	 *	変換中のカーソル位置の取得
 	 */
-	int GetFEPCursorPos(){
-		return ImmGetCompositionString(m_hImc, GCS_CURSORPOS, NULL, 0);
-	}
+	int GetFEPCursorPos();
 };
 
 /*

--- a/port/rs2_ime.cpp
+++ b/port/rs2_ime.cpp
@@ -12,6 +12,7 @@ namespace {
 
 std::string g_composition_utf8;
 std::string g_result_utf8;
+int g_open = 0;
 
 const char *as_cstr(const std::string &s) { return s.c_str(); }
 
@@ -52,6 +53,10 @@ void rs2_ime_stub_clear() { rs2_ime_backend_clear(); }
 
 void rs2_ime_reset() { rs2_ime_backend_reset(); }
 
+void rs2_ime_set_open(int open) { g_open = open ? 1 : 0; }
+
+int rs2_ime_is_open() { return g_open; }
+
 const char *rs2_ime_composition_utf8() { return as_cstr(g_composition_utf8); }
 
 const char *rs2_ime_result_utf8() { return as_cstr(g_result_utf8); }
@@ -63,6 +68,11 @@ int rs2_ime_get_composition_string_a(unsigned dw_index, void *buf,
 		return copy_cp932(g_composition_utf8, buf, buf_size);
 	case RS2_IME_GCS_RESULTSTR:
 		return copy_cp932(g_result_utf8, buf, buf_size);
+	case RS2_IME_GCS_COMPATTR:
+	case RS2_IME_GCS_COMPCLAUSE:
+	case RS2_IME_GCS_CURSORPOS:
+		// No clause / attr / caret in the record-only stub. SDL later.
+		return 0;
 	default:
 		return 0;
 	}

--- a/port/rs2_ime.h
+++ b/port/rs2_ime.h
@@ -12,7 +12,16 @@
 // Same numbers as <imm.h>; stub/imm.h does not define these yet.
 enum {
 	RS2_IME_GCS_COMPSTR = 0x0008,
+	RS2_IME_GCS_COMPATTR = 0x0010,
+	RS2_IME_GCS_COMPCLAUSE = 0x0020,
+	RS2_IME_GCS_CURSORPOS = 0x0080,
 	RS2_IME_GCS_RESULTSTR = 0x0800
+};
+
+// Win32 IME composition attributes used by CEditBox::ScanInput / Render.
+enum {
+	RS2_IME_ATTR_INPUT = 0x00,
+	RS2_IME_ATTR_TARGET_CONVERTED = 0x01
 };
 
 // --- thin backend (stub here; SDL_TEXTINPUT later) ---
@@ -29,6 +38,12 @@ void rs2_ime_stub_commit(const char *utf8);
 void rs2_ime_stub_clear();
 
 void rs2_ime_reset();
+
+// ImmSetOpenStatus / ImmGetOpenStatus stand-in. Independent of composition
+// buffers. 0 = off, non-zero = on. Default off. rs2_ime_reset does not
+// change this flag.
+void rs2_ime_set_open(int open);
+int rs2_ime_is_open();
 
 // UTF-8 views (in-process ADR). Never null; empty when none.
 const char *rs2_ime_composition_utf8();

--- a/port/rs2_ime_test.cpp
+++ b/port/rs2_ime_test.cpp
@@ -128,6 +128,36 @@ int self_test() {
 	            "GCS_RESULTCLAUSE is not RESULTSTR"))
 		return 1;
 
+	// Win32 COMPATTR / COMPCLAUSE / CURSORPOS numbers; stub returns 0.
+	if (!expect(RS2_IME_GCS_COMPATTR == 0x0010 &&
+	                RS2_IME_GCS_COMPCLAUSE == 0x0020 &&
+	                RS2_IME_GCS_CURSORPOS == 0x0080,
+	            "Win32 GCS_COMPATTR / COMPCLAUSE / CURSORPOS numbers"))
+		return 1;
+	rs2_ime_stub_set_composition("ab");
+	if (!expect(rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPATTR, nullptr,
+	                                            0) == 0 &&
+	                rs2_ime_get_composition_string_a(RS2_IME_GCS_COMPCLAUSE,
+	                                                 nullptr, 0) == 0 &&
+	                rs2_ime_get_composition_string_a(RS2_IME_GCS_CURSORPOS,
+	                                                 nullptr, 0) == 0,
+	            "clause/attr/cursor empty in record-only stub"))
+		return 1;
+
+	// ImmSetOpenStatus / ImmGetOpenStatus stand-in. Independent of buffers.
+	rs2_ime_reset();
+	if (!expect(rs2_ime_is_open() == 0, "open defaults off"))
+		return 1;
+	rs2_ime_set_open(1);
+	if (!expect(rs2_ime_is_open() != 0, "set open on"))
+		return 1;
+	rs2_ime_stub_set_composition("ab");
+	if (!expect(rs2_ime_is_open() != 0, "composition does not clear open"))
+		return 1;
+	rs2_ime_set_open(0);
+	if (!expect(rs2_ime_is_open() == 0, "set open off"))
+		return 1;
+
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
- Replace `CEditBox` Imm* (`ImmGetContext` / `ImmSetOpenStatus` / `ImmGetCompositionString` / `ImmGetOpenStatus`) with `rs2_ime_*`. `GetCompStr` / `GetResultStr` copy UTF-8 into `m_comp`; `CompEnd` still inserts into `m_str`.
- Add `rs2_ime_set_open` / `rs2_ime_is_open` and Win32 `GCS_COMPATTR` / `COMPCLAUSE` / `CURSORPOS` numbers (record-only stub returns 0). `lib/window.cpp` is unchanged.
- `lib/editbox.cpp` stays off the allowlist: check compile fails on clipboard (`GMEM_*` / `CF_TEXT` / `lstrcpy`), `wsprintf` (`SelectFile`), and `RS2_FLOAT_FMT` include order — leftover deps listed on #102.

Closes #102

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, native compile, 26/26 ctest including `rs2_ime_self_test`)
- [x] No Imm* left in `lib/editbox.cpp` / `lib/editbox.h`
- [x] No SDL2 on the `check` preset; `port/native_sources.txt` unchanged
- [ ] Cursor auto-review


Made with [Cursor](https://cursor.com)