### PR TITLE
Add FFP GLSL GL program link API that fails closed without OpenGL (#111)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/ffp_fvf.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_glsl.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_program.cpp"
+  "${CMAKE_SOURCE_DIR}/port/ffp_gl.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_audio.cpp"
@@ -102,8 +103,12 @@ target_compile_options(railsim2_native PRIVATE
 target_compile_definitions(railsim2_native PRIVATE
   RS2_PORTABLE_COMPILE_FIREWALL=1
   NOMINMAX
+  RS2_HAVE_OPENGL=$<BOOL:${RS2_HAVE_OPENGL}>
 )
 target_link_libraries(railsim2_native PRIVATE Iconv::Iconv)
+if(RS2_HAVE_OPENGL)
+  target_link_libraries(railsim2_native PRIVATE OpenGL::GL)
+endif()
 
 # Link skeleton: POSIX main only. Allowlisted game objects compile into
 # railsim2_native.a but are not linked yet — they still need udx globals
@@ -334,6 +339,28 @@ target_compile_options(rs2_ffp_program_test PRIVATE -Wall -Wextra)
 target_compile_definitions(rs2_ffp_program_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
 
 add_test(NAME rs2_ffp_program_self_test COMMAND rs2_ffp_program_test --self-test)
+
+# Link interned FFP GLSL (#111). check/CI: RS2_HAVE_OPENGL off, no SDL window.
+# The test TU always compiles with RS2_HAVE_OPENGL=0 so ctest verifies no-GL
+# failure even when the runtime preset found OpenGL for railsim2_native.
+add_executable(rs2_ffp_gl_test
+  port/ffp_gl_test.cpp
+  port/ffp_gl.cpp
+  port/ffp_program.cpp
+  port/ffp_glsl.cpp
+  port/ffp_state.cpp
+  port/ffp_fvf.cpp)
+target_include_directories(rs2_ffp_gl_test SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_ffp_gl_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_gl_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_gl_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_gl_test PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
+  RS2_HAVE_OPENGL=0)
+
+add_test(NAME rs2_ffp_gl_self_test COMMAND rs2_ffp_gl_test --self-test)
 
 # CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
 add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -280,12 +280,24 @@ ctest: `rs2_ffp_glsl_self_test` (`port/ffp_glsl_test.cpp --self-test`).
 | `rs2_ffp_program_vs` / `rs2_ffp_program_fs` | Interned NUL-terminated sources; must match `#88` for that key. |
 | `IDirect3DDevice8::DrawPrimitiveUP` | Calls `rs2_ffp_draw_primitive_up`. The UP record stores `shader_key` and the interned handle. Draw stays a CPU record. |
 
-`lib/graphic.cpp` / `lib/vertex.cpp` stay off the allowlist. SDL2 stays off the check preset. Real GL program link + VBO upload is the next `#5` slice.
+`lib/graphic.cpp` / `lib/vertex.cpp` stay off the allowlist. SDL2 stays off the check preset. GL program link is `#111` (`port/ffp_gl.*`). VBO upload / draw is the next `#5` slice.
 
 ctest: `rs2_ffp_program_self_test` (`port/ffp_program_test.cpp --self-test`).
 
+## GL program link (port, #111)
+
+Interned `#88` VS/FS (`rs2_ffp_program_vs` / `_fs`) can be linked to a GL program in `port/ffp_gl.*`. There is still no VBO, draw, or SDL window.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_gl_link(handle, &program)` | Link interned GLSL. `RS2_HAVE_OPENGL` off (`check` / CI) always fails and writes `0`. When on, `glCreateShader` / `glLinkProgram`; the caller must already have a current GL context. |
+
+`check` does not search or link OpenGL. `runtime` may set `RS2_HAVE_OPENGL` when `find_package(OpenGL)` succeeds. `port/ffp_gl.cpp` still compiles on `check` (the GL calls are `#if`'d out). The ctest does not create an SDL window.
+
+ctest: `rs2_ffp_gl_self_test` (`port/ffp_gl_test.cpp --self-test`). Verifies link failure without GL.
+
 ## What #5 should implement next
 
-1. **M3 required tier (GL)** -- Link interned `#88` VS/FS (`rs2_ffp_program_vs` / `_fs`) to a real GL program, upload `Rs2FfpUpRecord` through a dynamic VBO, and pick the variant from `Rs2FfpUpRecord.program` / `shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), and the program intern + stub draw hook (#92) are already in `port/`. SDL2 stays off the check preset.
+1. **M3 required tier (GL)** -- Upload `Rs2FfpUpRecord` through a dynamic VBO, bind the program from `rs2_ffp_gl_link`, and pick the variant from `Rs2FfpUpRecord.program` / `shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), and GL program link (#111) are already in `port/`. SDL2 stays off the check preset.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_gl.cpp
+++ b/port/ffp_gl.cpp
@@ -1,0 +1,84 @@
+// Link interned FFP VS/FS. GL entry points are runtime-only.
+
+#include "ffp_gl.h"
+
+#ifndef RS2_HAVE_OPENGL
+#define RS2_HAVE_OPENGL 0
+#endif
+
+#if RS2_HAVE_OPENGL
+#if defined(__APPLE__)
+#define GL_SILENCE_DEPRECATION 1
+#include <OpenGL/gl3.h>
+#else
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/glcorearb.h>
+#endif
+#include <unordered_map>
+#endif
+
+bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program) {
+	if (out_program) *out_program = 0;
+	if (!handle || !out_program) return false;
+	if (!rs2_ffp_program_vs(handle) || !rs2_ffp_program_fs(handle)) return false;
+
+#if !RS2_HAVE_OPENGL
+	return false;
+#else
+	static std::unordered_map<Rs2FfpProgramHandle, unsigned> linked;
+	const auto found = linked.find(handle);
+	if (found != linked.end()) {
+		*out_program = found->second;
+		return true;
+	}
+
+	const char *vs_src = rs2_ffp_program_vs(handle);
+	const char *fs_src = rs2_ffp_program_fs(handle);
+
+	const GLuint vs = glCreateShader(GL_VERTEX_SHADER);
+	if (vs == 0) return false;
+	glShaderSource(vs, 1, &vs_src, nullptr);
+	glCompileShader(vs);
+	GLint ok = GL_FALSE;
+	glGetShaderiv(vs, GL_COMPILE_STATUS, &ok);
+	if (!ok) {
+		glDeleteShader(vs);
+		return false;
+	}
+
+	const GLuint fs = glCreateShader(GL_FRAGMENT_SHADER);
+	if (fs == 0) {
+		glDeleteShader(vs);
+		return false;
+	}
+	glShaderSource(fs, 1, &fs_src, nullptr);
+	glCompileShader(fs);
+	glGetShaderiv(fs, GL_COMPILE_STATUS, &ok);
+	if (!ok) {
+		glDeleteShader(vs);
+		glDeleteShader(fs);
+		return false;
+	}
+
+	const GLuint prog = glCreateProgram();
+	if (prog == 0) {
+		glDeleteShader(vs);
+		glDeleteShader(fs);
+		return false;
+	}
+	glAttachShader(prog, vs);
+	glAttachShader(prog, fs);
+	glLinkProgram(prog);
+	glDeleteShader(vs);
+	glDeleteShader(fs);
+	glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+	if (!ok) {
+		glDeleteProgram(prog);
+		return false;
+	}
+
+	*out_program = static_cast<unsigned>(prog);
+	linked.emplace(handle, *out_program);
+	return true;
+#endif
+}

--- a/port/ffp_gl.h
+++ b/port/ffp_gl.h
@@ -1,0 +1,16 @@
+// Link interned FFP GLSL to a GL program (#111, parent #5).
+// No VBO, draw, or SDL window. check/CI leave RS2_HAVE_OPENGL off.
+
+#pragma once
+
+#include "ffp_program.h"
+
+// Link interned VS/FS from rs2_ffp_program_for_key into a GL program name.
+//
+// RS2_HAVE_OPENGL off (check/CI): always false; writes 0 when out_program.
+// RS2_HAVE_OPENGL on: glCreateShader / glLinkProgram. Caller must already
+// have a current GL context. This API does not create a window.
+//
+// out_program receives the GL program name (0 on failure). Null handle,
+// null out_program, or missing interned sources fail.
+bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program);

--- a/port/ffp_gl_test.cpp
+++ b/port/ffp_gl_test.cpp
@@ -1,0 +1,51 @@
+// No-GL FFP program link self-test (#111). Does not create an SDL window.
+
+#include "ffp_fvf.h"
+#include "ffp_gl.h"
+#include "ffp_program.h"
+#include "ffp_state.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool no_gl_link_fails() {
+	rs2_ffp_state_reset();
+	const std::uint64_t key = rs2_ffp_shader_key(RS2_FVF_TL);
+	Rs2FfpProgramHandle h = nullptr;
+	if (!expect(rs2_ffp_program_for_key(key, &h) && h != nullptr, "intern"))
+		return false;
+
+	unsigned prog = 0xFFFFFFFFu;
+	if (!expect(!rs2_ffp_gl_link(h, &prog) && prog == 0, "interned no-GL"))
+		return false;
+
+	prog = 0xFFFFFFFFu;
+	if (!expect(!rs2_ffp_gl_link(nullptr, &prog) && prog == 0, "null handle"))
+		return false;
+
+	if (!expect(!rs2_ffp_gl_link(h, nullptr), "null out")) return false;
+	if (!expect(!rs2_ffp_gl_link(nullptr, nullptr), "null both")) return false;
+
+	return true;
+}
+
+int self_test() {
+	if (!no_gl_link_fails()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}


### PR DESCRIPTION
## Summary
- Adds `rs2_ffp_gl_link` in `port/ffp_gl.*` so interned VS/FS from `rs2_ffp_program_for_key` can become a GL program when `RS2_HAVE_OPENGL` is on.
- `check` / CI keep OpenGL off: the TU still compiles, the API returns false, and `rs2_ffp_gl_self_test` verifies no-GL failure without creating an SDL window.
- Documents the seam in `docs/porting/ffp-render-states.md`. VBO / draw / SDL window stay for a later #5 slice.

Closes #111

## Test plan
- [x] `./scripts/check.sh` green locally
- [x] `rs2_ffp_gl_self_test` passes (link fails, `out_program == 0`, no SDL window)
- [ ] CI `check` on macOS + Linux


Made with [Cursor](https://cursor.com)