### PR TITLE
Add FFP UP VBO draw API that fails closed without OpenGL (#114)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,9 +340,10 @@ target_compile_definitions(rs2_ffp_program_test PRIVATE RS2_PORTABLE_COMPILE_FIR
 
 add_test(NAME rs2_ffp_program_self_test COMMAND rs2_ffp_program_test --self-test)
 
-# Link interned FFP GLSL (#111). check/CI: RS2_HAVE_OPENGL off, no SDL window.
-# The test TU always compiles with RS2_HAVE_OPENGL=0 so ctest verifies no-GL
-# failure even when the runtime preset found OpenGL for railsim2_native.
+# Link interned FFP GLSL (#111) and draw UP records through a VBO (#114).
+# check/CI: RS2_HAVE_OPENGL off, no SDL window. The test TU always compiles
+# with RS2_HAVE_OPENGL=0 so ctest verifies no-GL link/draw failure even when
+# the runtime preset found OpenGL for railsim2_native.
 add_executable(rs2_ffp_gl_test
   port/ffp_gl_test.cpp
   port/ffp_gl.cpp

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -280,13 +280,13 @@ ctest: `rs2_ffp_glsl_self_test` (`port/ffp_glsl_test.cpp --self-test`).
 | `rs2_ffp_program_vs` / `rs2_ffp_program_fs` | Interned NUL-terminated sources; must match `#88` for that key. |
 | `IDirect3DDevice8::DrawPrimitiveUP` | Calls `rs2_ffp_draw_primitive_up`. The UP record stores `shader_key` and the interned handle. Draw stays a CPU record. |
 
-`lib/graphic.cpp` / `lib/vertex.cpp` stay off the allowlist. SDL2 stays off the check preset. GL program link is `#111` (`port/ffp_gl.*`). VBO upload / draw is the next `#5` slice.
+`lib/graphic.cpp` / `lib/vertex.cpp` stay off the allowlist. SDL2 stays off the check preset. GL program link is `#111` (`port/ffp_gl.*`). VBO upload / draw is `#114`.
 
 ctest: `rs2_ffp_program_self_test` (`port/ffp_program_test.cpp --self-test`).
 
 ## GL program link (port, #111)
 
-Interned `#88` VS/FS (`rs2_ffp_program_vs` / `_fs`) can be linked to a GL program in `port/ffp_gl.*`. There is still no VBO, draw, or SDL window.
+Interned `#88` VS/FS (`rs2_ffp_program_vs` / `_fs`) can be linked to a GL program in `port/ffp_gl.*`. VBO upload / `glDrawArrays` is `#114`. There is still no SDL window.
 
 | API | Role |
 |-----|------|
@@ -296,8 +296,20 @@ Interned `#88` VS/FS (`rs2_ffp_program_vs` / `_fs`) can be linked to a GL progra
 
 ctest: `rs2_ffp_gl_self_test` (`port/ffp_gl_test.cpp --self-test`). Verifies link failure without GL.
 
+## GL UP draw / dynamic VBO (port, #114)
+
+A CPU `Rs2FfpUpRecord` can be uploaded through a 16-slot streaming VBO+VAO ring and issued as `glDrawArrays`. Client arrays (`glVertexAttribPointer` with a client pointer) are not used; the pointer argument is a VBO offset.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_gl_draw(record)` | Validate the record, then draw. `RS2_HAVE_OPENGL` off (`check` / CI) always fails. When on: `rs2_ffp_gl_link(record->program)`, `glBufferData` (`GL_STREAM_DRAW`), bind FVF attributes at the `#88` locations (0 position ... 5 tex1; diffuse is `GL_BGRA` / `UNSIGNED_BYTE` / normalized), `glDrawArrays`. Caller must already have a current GL context. |
+
+`IDirect3DDevice8::DrawPrimitiveUP` stays a CPU record. This slice does not create an SDL window, bind textures, or Present / SwapBuffers. `check` still compiles `port/ffp_gl.cpp` with the GL calls `#if`'d out.
+
+ctest: `rs2_ffp_gl_self_test` also verifies draw failure without GL (no SDL window).
+
 ## What #5 should implement next
 
-1. **M3 required tier (GL)** -- Upload `Rs2FfpUpRecord` through a dynamic VBO, bind the program from `rs2_ffp_gl_link`, and pick the variant from `Rs2FfpUpRecord.program` / `shader_key` until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), and GL program link (#111) are already in `port/`. SDL2 stays off the check preset.
+1. **M3 required tier (window / sample)** -- Create an SDL window + GL context, set FFP uniforms, bind textures, and Present until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), GL program link (#111), and UP VBO draw (#114) are already in `port/`. SDL2 stays off the check preset.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_gl.cpp
+++ b/port/ffp_gl.cpp
@@ -1,6 +1,9 @@
-// Link interned FFP VS/FS. GL entry points are runtime-only.
+// Link interned FFP VS/FS and draw UP records. GL entry points are
+// runtime-only.
 
 #include "ffp_gl.h"
+
+#include <cstdint>
 
 #ifndef RS2_HAVE_OPENGL
 #define RS2_HAVE_OPENGL 0
@@ -16,6 +19,105 @@
 #endif
 #include <unordered_map>
 #endif
+
+namespace {
+
+bool known_prim(DWORD prim_type) {
+	switch (prim_type) {
+	case D3DPT_POINTLIST:
+	case D3DPT_LINELIST:
+	case D3DPT_LINESTRIP:
+	case D3DPT_TRIANGLELIST:
+	case D3DPT_TRIANGLESTRIP:
+	case D3DPT_TRIANGLEFAN:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool record_ready(const Rs2FfpUpRecord *record, Rs2FfpLayout *layout) {
+	if (!record || !record->vertices || !record->program) return false;
+	if (record->stride == 0 || record->bytes == 0) return false;
+	if (record->bytes % record->stride != 0) return false;
+	if (!known_prim(record->prim_type)) return false;
+	if (!rs2_ffp_layout(record->fvf, layout)) return false;
+	if (layout->stride != record->stride) return false;
+	return true;
+}
+
+#if RS2_HAVE_OPENGL
+GLenum gl_prim(DWORD prim_type) {
+	switch (prim_type) {
+	case D3DPT_POINTLIST:
+		return GL_POINTS;
+	case D3DPT_LINELIST:
+		return GL_LINES;
+	case D3DPT_LINESTRIP:
+		return GL_LINE_STRIP;
+	case D3DPT_TRIANGLELIST:
+		return GL_TRIANGLES;
+	case D3DPT_TRIANGLESTRIP:
+		return GL_TRIANGLE_STRIP;
+	case D3DPT_TRIANGLEFAN:
+		return GL_TRIANGLE_FAN;
+	default:
+		return 0;
+	}
+}
+
+void bind_attr(GLuint loc, bool present, UINT off, GLint size, GLenum type,
+               GLboolean norm, GLsizei stride) {
+	if (!present) {
+		glDisableVertexAttribArray(loc);
+		return;
+	}
+	glEnableVertexAttribArray(loc);
+	glVertexAttribPointer(loc, size, type, norm, stride,
+	                      reinterpret_cast<const void *>(static_cast<std::uintptr_t>(off)));
+}
+
+void bind_layout(const Rs2FfpLayout &layout) {
+	const GLsizei stride = static_cast<GLsizei>(layout.stride);
+	bind_attr(0, (layout.attrs & RS2_FFP_ATTR_POSITION) != 0, layout.off_position, 3,
+	          GL_FLOAT, GL_FALSE, stride);
+	bind_attr(1, (layout.attrs & RS2_FFP_ATTR_RHW) != 0, layout.off_rhw, 1, GL_FLOAT,
+	          GL_FALSE, stride);
+	bind_attr(2, (layout.attrs & RS2_FFP_ATTR_NORMAL) != 0, layout.off_normal, 3,
+	          GL_FLOAT, GL_FALSE, stride);
+	// D3DCOLOR is 0xAARRGGBB; LE memory is B,G,R,A. GL_BGRA as size is the
+	// core-profile unpack into shader vec4 (R,G,B,A). Not a client array:
+	// the pointer is a VBO offset (ARRAY_BUFFER is bound).
+	if (layout.attrs & RS2_FFP_ATTR_DIFFUSE) {
+		glEnableVertexAttribArray(3);
+		glVertexAttribPointer(3, GL_BGRA, GL_UNSIGNED_BYTE, GL_TRUE, stride,
+		                      reinterpret_cast<const void *>(
+		                          static_cast<std::uintptr_t>(layout.off_diffuse)));
+	} else {
+		glDisableVertexAttribArray(3);
+	}
+	bind_attr(4, (layout.attrs & RS2_FFP_ATTR_TEX0) != 0, layout.off_tex0, 2, GL_FLOAT,
+	          GL_FALSE, stride);
+	bind_attr(5, (layout.attrs & RS2_FFP_ATTR_TEX1) != 0, layout.off_tex1, 2, GL_FLOAT,
+	          GL_FALSE, stride);
+}
+
+struct VboSlot {
+	GLuint vao = 0;
+	GLuint vbo = 0;
+};
+
+constexpr unsigned kVboRing = 16;
+
+bool ensure_slot(VboSlot *slot) {
+	if (slot->vao != 0 && slot->vbo != 0) return true;
+	if (slot->vao == 0) glGenVertexArrays(1, &slot->vao);
+	if (slot->vbo == 0) glGenBuffers(1, &slot->vbo);
+	return slot->vao != 0 && slot->vbo != 0;
+}
+#endif
+
+}  // namespace
 
 bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program) {
 	if (out_program) *out_program = 0;
@@ -79,6 +181,39 @@ bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program) {
 
 	*out_program = static_cast<unsigned>(prog);
 	linked.emplace(handle, *out_program);
+	return true;
+#endif
+}
+
+bool rs2_ffp_gl_draw(const Rs2FfpUpRecord *record) {
+	Rs2FfpLayout layout{};
+	if (!record_ready(record, &layout)) return false;
+
+#if !RS2_HAVE_OPENGL
+	return false;
+#else
+	unsigned prog = 0;
+	if (!rs2_ffp_gl_link(record->program, &prog) || prog == 0) return false;
+	const GLenum mode = gl_prim(record->prim_type);
+	if (mode == 0) return false;
+
+	static VboSlot ring[kVboRing];
+	static unsigned head = 0;
+	VboSlot &slot = ring[head];
+	head = (head + 1u) % kVboRing;
+	if (!ensure_slot(&slot)) return false;
+
+	glUseProgram(static_cast<GLuint>(prog));
+	glBindVertexArray(slot.vao);
+	glBindBuffer(GL_ARRAY_BUFFER, slot.vbo);
+	glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(record->bytes),
+	             record->vertices, GL_STREAM_DRAW);
+	bind_layout(layout);
+	const GLsizei nvert = static_cast<GLsizei>(record->bytes / record->stride);
+	glDrawArrays(mode, 0, nvert);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glBindVertexArray(0);
+	glUseProgram(0);
 	return true;
 #endif
 }

--- a/port/ffp_gl.h
+++ b/port/ffp_gl.h
@@ -1,9 +1,9 @@
-// Link interned FFP GLSL to a GL program (#111, parent #5).
-// No VBO, draw, or SDL window. check/CI leave RS2_HAVE_OPENGL off.
+// Link interned FFP GLSL and draw a CPU UP record through a VBO ring
+// (#111 / #114, parent #5). check/CI leave RS2_HAVE_OPENGL off.
 
 #pragma once
 
-#include "ffp_program.h"
+#include "ffp_fvf.h"
 
 // Link interned VS/FS from rs2_ffp_program_for_key into a GL program name.
 //
@@ -14,3 +14,15 @@
 // out_program receives the GL program name (0 on failure). Null handle,
 // null out_program, or missing interned sources fail.
 bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program);
+
+// Upload record->vertices through a dynamic VBO ring and glDrawArrays.
+//
+// RS2_HAVE_OPENGL off (check/CI): always false after record validation.
+// RS2_HAVE_OPENGL on: rs2_ffp_gl_link(record->program), glBufferData into
+// a 16-slot VBO+VAO ring (no client arrays), bind FVF attributes at the
+// #88 locations, glDrawArrays. Caller must already have a current GL
+// context. This API does not create a window or call Present.
+//
+// IDirect3DDevice8::DrawPrimitiveUP stays a CPU record; it does not call
+// this function.
+bool rs2_ffp_gl_draw(const Rs2FfpUpRecord *record);

--- a/port/ffp_gl_test.cpp
+++ b/port/ffp_gl_test.cpp
@@ -1,4 +1,5 @@
-// No-GL FFP program link self-test (#111). Does not create an SDL window.
+// No-GL FFP program link / UP draw self-test (#111 / #114).
+// Does not create an SDL window.
 
 #include "ffp_fvf.h"
 #include "ffp_gl.h"
@@ -10,6 +11,13 @@
 #include <cstring>
 
 namespace {
+
+using Color = std::uint32_t;
+
+struct VtxTL {
+	float x, y, z, rhw;
+	Color d;
+};
 
 bool expect(bool ok, const char *label) {
 	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
@@ -37,8 +45,42 @@ bool no_gl_link_fails() {
 	return true;
 }
 
+bool no_gl_draw_fails() {
+	rs2_ffp_state_reset();
+	rs2_ffp_up_reset();
+	if (!expect(!rs2_ffp_gl_draw(nullptr), "null record")) return false;
+
+	VtxTL verts[2] = {{0, 0, 0, 1, 0xFFFFFFFFu}, {10, 5, 0, 1, 0xFF00FF00u}};
+	if (!expect(rs2_ffp_set_fvf(RS2_FVF_TL) == S_OK, "set FVF_TL")) return false;
+
+	IDirect3DDevice8 dev;
+	if (!expect(dev.DrawPrimitiveUP(D3DPT_LINELIST, 1, verts, sizeof(VtxTL)) ==
+	                S_OK,
+	            "CPU DrawPrimitiveUP"))
+		return false;
+
+	const Rs2FfpUpRecord *rec = rs2_ffp_up_last();
+	if (!expect(rec != nullptr && rec->program != nullptr && rec->vertices != nullptr,
+	            "up record"))
+		return false;
+	if (!expect(!rs2_ffp_gl_draw(rec), "recorded no-GL draw")) return false;
+
+	Rs2FfpUpRecord bad = *rec;
+	bad.vertices = nullptr;
+	if (!expect(!rs2_ffp_gl_draw(&bad), "null vertices")) return false;
+	bad = *rec;
+	bad.program = nullptr;
+	if (!expect(!rs2_ffp_gl_draw(&bad), "null program")) return false;
+	bad = *rec;
+	bad.prim_type = 0;
+	if (!expect(!rs2_ffp_gl_draw(&bad), "bad prim")) return false;
+
+	return true;
+}
+
 int self_test() {
 	if (!no_gl_link_fails()) return 1;
+	if (!no_gl_draw_fails()) return 1;
 	return 0;
 }
 

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -245,7 +245,7 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetTexture(DWORD, IDirect3DTexture8*) { return S_OK; }
   HRESULT GetTexture(DWORD, IDirect3DBaseTexture8**) { return S_OK; }
   HRESULT DrawPrimitive(D3DPRIMITIVETYPE, UINT, UINT) { return S_OK; }
-  // CPU record + interned program handle. No GL link / VBO.
+  // CPU record + interned program handle. No auto GL draw (no window).
   HRESULT DrawPrimitiveUP(D3DPRIMITIVETYPE type, UINT count, const void *data,
                           UINT stride) {
     return rs2_ffp_draw_primitive_up(type, count, data, stride);


### PR DESCRIPTION
## Summary
- Adds `rs2_ffp_gl_draw` in `port/ffp_gl.*` so a CPU `Rs2FfpUpRecord` can be uploaded through a 16-slot dynamic VBO+VAO ring, have FVF attributes bound, and issued as `glDrawArrays` when `RS2_HAVE_OPENGL` is on. Client arrays are not used.
- `check` / CI keep OpenGL off: the TU still compiles, the API returns false, and `rs2_ffp_gl_self_test` verifies no-GL draw failure without creating an SDL window. `IDirect3DDevice8::DrawPrimitiveUP` stays a CPU record.
- Documents the seam in `docs/porting/ffp-render-states.md`. SDL window / Present / texture bind stay for a later #5 slice.

Closes #114

## Test plan
- [x] `./scripts/check.sh` green locally
- [x] `rs2_ffp_gl_self_test` passes (link and draw fail without GL; DrawPrimitiveUP still records; no SDL window)
- [ ] CI `check` on macOS + Linux


Made with [Cursor](https://cursor.com)