### PR TITLE
Allowlist lib/window.cpp with windowsx / Win32 window stubs (#110)

### DIFF
--- a/docs/porting/charset-seams.md
+++ b/docs/porting/charset-seams.md
@@ -234,4 +234,14 @@ ctest: `rs2_ime_self_test` also covers hide leaving open status and composition 
 
 Clipboard bytes are not stored. A later `#16` slice may replace the no-op with an SDL clipboard backend. Do not add SDL2 to `check`. Do not rewrite `CEditCtrl` / list / tree rename. Game sources stay CP932.
 
-`lib/window.cpp` stays off the allowlist (Win32 window / GDI leftovers from `#104`).
+`lib/window.cpp` stays off the allowlist (Win32 window / GDI leftovers from `#104`). Follow-up is `#110`.
+
+## Window `windowsx` / Win32 stubs so `lib/window.cpp` allowlists (`#110`)
+
+- **Issue**: [#110](https://github.com/lollipop-onl/railsim2-portable/issues/110) (parent [#9](https://github.com/lollipop-onl/railsim2-portable/issues/9); depends on [#104](https://github.com/lollipop-onl/railsim2-portable/issues/104))
+- **Entry**: `GetWindowStyle` / `GetWindowExStyle` in `port/stub/windowsx.h`; `WNDCLASSEX` / `RegisterClassEx` / `CreateWindow` / `PAINTSTRUCT` / A/W macros in `port/stub/windows.h`
+- **Allowlist**: `lib/window.cpp` is in `port/native_sources.txt`
+
+`CreateMainWindow` / `AdjustWindow` / `PeekAllMessage` / `MessageProc` compile against no-op window and GDI symbols. `GetWindowStyle` / `GetWindowExStyle` wrap stub `GetWindowLong` (style bits are 0). `BeginPaint` / `EndPaint` / `GetStockObject` / `LoadIcon` / `LoadCursor` return empty handles. `WM_IME_SETCONTEXT` still calls `rs2_ime_hide` (#104); this slice does not touch IME.
+
+CreateWindow / PeekMessage / DefWindowProc are ANSI macros over the existing `*A` stubs. There is no OS window and no real GDI blit; `#16` owns that. Do not add SDL2 to `check`. Do not rewrite IME UI. Game sources stay CP932.

--- a/port/native_sources.txt
+++ b/port/native_sources.txt
@@ -73,4 +73,5 @@ CTreeElement.cpp
 lib/input.cpp
 lib/wave.cpp
 lib/editbox.cpp
+lib/window.cpp
 SystemCover.cpp

--- a/port/stub/direct.h
+++ b/port/stub/direct.h
@@ -2,7 +2,15 @@
 
 #include <cstdio>
 #include <sys/stat.h>
+
+// Same CRT/glibc __argv collision as io.h: unistd.h must see the raw names.
+#pragma push_macro("__argc")
+#pragma push_macro("__argv")
+#undef __argc
+#undef __argv
 #include <unistd.h>
+#pragma pop_macro("__argv")
+#pragma pop_macro("__argc")
 #include "io.h"
 
 #ifndef _mkdir

--- a/port/stub/io.h
+++ b/port/stub/io.h
@@ -2,7 +2,17 @@
 
 #include <cstdio>
 #include <cstring>
+
+// glibc unistd.h uses __argv as a parameter name (char *const __argv[]).
+// windows.h maps MSVC CRT __argv/__argc to rs2_argv()/rs2_argc(); if those
+// macros are live here, execve prototypes become "function returning array".
+#pragma push_macro("__argc")
+#pragma push_macro("__argv")
+#undef __argc
+#undef __argv
 #include <unistd.h>
+#pragma pop_macro("__argv")
+#pragma pop_macro("__argc")
 
 #ifndef _access
 #define _access access

--- a/port/stub/windows.h
+++ b/port/stub/windows.h
@@ -49,6 +49,10 @@ typedef void* HBITMAP;
 typedef void* HFONT;
 typedef void* HIMC;
 typedef void* HMMIO;
+typedef void* HICON;
+typedef void* HCURSOR;
+typedef void* HMENU;
+typedef void* HGDIOBJ;
 typedef void* LPVOID;
 typedef const void* LPCVOID;
 typedef char* LPSTR;
@@ -186,6 +190,15 @@ typedef struct tagLOGFONTA {
 #define STDCALL __stdcall
 #endif
 
+typedef LRESULT(CALLBACK *WNDPROC)(HWND, UINT, WPARAM, LPARAM);
+
+#ifndef MAKEINTRESOURCEA
+#define MAKEINTRESOURCEA(i) ((LPSTR)((ULONG_PTR)((WORD)(i))))
+#endif
+#ifndef MAKEINTRESOURCE
+#define MAKEINTRESOURCE MAKEINTRESOURCEA
+#endif
+
 #ifndef TRUE
 #define TRUE 1
 #endif
@@ -230,11 +243,30 @@ typedef long HRESULT;
 
 #define WM_APP 0x8000
 #define WM_CLOSE 0x0010
+#define WM_QUIT 0x0012
 #define WM_CHAR 0x0102
 #define WM_PAINT 0x000F
 #define WM_SIZE 0x0005
 #define WM_MOVE 0x0003
 #define WM_ACTIVATEAPP 0x001C
+#define WM_SYSCOMMAND 0x0112
+#define WM_SYSKEYDOWN 0x0104
+#define WM_DISPLAYCHANGE 0x007E
+#define WM_IME_SETCONTEXT 0x0281
+#define SC_SCREENSAVE 0xF140
+#define SC_MONITORPOWER 0xF170
+#define PM_REMOVE 0x0001
+#define WS_CAPTION 0x00C00000L
+#define WS_SYSMENU 0x00080000L
+#define WS_MINIMIZEBOX 0x00020000L
+#define SWP_NOZORDER 0x0004
+#define SWP_NOACTIVATE 0x0010
+#define GWL_STYLE (-16)
+#define GWL_EXSTYLE (-20)
+#define BLACK_BRUSH 4
+#ifndef IDC_ARROW
+#define IDC_ARROW MAKEINTRESOURCE(32512)
+#endif
 
 #define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
 
@@ -317,6 +349,22 @@ inline LONG DispatchMessageA(const MSG*) { return 0; }
 inline LRESULT DefWindowProcA(HWND, UINT, WPARAM, LPARAM) { return 0; }
 inline ATOM RegisterClassA(void*) { return 1; }
 inline HWND CreateWindowExA(DWORD, LPCSTR, LPCSTR, DWORD, int, int, int, int, HWND, HANDLE, HINSTANCE, LPVOID) { return (HWND)1; }
+#ifndef PeekMessage
+#define PeekMessage PeekMessageA
+#endif
+#ifndef DispatchMessage
+#define DispatchMessage DispatchMessageA
+#endif
+#ifndef DefWindowProc
+#define DefWindowProc DefWindowProcA
+#endif
+#ifndef CreateWindowEx
+#define CreateWindowEx CreateWindowExA
+#endif
+#ifndef CreateWindow
+#define CreateWindow(lpClassName, lpWindowName, dwStyle, x, y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam) \
+  CreateWindowExA(0L, lpClassName, lpWindowName, dwStyle, x, y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam)
+#endif
 inline BOOL ShowWindow(HWND, int) { return TRUE; }
 inline BOOL UpdateWindow(HWND) { return TRUE; }
 inline HDC GetDC(HWND) { return nullptr; }
@@ -382,6 +430,62 @@ typedef int (*FARPROC)();
 typedef void* HBRUSH;
 typedef void* HPEN;
 typedef void* HRGN;
+
+typedef struct tagWNDCLASSEXA {
+  UINT cbSize;
+  UINT style;
+  WNDPROC lpfnWndProc;
+  int cbClsExtra;
+  int cbWndExtra;
+  HINSTANCE hInstance;
+  HICON hIcon;
+  HCURSOR hCursor;
+  HBRUSH hbrBackground;
+  LPCSTR lpszMenuName;
+  LPCSTR lpszClassName;
+  HICON hIconSm;
+} WNDCLASSEXA, WNDCLASSEX, *PWNDCLASSEXA, *LPWNDCLASSEX;
+
+typedef struct tagPAINTSTRUCT {
+  HDC hdc;
+  BOOL fErase;
+  RECT rcPaint;
+  BOOL fRestore;
+  BOOL fIncUpdate;
+  BYTE rgbReserved[32];
+} PAINTSTRUCT, *PPAINTSTRUCT, *LPPAINTSTRUCT;
+
+inline ATOM RegisterClassExA(const WNDCLASSEXA *) { return 1; }
+inline ATOM RegisterClassEx(const WNDCLASSEX *wc) { return RegisterClassExA(wc); }
+inline HICON LoadIconA(HINSTANCE, LPCSTR) { return nullptr; }
+inline HICON LoadIcon(HINSTANCE i, LPCSTR n) { return LoadIconA(i, n); }
+inline HCURSOR LoadCursorA(HINSTANCE, LPCSTR) { return nullptr; }
+inline HCURSOR LoadCursor(HINSTANCE i, LPCSTR n) { return LoadCursorA(i, n); }
+inline HGDIOBJ GetStockObject(int) { return nullptr; }
+inline HWND GetDesktopWindow() { return (HWND)1; }
+inline BOOL GetWindowRect(HWND, LPRECT rc) {
+  if (rc) {
+    rc->left = 0;
+    rc->top = 0;
+    rc->right = 0;
+    rc->bottom = 0;
+  }
+  return TRUE;
+}
+inline HMENU GetMenu(HWND) { return nullptr; }
+inline BOOL AdjustWindowRectEx(LPRECT, DWORD, BOOL, DWORD) { return TRUE; }
+inline BOOL SetWindowPos(HWND, HWND, int, int, int, int, UINT) { return TRUE; }
+inline LONG GetWindowLongA(HWND, int) { return 0; }
+inline LONG GetWindowLong(HWND h, int i) { return GetWindowLongA(h, i); }
+inline HDC BeginPaint(HWND, LPPAINTSTRUCT ps) {
+  if (ps) std::memset(ps, 0, sizeof(*ps));
+  return nullptr;
+}
+inline BOOL EndPaint(HWND, const PAINTSTRUCT *) { return TRUE; }
+inline BOOL SetWindowTextA(HWND, LPCSTR) { return TRUE; }
+inline BOOL SetWindowText(HWND h, LPCSTR s) { return SetWindowTextA(h, s); }
+inline LRESULT SendMessageA(HWND, UINT, WPARAM, LPARAM) { return 0; }
+inline LRESULT SendMessage(HWND h, UINT m, WPARAM w, LPARAM l) { return SendMessageA(h, m, w, l); }
 
 typedef struct tagBITMAPINFOHEADER {
   DWORD biSize;

--- a/port/stub/windowsx.h
+++ b/port/stub/windowsx.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Compile-firewall stub for windowsx.h (#110).
+// lib/window.cpp only needs GetWindowStyle / GetWindowExStyle (AdjustWindow).
+// Real window metrics belong to a later GDI / SDL slice (#16).
+
+#include <windows.h>
+
+#ifndef GetWindowStyle
+#define GetWindowStyle(hwnd) ((DWORD)GetWindowLong((hwnd), GWL_STYLE))
+#endif
+#ifndef GetWindowExStyle
+#define GetWindowExStyle(hwnd) ((DWORD)GetWindowLong((hwnd), GWL_EXSTYLE))
+#endif


### PR DESCRIPTION
## Summary
- Add `port/stub/windowsx.h` with `GetWindowStyle` / `GetWindowExStyle` (via stub `GetWindowLong`) so `AdjustWindow` compiles.
- Grow `port/stub/windows.h` with `WNDCLASSEX` / `RegisterClassEx` / `CreateWindow` / `PAINTSTRUCT` / `BeginPaint` / window messages and ANSI A/W macros. GDI calls are compile-only no-ops (#16 owns a real blit).
- Allowlist `lib/window.cpp` (73/254). IME hide stays `rs2_ime_hide` (#104). No SDL2 on check.

Closes #110.

## Test plan
- [x] `./scripts/check.sh` green locally (26/26 tests, `lib/window.cpp` compiled)
- [ ] CI `check` matrix (macOS + Linux)


Made with [Cursor](https://cursor.com)