### PR TITLE
Add FFP SDL window + GL 3.3 core context API without pulling SDL2 into check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/ffp_glsl.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_program.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_gl.cpp"
+  "${CMAKE_SOURCE_DIR}/port/ffp_window.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_audio.cpp"
@@ -104,10 +105,14 @@ target_compile_definitions(railsim2_native PRIVATE
   RS2_PORTABLE_COMPILE_FIREWALL=1
   NOMINMAX
   RS2_HAVE_OPENGL=$<BOOL:${RS2_HAVE_OPENGL}>
+  RS2_HAVE_SDL2=$<BOOL:${RS2_HAVE_SDL2}>
 )
 target_link_libraries(railsim2_native PRIVATE Iconv::Iconv)
 if(RS2_HAVE_OPENGL)
   target_link_libraries(railsim2_native PRIVATE OpenGL::GL)
+endif()
+if(RS2_HAVE_SDL2)
+  target_link_libraries(railsim2_native PRIVATE SDL2::SDL2)
 endif()
 
 # Link skeleton: POSIX main only. Allowlisted game objects compile into
@@ -362,6 +367,24 @@ target_compile_definitions(rs2_ffp_gl_test PRIVATE
   RS2_HAVE_OPENGL=0)
 
 add_test(NAME rs2_ffp_gl_self_test COMMAND rs2_ffp_gl_test --self-test)
+
+# SDL window + GL 3.3 core context (#116). check/CI: both feature flags
+# off, no SDL window. The test TU always compiles with RS2_HAVE_SDL2=0
+# and RS2_HAVE_OPENGL=0 so ctest verifies create/present/destroy failure
+# even when the runtime preset found SDL2/GL for railsim2_native.
+add_executable(rs2_ffp_window_test
+  port/ffp_window_test.cpp
+  port/ffp_window.cpp)
+target_include_directories(rs2_ffp_window_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_window_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_window_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_window_test PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
+  RS2_HAVE_SDL2=0
+  RS2_HAVE_OPENGL=0)
+
+add_test(NAME rs2_ffp_window_self_test COMMAND rs2_ffp_window_test --self-test)
 
 # CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
 add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -308,8 +308,22 @@ A CPU `Rs2FfpUpRecord` can be uploaded through a 16-slot streaming VBO+VAO ring 
 
 ctest: `rs2_ffp_gl_self_test` also verifies draw failure without GL (no SDL window).
 
+## SDL window / GL context (port, #116)
+
+`rs2_ffp_gl_link` / `rs2_ffp_gl_draw` need a current GL context. `port/ffp_window.*` creates an SDL window and a GL 3.3 core context and makes it current. `check` / CI still do not search or link SDL2 / OpenGL.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_window_create(w, h, title, &window)` | `RS2_HAVE_SDL2` off or `RS2_HAVE_OPENGL` off: fail and write null. Both on: SDL window + GL 3.3 core (`SDL_GL_CONTEXT_PROFILE_CORE`), make current. |
+| `rs2_ffp_window_present(window)` | `SDL_GL_SwapWindow`. Fails without SDL/GL or a valid handle. |
+| `rs2_ffp_window_destroy(window)` | Delete context + window. Fails without SDL/GL or a null handle. |
+
+`IDirect3DDevice8::Present` stays a no-op. This slice does not call SwapBuffers from Present, bind textures, poll SDL events into `rs2_input`, or draw Sample.rs2. `check` still compiles `port/ffp_window.cpp` with the SDL calls `#if`'d out. `runtime` passes `RS2_HAVE_SDL2` and links `SDL2::SDL2` only when SDL2 was found.
+
+ctest: `rs2_ffp_window_self_test` (`port/ffp_window_test.cpp --self-test`). Verifies create / present / destroy failure without SDL/GL (no window).
+
 ## What #5 should implement next
 
-1. **M3 required tier (window / sample)** -- Create an SDL window + GL context, set FFP uniforms, bind textures, and Present until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), GL program link (#111), and UP VBO draw (#114) are already in `port/`. SDL2 stays off the check preset.
+1. **M3 required tier (sample)** -- Set FFP uniforms, bind textures, and Present until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), GL program link (#111), UP VBO draw (#114), and the SDL window + GL 3.3 context (#116) are already in `port/`. SDL2 stays off the check preset. Do not auto-wire `DrawPrimitiveUP` to `rs2_ffp_gl_draw` or `Present` to `rs2_ffp_window_present` until a later slice.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_window.cpp
+++ b/port/ffp_window.cpp
@@ -1,0 +1,120 @@
+// SDL window + GL 3.3 core context. SDL/GL entry points are runtime-only.
+
+#include "ffp_window.h"
+
+#ifndef RS2_HAVE_SDL2
+#define RS2_HAVE_SDL2 0
+#endif
+#ifndef RS2_HAVE_OPENGL
+#define RS2_HAVE_OPENGL 0
+#endif
+
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
+#include <SDL.h>
+#endif
+
+struct Rs2FfpWindow {
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
+	SDL_Window *window = nullptr;
+	SDL_GLContext context = nullptr;
+#endif
+};
+
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
+namespace {
+int g_sdl_video_refs = 0;
+
+void teardown_video() {
+	if (g_sdl_video_refs > 0) {
+		--g_sdl_video_refs;
+	}
+	if (g_sdl_video_refs == 0) {
+		SDL_QuitSubSystem(SDL_INIT_VIDEO);
+	}
+}
+}  // namespace
+#endif
+
+bool rs2_ffp_window_create(int width, int height, const char *title,
+                           Rs2FfpWindowHandle *out_window) {
+	if (out_window) *out_window = nullptr;
+	if (width <= 0 || height <= 0 || !out_window) return false;
+
+#if !RS2_HAVE_SDL2 || !RS2_HAVE_OPENGL
+	(void)title;
+	return false;
+#else
+	if (g_sdl_video_refs == 0) {
+		if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) return false;
+	}
+	++g_sdl_video_refs;
+
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+#if defined(__APPLE__)
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
+#endif
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+	const char *name = title ? title : "RailSim2";
+	SDL_Window *win = SDL_CreateWindow(name, SDL_WINDOWPOS_UNDEFINED,
+	                                   SDL_WINDOWPOS_UNDEFINED, width, height,
+	                                   SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+	if (!win) {
+		teardown_video();
+		return false;
+	}
+
+	SDL_GLContext ctx = SDL_GL_CreateContext(win);
+	if (!ctx) {
+		SDL_DestroyWindow(win);
+		teardown_video();
+		return false;
+	}
+	if (SDL_GL_MakeCurrent(win, ctx) != 0) {
+		SDL_GL_DeleteContext(ctx);
+		SDL_DestroyWindow(win);
+		teardown_video();
+		return false;
+	}
+
+	auto *handle = new Rs2FfpWindow;
+	handle->window = win;
+	handle->context = ctx;
+	*out_window = handle;
+	return true;
+#endif
+}
+
+bool rs2_ffp_window_present(Rs2FfpWindowHandle window) {
+#if !RS2_HAVE_SDL2 || !RS2_HAVE_OPENGL
+	(void)window;
+	return false;
+#else
+	if (!window || !window->window || !window->context) return false;
+	if (SDL_GL_MakeCurrent(window->window, window->context) != 0) return false;
+	SDL_GL_SwapWindow(window->window);
+	return true;
+#endif
+}
+
+bool rs2_ffp_window_destroy(Rs2FfpWindowHandle window) {
+#if !RS2_HAVE_SDL2 || !RS2_HAVE_OPENGL
+	(void)window;
+	return false;
+#else
+	if (!window) return false;
+	if (window->context) {
+		SDL_GL_DeleteContext(window->context);
+		window->context = nullptr;
+	}
+	if (window->window) {
+		SDL_DestroyWindow(window->window);
+		window->window = nullptr;
+	}
+	delete window;
+	teardown_video();
+	return true;
+#endif
+}

--- a/port/ffp_window.h
+++ b/port/ffp_window.h
@@ -1,0 +1,28 @@
+// SDL window + GL 3.3 core context for FFP draw (#116, parent #5).
+// check/CI leave RS2_HAVE_SDL2 and RS2_HAVE_OPENGL off.
+
+#pragma once
+
+struct Rs2FfpWindow;
+
+// Opaque window + GL context. Null is invalid.
+using Rs2FfpWindowHandle = Rs2FfpWindow *;
+
+// Create an SDL window with a GL 3.3 core context and make it current.
+//
+// RS2_HAVE_SDL2 off or RS2_HAVE_OPENGL off (check/CI): always false; writes
+// null when out_window.
+// Both on: SDL_CreateWindow + SDL_GL_CreateContext (3.3 core), make current.
+// width/height must be > 0. Null title becomes "RailSim2". Null out_window
+// fails.
+//
+// IDirect3DDevice8::Present stays a no-op. This API does not call it, and
+// Present does not call this API.
+bool rs2_ffp_window_create(int width, int height, const char *title,
+                           Rs2FfpWindowHandle *out_window);
+
+// SDL_GL_SwapWindow. Fails if handle is null or SDL/GL is off.
+bool rs2_ffp_window_present(Rs2FfpWindowHandle window);
+
+// Destroy context + window. Null handle or SDL/GL off fails (false).
+bool rs2_ffp_window_destroy(Rs2FfpWindowHandle window);

--- a/port/ffp_window_test.cpp
+++ b/port/ffp_window_test.cpp
@@ -1,0 +1,67 @@
+// No-SDL / no-GL FFP window self-test (#116).
+// Does not create an SDL window.
+
+#include "ffp_window.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool no_sdl_gl_create_fails() {
+	Rs2FfpWindowHandle w = reinterpret_cast<Rs2FfpWindowHandle>(0x1);
+	if (!expect(!rs2_ffp_window_create(640, 480, "test", &w) && w == nullptr,
+	            "create both flags off"))
+		return false;
+
+	w = reinterpret_cast<Rs2FfpWindowHandle>(0x1);
+	if (!expect(!rs2_ffp_window_create(0, 480, "test", &w) && w == nullptr,
+	            "create zero width"))
+		return false;
+
+	w = reinterpret_cast<Rs2FfpWindowHandle>(0x1);
+	if (!expect(!rs2_ffp_window_create(640, -1, nullptr, &w) && w == nullptr,
+	            "create negative height"))
+		return false;
+
+	if (!expect(!rs2_ffp_window_create(640, 480, "test", nullptr),
+	            "create null out"))
+		return false;
+
+	return true;
+}
+
+bool no_sdl_gl_present_destroy_fail() {
+	if (!expect(!rs2_ffp_window_present(nullptr), "present null")) return false;
+	if (!expect(!rs2_ffp_window_destroy(nullptr), "destroy null")) return false;
+
+	Rs2FfpWindowHandle w = nullptr;
+	if (!expect(!rs2_ffp_window_create(800, 600, nullptr, &w) && w == nullptr,
+	            "create default title still fails"))
+		return false;
+	if (!expect(!rs2_ffp_window_present(w), "present after failed create"))
+		return false;
+	if (!expect(!rs2_ffp_window_destroy(w), "destroy after failed create"))
+		return false;
+
+	return true;
+}
+
+int self_test() {
+	if (!no_sdl_gl_create_fails()) return 1;
+	if (!no_sdl_gl_present_destroy_fail()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -255,6 +255,7 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetVertexShader(DWORD) { return S_OK; }
   HRESULT BeginScene() { return S_OK; }
   HRESULT EndScene() { return S_OK; }
+  // No GL/SDL swap. rs2_ffp_window_present is a separate port API (#116).
   HRESULT Present(const RECT*, const RECT*, HWND, void*) { return S_OK; }
   HRESULT GetViewport(D3DVIEWPORT8*) { return S_OK; }
   HRESULT SetViewport(const D3DVIEWPORT8*) { return S_OK; }


### PR DESCRIPTION
## Summary
- Add `rs2_ffp_window_create` / `present` / `destroy` in `port/ffp_window.*` so FFP GL draw can obtain a current GL 3.3 core context behind an SDL window.
- `RS2_HAVE_SDL2` or `RS2_HAVE_OPENGL` off fails without creating a window; `runtime` links `SDL2::SDL2` only when SDL2 is found. `IDirect3DDevice8::Present` stays a no-op.
- ctest `rs2_ffp_window_self_test` verifies no-SDL/no-GL create/present/destroy failure. `check` / CI / apt are unchanged.

Closes #116

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, cmake check, 28 ctests including `rs2_ffp_window_self_test`)
- [ ] CI macOS + Linux `check` matrix
- [ ] Optional local `cmake --preset runtime`: when SDL2 and OpenGL are both found, `rs2_ffp_window_create` can open a window (not required for this slice)


Made with [Cursor](https://cursor.com)