### PR TITLE
Allowlist lib/editbox.cpp with clipboard / wsprintf stubs (#108)

### DIFF
--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -223,3 +223,15 @@ ctest: `rs2_ime_self_test` also covers open-status on/off and zero-size COMPATTR
 `lib/window.cpp` stays off the allowlist. A check compile of that TU fails on leftover Win32 window / GDI symbols, not on Imm*. Follow-up (not this slice): `<windowsx.h>` (`GetWindowStyle` / `GetWindowExStyle`), `WNDCLASSEX` / `RegisterClassEx` / `CreateWindow`, `LoadIcon` / `LoadCursor` / `GetStockObject`, `AdjustWindowRectEx` / `SetWindowPos` / `GetDesktopWindow` / `GetWindowRect` / `GetMenu`, `BeginPaint` / `EndPaint` / `PAINTSTRUCT`, `SetWindowText` / `SendMessage`, `WM_IME_SETCONTEXT` / `WM_DISPLAYCHANGE` / `WM_SYSCOMMAND` / `SC_SCREENSAVE`, and A/W macros (`PeekMessage` / `DispatchMessage` / `DefWindowProc`). Do not grow those stubs in a charset slice. Do not add SDL2 to `check`. Do not allowlist `lib/editbox.cpp`. Game sources stay CP932.
 
 ctest: `rs2_ime_self_test` also covers hide leaving open status and composition intact.
+
+## CEditBox clipboard / `wsprintf` stubs so `lib/editbox.cpp` allowlists (`#108`)
+
+- **Issue**: [#108](https://github.com/lollipop-onl/railsim2-portable/issues/108) (parent [#9](https://github.com/lollipop-onl/railsim2-portable/issues/9); depends on [#102](https://github.com/lollipop-onl/railsim2-portable/issues/102))
+- **Entry**: `GMEM_MOVEABLE` / `GMEM_DDESHARE` / `CF_TEXT` / `lstrcpy` / `wsprintf` in `port/stub/windows.h`
+- **Allowlist**: `lib/editbox.cpp` is in `port/native_sources.txt`
+
+`CEditBox::ClipCopy` / `ClipPaste` compile against no-op `GlobalAlloc` / `OpenClipboard` / `GetClipboardData` (already stubbed). This slice only names the leftover Win32 constants and `lstrcpy`. `SelectFile` in the same TU uses `wsprintf` to build the `OPENFILENAME` filter; `GetOpenFileName` / `GetSaveFileName` stay FALSE. `lib/editbox.cpp` does not include `stdafx.h`, so `#include "rs2_float.h"` is inserted before `SystemCover.h` for `RS2_FLOAT_FMT` in `V3Save`. Game logic and IME (`rs2_ime_*`) are unchanged.
+
+Clipboard bytes are not stored. A later `#16` slice may replace the no-op with an SDL clipboard backend. Do not add SDL2 to `check`. Do not rewrite `CEditCtrl` / list / tree rename. Game sources stay CP932.
+
+`lib/window.cpp` stays off the allowlist (Win32 window / GDI leftovers from `#104`).

--- a/lib/editbox.cpp
+++ b/lib/editbox.cpp
@@ -15,6 +15,7 @@
 #include "object.h"
 #include "editbox.h"
 #include "rs2_ime.h"
+#include "rs2_float.h"
 #include "../Const.h"
 #include "../Macro.h"
 #include "../SystemCover.h"

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -72,4 +72,5 @@ CFileMode.cpp
 CTreeElement.cpp
 lib/input.cpp
 lib/wave.cpp
+lib/editbox.cpp
 SystemCover.cpp

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -325,6 +325,16 @@ inline BOOL GetClientRect(HWND, LPRECT) { return TRUE; }
 inline BOOL MoveWindow(HWND, int, int, int, int, BOOL) { return TRUE; }
 inline BOOL DestroyWindow(HWND) { return TRUE; }
 inline void PostQuitMessage(int) {}
+#ifndef GMEM_MOVEABLE
+#define GMEM_MOVEABLE 0x0002
+#endif
+#ifndef GMEM_DDESHARE
+#define GMEM_DDESHARE 0x2000
+#endif
+#ifndef CF_TEXT
+#define CF_TEXT 1
+#endif
+
 inline HGLOBAL GlobalAlloc(UINT, SIZE_T) { return nullptr; }
 inline LPVOID GlobalLock(HGLOBAL) { return nullptr; }
 inline BOOL GlobalUnlock(HGLOBAL) { return TRUE; }
@@ -334,6 +344,31 @@ inline BOOL CloseClipboard() { return TRUE; }
 inline HANDLE SetClipboardData(UINT, HANDLE) { return nullptr; }
 inline HANDLE GetClipboardData(UINT) { return nullptr; }
 inline BOOL EmptyClipboard() { return TRUE; }
+inline LPSTR lstrcpyA(LPSTR dest, LPCSTR src) {
+  if (!dest) return dest;
+  if (!src) {
+    dest[0] = '\0';
+    return dest;
+  }
+  return std::strcpy(dest, src);
+}
+inline LPSTR lstrcpy(LPSTR dest, LPCSTR src) { return lstrcpyA(dest, src); }
+inline int wsprintfA(LPSTR dest, LPCSTR fmt, ...) {
+  if (!dest || !fmt) return 0;
+  va_list ap;
+  va_start(ap, fmt);
+  int n = std::vsprintf(dest, fmt, ap);
+  va_end(ap);
+  return n;
+}
+inline int wsprintf(LPSTR dest, LPCSTR fmt, ...) {
+  if (!dest || !fmt) return 0;
+  va_list ap;
+  va_start(ap, fmt);
+  int n = std::vsprintf(dest, fmt, ap);
+  va_end(ap);
+  return n;
+}
 inline LPSTR CharNextA(LPCSTR p) { return (LPSTR)(p + 1); }
 inline LPSTR CharPrevA(LPCSTR start, LPCSTR p) { return (p > start) ? (LPSTR)(p - 1) : (LPSTR)start; }
 inline LPSTR CharNext(LPCSTR p) { return CharNextA(p); }


### PR DESCRIPTION
## Summary
- Grow `port/stub/windows.h` with `GMEM_MOVEABLE` / `GMEM_DDESHARE` / `CF_TEXT` / `lstrcpy` / `wsprintf` so `CEditBox::ClipCopy` / `ClipPaste` and `SelectFile` compile. Clipboard stays a no-op (`GlobalAlloc` / `OpenClipboard` already return empty).
- Include `rs2_float.h` before `SystemCover.h` in `lib/editbox.cpp` so `RS2_FLOAT_FMT` is defined for `V3Save` (this TU does not go through `stdafx.h`).
- Allowlist `lib/editbox.cpp` (72/254). Document the seam in `docs/porting/charset-seams.md`. No SDL2 on check; real clipboard is #16.

Closes #108.

## Test plan
- [x] `./scripts/check.sh` green locally (26/26 tests, `lib/editbox.cpp` compiled)
- [ ] CI `check` matrix (macOS + Linux)


Made with [Cursor](https://cursor.com)