### PR TITLE
Add optional runtime CMake preset for SDL2/GL/OpenAL (#105)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,42 @@ project(railsim2-portable LANGUAGES CXX)
 # iconv for port/rs2_text CP932<->UTF-8 (#75). Not SDL; glibc is built-in on Linux.
 find_package(Iconv REQUIRED)
 
+# Optional runtime deps (#105). The check preset leaves RS2_RUNTIME OFF and
+# must not search SDL2 / OpenGL / OpenAL. CI apt does not install them.
+# find_package is QUIET (not REQUIRED): missing packages leave the feature off.
+option(RS2_RUNTIME "Search optional SDL2 / OpenGL / OpenAL (runtime preset)" OFF)
+set(RS2_HAVE_SDL2 OFF)
+set(RS2_HAVE_OPENGL OFF)
+set(RS2_HAVE_OPENAL OFF)
+if(RS2_RUNTIME)
+  find_package(SDL2 CONFIG QUIET)
+  if(NOT SDL2_FOUND)
+    find_package(SDL2 QUIET)
+  endif()
+  if(SDL2_FOUND OR TARGET SDL2::SDL2)
+    set(RS2_HAVE_SDL2 ON)
+  endif()
+
+  find_package(OpenGL QUIET)
+  if(OpenGL_FOUND OR OPENGL_FOUND)
+    set(RS2_HAVE_OPENGL ON)
+  endif()
+
+  find_package(OpenAL QUIET)
+  if(OpenAL_FOUND OR OPENAL_FOUND)
+    set(RS2_HAVE_OPENAL ON)
+  endif()
+
+  message(STATUS "RS2 runtime SDL2: ${RS2_HAVE_SDL2}")
+  message(STATUS "RS2 runtime OpenGL: ${RS2_HAVE_OPENGL}")
+  message(STATUS "RS2 runtime OpenAL: ${RS2_HAVE_OPENAL}")
+else()
+  message(STATUS "RS2 runtime: off (check preset; SDL2/GL/OpenAL not searched)")
+endif()
+set(RS2_HAVE_SDL2 "${RS2_HAVE_SDL2}" CACHE BOOL "SDL2 found (runtime preset; unused by check)" FORCE)
+set(RS2_HAVE_OPENGL "${RS2_HAVE_OPENGL}" CACHE BOOL "OpenGL found (runtime preset; unused by check)" FORCE)
+set(RS2_HAVE_OPENAL "${RS2_HAVE_OPENAL}" CACHE BOOL "OpenAL found (runtime preset; unused by check)" FORCE)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,6 +33,14 @@
         "CMAKE_C_COMPILER": "gcc-14",
         "CMAKE_CXX_COMPILER": "g++-14"
       }
+    },
+    {
+      "name": "runtime",
+      "displayName": "Optional SDL2 / OpenGL / OpenAL (local; not CI)",
+      "inherits": "check",
+      "cacheVariables": {
+        "RS2_RUNTIME": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -43,6 +51,10 @@
     {
       "name": "check-gcc",
       "configurePreset": "check-gcc"
+    },
+    {
+      "name": "runtime",
+      "configurePreset": "runtime"
     }
   ],
   "testPresets": [
@@ -56,6 +68,13 @@
     {
       "name": "check-gcc",
       "configurePreset": "check-gcc",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "runtime",
+      "configurePreset": "runtime",
       "output": {
         "outputOnFailure": true
       }

--- a/docs/porting/adr-backend.md
+++ b/docs/porting/adr-backend.md
@@ -110,11 +110,13 @@ Wrappers in `render.h` / `texture.h` **and** raw `sv3.pDev` from the seven leak 
 - Ship communication-wire compatibility (#11) or Capture/AVI (#17) as part of this backend.
 - Enable Emscripten legacy FFP emulation to ?gget something on screen.?h
 
-## CMake / CI notes (for #3)
+## CMake / CI notes (for #3 / #105)
 
-M1 CMake should grow a **linkable native target** that can later `find_package(SDL2)` without requiring SDL at the current object-only `check` preset. SDL/OpenAL as hard dependencies belong when the first window TU is allowlisted (M3), not as a gate that turns M0 `check.sh` red.
+`check` (`./scripts/check.sh`, GitHub Actions) never searches SDL2, OpenGL, or OpenAL. Those packages stay off apt CI.
 
-Optional preset `native` (link SDL2) vs `check` (stubs only) is the expected split.
+The **`runtime`** preset sets `RS2_RUNTIME=ON` and calls `find_package` **without REQUIRED**. Configure succeeds with features off when a package is missing. `RS2_HAVE_SDL2` / `RS2_HAVE_OPENGL` / `RS2_HAVE_OPENAL` are the flags later GL-link / SDL-input / OpenAL-play slices consume. This preset does not draw, poll, or play.
+
+See [dev-env.md](dev-env.md) (`check` vs `runtime`).
 
 ## Related
 

--- a/docs/porting/dev-env.md
+++ b/docs/porting/dev-env.md
@@ -33,6 +33,7 @@ brew bundle --file Brewfile
 | `cmake --preset check` | Configure AppleClang native target |
 | `cmake --build --preset check` | Compile allowlisted sources and link `railsim2` |
 | `ctest --preset check` | Smoke + `Sample.rs2` roundtrip + text `.x` load + path join (see [rs2-roundtrip.md](rs2-roundtrip.md), [x-file-parser.md](x-file-parser.md), [path-seams.md](path-seams.md)) |
+| `cmake --preset runtime` | Same sources, plus **optional** SDL2 / OpenGL / OpenAL search. Not CI. |
 
 ## Compile firewall
 
@@ -69,10 +70,34 @@ We do **not** vendor DirectX SDK headers or adopt MinGW for CI. The compile-fire
 
 ## CI
 
-GitHub Actions runs `./scripts/check.sh` on a **macOS + Linux matrix** (`macos-15`, `ubuntu-24.04`). Both jobs use `mise install` for cmake/ninja; Linux also installs `clang` from apt. Local Mac dev can use the same path via `.mise.toml`, or legacy `brew bundle`.
+GitHub Actions runs `./scripts/check.sh` on a **macOS + Linux matrix** (`macos-15`, `ubuntu-24.04`). Both jobs use `mise install` for cmake/ninja; Linux also installs `clang` from apt. Local Mac dev can use the same path via `.mise.toml`, or legacy `brew bundle`. Do **not** apt-install SDL2, OpenGL loaders, or OpenAL Soft on that job.
+
+## check vs runtime
+
+`check` is the gate. `runtime` is a local-only configure that **may** find window / GL / audio packages. Later GL link, SDL input, and OpenAL play slices use `runtime`; they must not add those packages to `check` or to CI apt.
+
+| Preset | Who runs it | SDL2 / OpenGL / OpenAL |
+|--------|-------------|------------------------|
+| `check` (`./scripts/check.sh`, CI) | Everyone | **Not searched.** `RS2_RUNTIME=OFF`. Stubs only. |
+| `runtime` | Local machine with optional packages | `find_package` **QUIET / not REQUIRED**. Missing package → feature off, configure still succeeds. |
+
+This slice does **not** draw, poll SDL events, or play OpenAL. `cmake --preset runtime` only records `RS2_HAVE_SDL2` / `RS2_HAVE_OPENGL` / `RS2_HAVE_OPENAL` (`ON` or `OFF` in the configure log). Do not link `lib/graphic.cpp` / `lib/vertex.cpp` / `lib/sound.cpp` from this preset yet.
+
+Optional local packages (Homebrew; not in `Brewfile`, not required for `check`):
+
+```bash
+brew install sdl2 openal-soft
+# OpenAL Soft is keg-only on macOS; prefix it if FindOpenAL misses it:
+cmake --preset runtime --fresh \
+  -DCMAKE_PREFIX_PATH="$(brew --prefix openal-soft)"
+```
+
+Linux: install distro `libsdl2-dev`, OpenGL headers, and `libopenal-dev` the same way — locally, never as a `check` CI step. If nothing is installed, `cmake --preset runtime` must still succeed with all three features off.
+
+See [adr-backend.md](adr-backend.md) for why the stack is SDL2 + GL 3.3 core / GLES3 + OpenAL Soft.
 
 ## Next milestones
 
 - **#10** replaces the roundtrip passthrough with `CSaveFile` and drives byte-identity (`%p` / MD5 / float). The ctest harness itself is [#24](https://github.com/lollipop-onl/railsim2-portable/issues/24) ([rs2-roundtrip.md](rs2-roundtrip.md)).
 - **#6** replaces `CXFile` / `D3DXLoadMeshFromX` with the closed parser in `port/xfile.cpp`. Loading Distribution `.x` into memory is [#28](https://github.com/lollipop-onl/railsim2-portable/issues/28) ([x-file-parser.md](x-file-parser.md)).
-- Backend / window bring-up uses SDL2 only when a `native` preset is added (see `adr-backend.md`); keep `check` stub-only.
+- Backend / window bring-up uses the `runtime` preset for optional SDL2 / GL / OpenAL (see `adr-backend.md`); keep `check` stub-only.


### PR DESCRIPTION
## Summary
- Add a local-only `runtime` CMake preset (`RS2_RUNTIME=ON`) that `find_package`s SDL2, OpenGL, and OpenAL **QUIET / not REQUIRED**. Missing packages leave `RS2_HAVE_*` off; configure still succeeds.
- `check` preset, `./scripts/check.sh`, and `.github/workflows/check.yml` are unchanged. CI still does not install or search SDL2/GL/OpenAL.
- Lock the `check` vs `runtime` boundary in `docs/porting/dev-env.md` and `docs/porting/adr-backend.md`. This slice does not draw, poll SDL input, or play OpenAL.

Closes #105

## Test plan
- [x] `./scripts/check.sh` green (`RS2 runtime: off (check preset; SDL2/GL/OpenAL not searched)`)
- [x] `cmake --preset runtime` configures (this machine: all three ON)
- [x] `cmake -D RS2_RUNTIME=ON -DCMAKE_DISABLE_FIND_PACKAGE_{SDL2,OpenGL,OpenAL}=ON` still configures with all three OFF
- [ ] CI `check` matrix (macOS + Linux) unchanged — no SDL2 apt


Made with [Cursor](https://cursor.com)