### PR TITLE
Add FFP transform shadow and uniform/tex-bind APIs without pulling OpenGL into check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,10 +345,11 @@ target_compile_definitions(rs2_ffp_program_test PRIVATE RS2_PORTABLE_COMPILE_FIR
 
 add_test(NAME rs2_ffp_program_self_test COMMAND rs2_ffp_program_test --self-test)
 
-# Link interned FFP GLSL (#111) and draw UP records through a VBO (#114).
+# Link interned FFP GLSL (#111), draw UP records through a VBO (#114),
+# and apply FFP uniforms / CPU RGBA bind (#118).
 # check/CI: RS2_HAVE_OPENGL off, no SDL window. The test TU always compiles
-# with RS2_HAVE_OPENGL=0 so ctest verifies no-GL link/draw failure even when
-# the runtime preset found OpenGL for railsim2_native.
+# with RS2_HAVE_OPENGL=0 so ctest verifies no-GL link/draw/apply/bind
+# failure even when the runtime preset found OpenGL for railsim2_native.
 add_executable(rs2_ffp_gl_test
   port/ffp_gl_test.cpp
   port/ffp_gl.cpp

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -322,8 +322,23 @@ ctest: `rs2_ffp_gl_self_test` also verifies draw failure without GL (no SDL wind
 
 ctest: `rs2_ffp_window_self_test` (`port/ffp_window_test.cpp --self-test`). Verifies create / present / destroy failure without SDL/GL (no window).
 
+## FFP uniforms / CPU texture bind (port, #118)
+
+GLSL uniforms declared in #88 (`u_world` / `u_view` / `u_proj` / `u_viewport` / `u_tex*_xform` / `u_ambient` / `u_tex0` / `u_tex1` / `u_alpharef`) now have a CPU shadow and a GL upload. `check` / CI still do not search or link OpenGL. File textures / DXT / `D3DXCreateTextureFromFile*` stay later.
+
+| API | Role |
+|-----|------|
+| `rs2_ffp_set_transform` / `_viewport` / `_material` | Shadow `D3DTS_WORLD` / `VIEW` / `PROJECTION` / `TEXTURE0` / `TEXTURE1`, `D3DVIEWPORT8`, and `D3DMATERIAL8`. Unknown transform type or a null pointer returns `E_FAIL`. Matrices are 16 floats, D3D row-major. |
+| `IDirect3DDevice8::SetTransform` / `SetViewport` / `SetMaterial` | Call the shadow (same pattern as `SetRenderState` in #80). `SetTexture` / `CreateTexture` stay no-ops. |
+| `rs2_ffp_gl_apply_uniforms(program)` | `RS2_HAVE_OPENGL` off: false. When on: `glUniform*` the snapshot (matrices, viewport xywh, ambient, alpharef / 255, material) and bind `u_tex0` / `u_tex1`. Unbound stages use a 1x1 white texel. |
+| `rs2_ffp_gl_tex_bind(stage, w, h, rgba)` | CPU RGBA8 to `GL_TEXTURE_2D` for stage 0/1. Off / bad stage / zero size / null pixels: false. Not a file loader. |
+
+`DrawPrimitiveUP` still does not call `rs2_ffp_gl_draw`. `Present` still does not swap. `port/ffp_gl.cpp` still compiles on `check` (GL calls `#if`'d out).
+
+ctest: `rs2_ffp_state_self_test` covers transform / viewport / material shadow without GL. `rs2_ffp_gl_self_test` covers apply/bind failure without GL (no SDL window).
+
 ## What #5 should implement next
 
-1. **M3 required tier (sample)** -- Set FFP uniforms, bind textures, and Present until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), GL program link (#111), UP VBO draw (#114), and the SDL window + GL 3.3 context (#116) are already in `port/`. SDL2 stays off the check preset. Do not auto-wire `DrawPrimitiveUP` to `rs2_ffp_gl_draw` or `Present` to `rs2_ffp_window_present` until a later slice.
+1. **M3 required tier (sample)** -- Wire uniforms + CPU textures through a windowed Present until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), GL program link (#111), UP VBO draw (#114), the SDL window + GL 3.3 context (#116), and FFP uniforms / 1x1 bind (#118) are already in `port/`. SDL2 stays off the check preset. Do not auto-wire `DrawPrimitiveUP` to `rs2_ffp_gl_draw` or `Present` to `rs2_ffp_window_present` until a later slice.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_gl.cpp
+++ b/port/ffp_gl.cpp
@@ -1,7 +1,9 @@
-// Link interned FFP VS/FS and draw UP records. GL entry points are
-// runtime-only.
+// Link interned FFP VS/FS, draw UP records, apply uniforms. GL entry
+// points are runtime-only.
 
 #include "ffp_gl.h"
+
+#include "ffp_state.h"
 
 #include <cstdint>
 
@@ -115,6 +117,65 @@ bool ensure_slot(VboSlot *slot) {
 	if (slot->vbo == 0) glGenBuffers(1, &slot->vbo);
 	return slot->vao != 0 && slot->vbo != 0;
 }
+
+void d3dcolor_rgba(DWORD c, float out[4]) {
+	out[0] = static_cast<float>((c >> 16) & 0xffu) / 255.0f;
+	out[1] = static_cast<float>((c >> 8) & 0xffu) / 255.0f;
+	out[2] = static_cast<float>(c & 0xffu) / 255.0f;
+	out[3] = static_cast<float>((c >> 24) & 0xffu) / 255.0f;
+}
+
+void set_mat4(GLuint prog, const char *name, const float *m) {
+	const GLint loc = glGetUniformLocation(prog, name);
+	if (loc < 0) return;
+	// D3D row-major last-row translation becomes a GL last-column
+	// translation when the 16 floats are read as column-major.
+	glUniformMatrix4fv(loc, 1, GL_FALSE, m);
+}
+
+void set_vec4(GLuint prog, const char *name, const float *v) {
+	const GLint loc = glGetUniformLocation(prog, name);
+	if (loc >= 0) glUniform4fv(loc, 1, v);
+}
+
+void set_vec3(GLuint prog, const char *name, float x, float y, float z) {
+	const GLint loc = glGetUniformLocation(prog, name);
+	if (loc >= 0) glUniform3f(loc, x, y, z);
+}
+
+void set_float(GLuint prog, const char *name, float v) {
+	const GLint loc = glGetUniformLocation(prog, name);
+	if (loc >= 0) glUniform1f(loc, v);
+}
+
+void set_int(GLuint prog, const char *name, int v) {
+	const GLint loc = glGetUniformLocation(prog, name);
+	if (loc >= 0) glUniform1i(loc, v);
+}
+
+GLuint g_tex[2] = {0, 0};
+GLuint g_white = 0;
+
+GLuint ensure_white() {
+	if (g_white != 0) return g_white;
+	glGenTextures(1, &g_white);
+	if (g_white == 0) return 0;
+	const unsigned char px[4] = {255, 255, 255, 255};
+	glBindTexture(GL_TEXTURE_2D, g_white);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
+	return g_white;
+}
+
+void bind_stage(unsigned stage, GLuint white) {
+	const GLuint name = (g_tex[stage] != 0) ? g_tex[stage] : white;
+	glActiveTexture(GL_TEXTURE0 + stage);
+	glBindTexture(GL_TEXTURE_2D, name);
+}
 #endif
 
 }  // namespace
@@ -214,6 +275,78 @@ bool rs2_ffp_gl_draw(const Rs2FfpUpRecord *record) {
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindVertexArray(0);
 	glUseProgram(0);
+	return true;
+#endif
+}
+
+bool rs2_ffp_gl_apply_uniforms(unsigned program) {
+#if !RS2_HAVE_OPENGL
+	(void)program;
+	return false;
+#else
+	if (program == 0) return false;
+	const Rs2FfpSnapshot *snap = rs2_ffp_state_get();
+	if (!snap) return false;
+
+	const GLuint prog = static_cast<GLuint>(program);
+	glUseProgram(prog);
+
+	set_mat4(prog, "u_world", snap->world);
+	set_mat4(prog, "u_view", snap->view);
+	set_mat4(prog, "u_proj", snap->proj);
+	set_mat4(prog, "u_tex0_xform", snap->tex0);
+	set_mat4(prog, "u_tex1_xform", snap->tex1);
+
+	const float vp[4] = {
+	    static_cast<float>(snap->viewport.X),
+	    static_cast<float>(snap->viewport.Y),
+	    static_cast<float>(snap->viewport.Width),
+	    static_cast<float>(snap->viewport.Height),
+	};
+	set_vec4(prog, "u_viewport", vp);
+
+	float ambient[4];
+	d3dcolor_rgba(snap->rs.ambient, ambient);
+	set_vec4(prog, "u_ambient", ambient);
+
+	float fog[4];
+	d3dcolor_rgba(snap->rs.fogcolor, fog);
+	set_vec4(prog, "u_fog_color", fog);
+
+	set_vec4(prog, "u_material_diffuse", snap->material.diffuse);
+	set_vec4(prog, "u_material_ambient", snap->material.ambient);
+	set_vec3(prog, "u_light_dir", 0.0f, 1.0f, 0.0f);
+	set_vec3(prog, "u_light_color", 1.0f, 1.0f, 1.0f);
+	set_float(prog, "u_alpharef", static_cast<float>(snap->rs.alpharef) / 255.0f);
+
+	const GLuint white = ensure_white();
+	if (white == 0) return false;
+	bind_stage(0, white);
+	bind_stage(1, white);
+	set_int(prog, "u_tex0", 0);
+	set_int(prog, "u_tex1", 1);
+	return true;
+#endif
+}
+
+bool rs2_ffp_gl_tex_bind(unsigned stage, unsigned width, unsigned height,
+                         const unsigned char *rgba) {
+	if (stage > 1 || width == 0 || height == 0 || !rgba) return false;
+#if !RS2_HAVE_OPENGL
+	return false;
+#else
+	if (g_tex[stage] == 0) {
+		glGenTextures(1, &g_tex[stage]);
+		if (g_tex[stage] == 0) return false;
+	}
+	glBindTexture(GL_TEXTURE_2D, g_tex[stage]);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, static_cast<GLsizei>(width),
+	             static_cast<GLsizei>(height), 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
 	return true;
 #endif
 }

--- a/port/ffp_gl.h
+++ b/port/ffp_gl.h
@@ -1,5 +1,5 @@
-// Link interned FFP GLSL and draw a CPU UP record through a VBO ring
-// (#111 / #114, parent #5). check/CI leave RS2_HAVE_OPENGL off.
+// Link interned FFP GLSL, draw a CPU UP record, and apply FFP uniforms
+// (#111 / #114 / #118, parent #5). check/CI leave RS2_HAVE_OPENGL off.
 
 #pragma once
 
@@ -26,3 +26,21 @@ bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program);
 // IDirect3DDevice8::DrawPrimitiveUP stays a CPU record; it does not call
 // this function.
 bool rs2_ffp_gl_draw(const Rs2FfpUpRecord *record);
+
+// Upload the CPU FFP snapshot (matrices, viewport, ambient, alpharef,
+// material) plus bound samplers into a linked GL program.
+//
+// RS2_HAVE_OPENGL off (check/CI): always false.
+// RS2_HAVE_OPENGL on: glUseProgram + glUniform*. program 0 fails.
+// Caller must already have a current GL context. Does not create a
+// window, draw, or Present.
+bool rs2_ffp_gl_apply_uniforms(unsigned program);
+
+// Upload CPU RGBA8 pixels to GL_TEXTURE_2D for sampler u_tex0 / u_tex1.
+// stage must be 0 or 1. Unbound stages use a 1x1 white texel on apply.
+//
+// RS2_HAVE_OPENGL off (check/CI): always false.
+// RS2_HAVE_OPENGL on: glTexImage2D. w/h must be > 0; rgba must be
+// w*h*4 bytes. This is not a file / DXT loader.
+bool rs2_ffp_gl_tex_bind(unsigned stage, unsigned width, unsigned height,
+                         const unsigned char *rgba);

--- a/port/ffp_gl_test.cpp
+++ b/port/ffp_gl_test.cpp
@@ -1,5 +1,5 @@
-// No-GL FFP program link / UP draw self-test (#111 / #114).
-// Does not create an SDL window.
+// No-GL FFP program link / UP draw / uniform apply self-test
+// (#111 / #114 / #118). Does not create an SDL window.
 
 #include "ffp_fvf.h"
 #include "ffp_gl.h"
@@ -78,9 +78,24 @@ bool no_gl_draw_fails() {
 	return true;
 }
 
+bool no_gl_apply_bind_fails() {
+	rs2_ffp_state_reset();
+	if (!expect(!rs2_ffp_gl_apply_uniforms(0), "apply 0")) return false;
+	if (!expect(!rs2_ffp_gl_apply_uniforms(1), "apply no-GL")) return false;
+
+	const unsigned char px[4] = {255, 0, 0, 255};
+	if (!expect(!rs2_ffp_gl_tex_bind(0, 1, 1, px), "bind no-GL")) return false;
+	if (!expect(!rs2_ffp_gl_tex_bind(1, 1, 1, px), "bind1 no-GL")) return false;
+	if (!expect(!rs2_ffp_gl_tex_bind(0, 1, 1, nullptr), "bind null")) return false;
+	if (!expect(!rs2_ffp_gl_tex_bind(2, 1, 1, px), "bind stage")) return false;
+	if (!expect(!rs2_ffp_gl_tex_bind(0, 0, 1, px), "bind size")) return false;
+	return true;
+}
+
 int self_test() {
 	if (!no_gl_link_fails()) return 1;
 	if (!no_gl_draw_fails()) return 1;
+	if (!no_gl_apply_bind_fails()) return 1;
 	return 0;
 }
 

--- a/port/ffp_state.cpp
+++ b/port/ffp_state.cpp
@@ -5,6 +5,7 @@
 #include "ffp_fvf.h"
 
 #include <cstdio>
+#include <cstring>
 
 namespace {
 
@@ -51,6 +52,29 @@ void apply_init_defaults(Rs2FfpSnapshot *s) {
 		st.textransform = D3DTTFF_DISABLE;
 		st.texcoordindex = D3DTSS_TCI_PASSTHRU;
 	}
+
+	const auto identity = [](float *m) {
+		std::memset(m, 0, 16 * sizeof(float));
+		m[0] = m[5] = m[10] = m[15] = 1.0f;
+	};
+	identity(s->world);
+	identity(s->view);
+	identity(s->proj);
+	identity(s->tex0);
+	identity(s->tex1);
+
+	s->viewport.X = 0;
+	s->viewport.Y = 0;
+	s->viewport.Width = 0;
+	s->viewport.Height = 0;
+	s->viewport.MinZ = 0.0f;
+	s->viewport.MaxZ = 1.0f;
+
+	std::memset(&s->material, 0, sizeof(s->material));
+	s->material.diffuse[0] = s->material.diffuse[1] = s->material.diffuse[2] =
+	    s->material.diffuse[3] = 1.0f;
+	s->material.ambient[0] = s->material.ambient[1] = s->material.ambient[2] =
+	    s->material.ambient[3] = 1.0f;
 }
 
 struct InitOnce {
@@ -350,6 +374,44 @@ HRESULT rs2_ffp_get_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE ty
 		*value = 0;
 		return unknown_fail("D3DTSS", static_cast<unsigned long>(type));
 	}
+}
+
+HRESULT rs2_ffp_set_transform(D3DTRANSFORMSTATETYPE type, const void *matrix) {
+	if (!matrix) return unknown_fail("D3DTS", static_cast<unsigned long>(type));
+	float *slot = nullptr;
+	switch (type) {
+	case D3DTS_WORLD:
+		slot = g_snap.world;
+		break;
+	case D3DTS_VIEW:
+		slot = g_snap.view;
+		break;
+	case D3DTS_PROJECTION:
+		slot = g_snap.proj;
+		break;
+	case D3DTS_TEXTURE0:
+		slot = g_snap.tex0;
+		break;
+	case D3DTS_TEXTURE1:
+		slot = g_snap.tex1;
+		break;
+	default:
+		return unknown_fail("D3DTS", static_cast<unsigned long>(type));
+	}
+	std::memcpy(slot, matrix, 16 * sizeof(float));
+	return S_OK;
+}
+
+HRESULT rs2_ffp_set_viewport(const D3DVIEWPORT8 *viewport) {
+	if (!viewport) return unknown_fail("viewport", 0);
+	g_snap.viewport = *viewport;
+	return S_OK;
+}
+
+HRESULT rs2_ffp_set_material(const void *material) {
+	if (!material) return unknown_fail("material", 0);
+	std::memcpy(&g_snap.material, material, sizeof(g_snap.material));
+	return S_OK;
 }
 
 std::uint64_t rs2_ffp_shader_key(DWORD fvf) {

--- a/port/ffp_state.h
+++ b/port/ffp_state.h
@@ -49,9 +49,26 @@ struct Rs2FfpRs {
 	DWORD fogend;
 };
 
+// D3DMATERIAL8 layout (d3dx8.h). Stored here so ffp_state.h stays on d3d8.h.
+struct Rs2FfpMaterial {
+	float diffuse[4];
+	float ambient[4];
+	float specular[4];
+	float emissive[4];
+	float power;
+};
+
 struct Rs2FfpSnapshot {
 	Rs2FfpRs rs;
 	Rs2FfpTexStage stage[2];
+	// Row-major D3D matrices (16 floats). Closed SetTransform set only.
+	float world[16];
+	float view[16];
+	float proj[16];
+	float tex0[16];
+	float tex1[16];
+	D3DVIEWPORT8 viewport;
+	Rs2FfpMaterial material;
 };
 
 // Restore InitRenderState defaults (lib/graphic.cpp).
@@ -64,6 +81,9 @@ HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE ty
                                         DWORD value);
 HRESULT rs2_ffp_get_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
                                         DWORD *value);
+HRESULT rs2_ffp_set_transform(D3DTRANSFORMSTATETYPE type, const void *matrix);
+HRESULT rs2_ffp_set_viewport(const D3DVIEWPORT8 *viewport);
+HRESULT rs2_ffp_set_material(const void *material);
 
 // Packed FVF + core-state key. Ambient / alpharef / fog distances stay as
 // uniforms on the snapshot, not variant bits. Unknown / deferred FVF returns 0.

--- a/port/ffp_state_test.cpp
+++ b/port/ffp_state_test.cpp
@@ -3,9 +3,14 @@
 #include "ffp_fvf.h"
 #include "ffp_state.h"
 
+#include <d3dx8.h>
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+
+static_assert(sizeof(Rs2FfpMaterial) == sizeof(D3DMATERIAL8),
+              "Rs2FfpMaterial matches D3DMATERIAL8");
 
 namespace {
 
@@ -201,12 +206,121 @@ bool up_snapshot_ok() {
 	return true;
 }
 
+bool identity16(const float *m) {
+	for (int i = 0; i < 16; ++i) {
+		const float want = (i % 5 == 0) ? 1.0f : 0.0f;
+		if (m[i] != want) return false;
+	}
+	return true;
+}
+
+bool transform_shadow_ok() {
+	rs2_ffp_state_reset();
+	const Rs2FfpSnapshot *s = rs2_ffp_state_get();
+	if (!expect(s != nullptr, "snapshot xform")) return false;
+	if (!expect(identity16(s->world) && identity16(s->view) && identity16(s->proj) &&
+	                identity16(s->tex0) && identity16(s->tex1),
+	            "identity matrices"))
+		return false;
+	if (!expect(s->viewport.Width == 0 && s->viewport.MaxZ == 1.0f,
+	            "default viewport"))
+		return false;
+	if (!expect(s->material.diffuse[0] == 1.0f && s->material.ambient[3] == 1.0f,
+	            "default material"))
+		return false;
+
+	float world[16] = {};
+	world[0] = 2.0f;
+	world[5] = 3.0f;
+	world[10] = 4.0f;
+	world[15] = 1.0f;
+	world[12] = 9.0f;
+	if (!expect(rs2_ffp_set_transform(D3DTS_WORLD, world) == S_OK, "set world"))
+		return false;
+	if (!expect(s->world[0] == 2.0f && s->world[5] == 3.0f && s->world[12] == 9.0f &&
+	                s->world[15] == 1.0f,
+	            "world shadow"))
+		return false;
+	if (!expect(identity16(s->view), "view untouched")) return false;
+
+	IDirect3DDevice8 dev;
+	float view[16] = {};
+	view[0] = view[5] = view[10] = view[15] = 1.0f;
+	view[13] = 7.0f;
+	if (!expect(dev.SetTransform(D3DTS_VIEW, view) == S_OK, "hook view")) return false;
+	if (!expect(s->view[13] == 7.0f, "view shadow")) return false;
+
+	float proj[16] = {};
+	proj[0] = proj[5] = proj[10] = proj[15] = 1.0f;
+	proj[11] = -1.0f;
+	if (!expect(dev.SetTransform(D3DTS_PROJECTION, proj) == S_OK, "hook proj"))
+		return false;
+	if (!expect(s->proj[11] == -1.0f, "proj shadow")) return false;
+
+	float tex0[16] = {};
+	tex0[0] = tex0[5] = tex0[10] = tex0[15] = 1.0f;
+	tex0[12] = 0.25f;
+	if (!expect(dev.SetTransform(D3DTS_TEXTURE0, tex0) == S_OK, "hook tex0"))
+		return false;
+	float tex1[16] = {};
+	tex1[0] = tex1[5] = tex1[10] = tex1[15] = 1.0f;
+	tex1[13] = 0.5f;
+	if (!expect(dev.SetTransform(D3DTS_TEXTURE1, tex1) == S_OK, "hook tex1"))
+		return false;
+	if (!expect(s->tex0[12] == 0.25f && s->tex1[13] == 0.5f, "tex shadow"))
+		return false;
+
+	if (!expect(rs2_ffp_set_transform(static_cast<D3DTRANSFORMSTATETYPE>(99),
+	                                  world) == E_FAIL,
+	            "unknown D3DTS"))
+		return false;
+	if (!expect(rs2_ffp_set_transform(D3DTS_WORLD, nullptr) == E_FAIL, "null matrix"))
+		return false;
+	if (!expect(s->world[12] == 9.0f, "unknown leaves world")) return false;
+
+	D3DVIEWPORT8 vp{};
+	vp.X = 10;
+	vp.Y = 20;
+	vp.Width = 320;
+	vp.Height = 240;
+	vp.MinZ = 0.0f;
+	vp.MaxZ = 1.0f;
+	if (!expect(dev.SetViewport(&vp) == S_OK, "hook viewport")) return false;
+	if (!expect(s->viewport.X == 10 && s->viewport.Y == 20 && s->viewport.Width == 320 &&
+	                s->viewport.Height == 240,
+	            "viewport shadow"))
+		return false;
+	if (!expect(rs2_ffp_set_viewport(nullptr) == E_FAIL, "null viewport")) return false;
+
+	Rs2FfpMaterial mat{};
+	mat.diffuse[0] = 0.1f;
+	mat.diffuse[1] = 0.2f;
+	mat.diffuse[2] = 0.3f;
+	mat.diffuse[3] = 1.0f;
+	mat.ambient[0] = 0.4f;
+	mat.power = 16.0f;
+	if (!expect(dev.SetMaterial(&mat) == S_OK, "hook material")) return false;
+	if (!expect(s->material.diffuse[1] == 0.2f && s->material.ambient[0] == 0.4f &&
+	                s->material.power == 16.0f,
+	            "material shadow"))
+		return false;
+	if (!expect(rs2_ffp_set_material(nullptr) == E_FAIL, "null material")) return false;
+
+	rs2_ffp_state_reset();
+	if (!expect(identity16(s->world) && s->viewport.Width == 0 &&
+	                s->material.diffuse[0] == 1.0f,
+	            "reset xform"))
+		return false;
+	return true;
+}
+
 int self_test() {
 	if (!defaults_ok()) return 1;
 	if (!hook_and_unknown_ok()) return 1;
 	if (!key_toggles_ok()) return 1;
 	if (!fvf_keys_ok()) return 1;
 	if (!up_snapshot_ok()) return 1;
+	if (!transform_shadow_ok()) return 1;
 	return 0;
 }
 

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -116,6 +116,7 @@ typedef DWORD D3DTEXTURETRANSFORMFLAGS;
 #define D3DTTFF_DISABLE 0
 #define D3DTTFF_COUNT2 2
 #define D3DTS_TEXTURE0 16
+#define D3DTS_TEXTURE1 17
 
 #define D3DTSS_TEXCOORDINDEX 11
 #define D3DTSS_TCI_PASSTHRU 0x00000000
@@ -222,6 +223,9 @@ HRESULT rs2_ffp_set_render_state(D3DRENDERSTATETYPE type, DWORD value);
 HRESULT rs2_ffp_get_render_state(D3DRENDERSTATETYPE type, DWORD* value);
 HRESULT rs2_ffp_set_texture_stage_state(DWORD stage, D3DTEXTURESTAGESTATETYPE type,
                                         DWORD value);
+HRESULT rs2_ffp_set_transform(D3DTRANSFORMSTATETYPE type, const void* matrix);
+HRESULT rs2_ffp_set_viewport(const D3DVIEWPORT8* viewport);
+HRESULT rs2_ffp_set_material(const void* material);
 
 // CPU UP ring + program intern (#74 / #92). Bodies in port/ffp_fvf.cpp.
 HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *data,
@@ -237,8 +241,10 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetTextureStageState(DWORD stage, D3DTEXTURESTAGESTATETYPE type, DWORD value) {
     return rs2_ffp_set_texture_stage_state(stage, type, value);
   }
-  HRESULT SetTransform(D3DTRANSFORMSTATETYPE, const void*) { return S_OK; }
-  HRESULT SetMaterial(const void*) { return S_OK; }
+  HRESULT SetTransform(D3DTRANSFORMSTATETYPE type, const void* matrix) {
+    return rs2_ffp_set_transform(type, matrix);
+  }
+  HRESULT SetMaterial(const void* material) { return rs2_ffp_set_material(material); }
   HRESULT SetLight(DWORD, const void*) { return S_OK; }
   HRESULT LightEnable(DWORD, BOOL) { return S_OK; }
   HRESULT Clear(DWORD, const void*, DWORD, D3DCOLOR, float, DWORD) { return S_OK; }
@@ -258,7 +264,9 @@ struct IDirect3DDevice8 : IUnknown {
   // No GL/SDL swap. rs2_ffp_window_present is a separate port API (#116).
   HRESULT Present(const RECT*, const RECT*, HWND, void*) { return S_OK; }
   HRESULT GetViewport(D3DVIEWPORT8*) { return S_OK; }
-  HRESULT SetViewport(const D3DVIEWPORT8*) { return S_OK; }
+  HRESULT SetViewport(const D3DVIEWPORT8* viewport) {
+    return rs2_ffp_set_viewport(viewport);
+  }
   HRESULT CreateTexture(UINT, UINT, UINT, DWORD, D3DFORMAT, DWORD, IDirect3DTexture8**) { return S_OK; }
   HRESULT CopyRects(IDirect3DSurface8*, const RECT*, UINT, IDirect3DSurface8*, const POINT*) { return S_OK; }
   HRESULT GetDeviceCaps(void*) { return S_OK; }


### PR DESCRIPTION
## Summary
- Shadow `D3DTS_WORLD` / `VIEW` / `PROJECTION` / `TEXTURE0` / `TEXTURE1`, viewport, and material on the CPU FFP snapshot. Unknown transform types and null pointers return `E_FAIL`. `IDirect3DDevice8::SetTransform` / `SetViewport` / `SetMaterial` call that shadow; `SetTexture` / `CreateTexture` stay no-ops.
- Add `rs2_ffp_gl_apply_uniforms(program)` and `rs2_ffp_gl_tex_bind(stage, w, h, rgba)`. With `RS2_HAVE_OPENGL` off they return false; when on they `glUniform*` the snapshot and upload CPU RGBA8 (unbound stages use a 1x1 white texel).
- ctest covers transform shadow without GL and apply/bind failure without GL. No SDL window. One section appended to `docs/porting/ffp-render-states.md`.

Closes #118

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, check preset, 28/28 ctest)
- [x] `rs2_ffp_state_self_test` asserts WORLD/VIEW/PROJECTION/TEXTURE0/TEXTURE1, viewport, material, unknown `D3DTS`, and reset
- [x] `rs2_ffp_gl_self_test` asserts `apply_uniforms` / `tex_bind` fail without GL (and reject bad stage / null / zero size)
- [ ] Runtime (`RS2_HAVE_OPENGL` on) is not exercised by check/CI; later slice wires draw + Present


Made with [Cursor](https://cursor.com)