### PR TITLE
Wire FFP DrawPrimitiveUP / Present / Clear onto GL without pulling SDL2 into check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,19 +329,25 @@ target_compile_definitions(rs2_ffp_glsl_test PRIVATE RS2_PORTABLE_COMPILE_FIREWA
 
 add_test(NAME rs2_ffp_glsl_self_test COMMAND rs2_ffp_glsl_test --self-test)
 
-# Interned FFP program handle + stub DrawPrimitiveUP (#92). No GL link.
+# Interned FFP program handle + stub DrawPrimitiveUP (#92). Device UP also
+# tries GL after the CPU record (#120); this TU links ffp_gl.cpp compiled
+# with RS2_HAVE_OPENGL=0 so the try is a no-op.
 add_executable(rs2_ffp_program_test
   port/ffp_program_test.cpp
   port/ffp_program.cpp
   port/ffp_glsl.cpp
   port/ffp_state.cpp
-  port/ffp_fvf.cpp)
+  port/ffp_fvf.cpp
+  port/ffp_gl.cpp)
 target_include_directories(rs2_ffp_program_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")
 target_include_directories(rs2_ffp_program_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
 target_compile_features(rs2_ffp_program_test PRIVATE cxx_std_17)
 target_compile_options(rs2_ffp_program_test PRIVATE -Wall -Wextra)
-target_compile_definitions(rs2_ffp_program_test PRIVATE RS2_PORTABLE_COMPILE_FIREWALL=1 NOMINMAX)
+target_compile_definitions(rs2_ffp_program_test PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
+  RS2_HAVE_OPENGL=0)
 
 add_test(NAME rs2_ffp_program_self_test COMMAND rs2_ffp_program_test --self-test)
 
@@ -386,6 +392,54 @@ target_compile_definitions(rs2_ffp_window_test PRIVATE
   RS2_HAVE_OPENGL=0)
 
 add_test(NAME rs2_ffp_window_self_test COMMAND rs2_ffp_window_test --self-test)
+
+# Wire DrawPrimitiveUP / Present / Clear / SetVertexShader (#120).
+# check/CI: OpenGL and SDL2 off, no SDL window. Present without a created
+# window is S_OK; DrawPrimitiveUP still records on the CPU.
+add_executable(rs2_ffp_device_test
+  port/ffp_device_test.cpp
+  port/ffp_gl.cpp
+  port/ffp_window.cpp
+  port/ffp_program.cpp
+  port/ffp_glsl.cpp
+  port/ffp_state.cpp
+  port/ffp_fvf.cpp)
+target_include_directories(rs2_ffp_device_test SYSTEM BEFORE PRIVATE
+  "${CMAKE_SOURCE_DIR}/port/stub")
+target_include_directories(rs2_ffp_device_test PRIVATE "${CMAKE_SOURCE_DIR}/port")
+target_compile_features(rs2_ffp_device_test PRIVATE cxx_std_17)
+target_compile_options(rs2_ffp_device_test PRIVATE -Wall -Wextra)
+target_compile_definitions(rs2_ffp_device_test PRIVATE
+  RS2_PORTABLE_COMPILE_FIREWALL=1
+  NOMINMAX
+  RS2_HAVE_OPENGL=0
+  RS2_HAVE_SDL2=0)
+
+add_test(NAME rs2_ffp_device_self_test COMMAND rs2_ffp_device_test --self-test)
+
+# Runtime-only smoke: solid UP triangle through create/draw/present/destroy.
+# Not added to ctest / CI. Missing SDL2 or OpenGL leaves the target out.
+if(RS2_RUNTIME AND RS2_HAVE_SDL2 AND RS2_HAVE_OPENGL)
+  add_executable(rs2_ffp_smoke
+    port/ffp_smoke.cpp
+    port/ffp_gl.cpp
+    port/ffp_window.cpp
+    port/ffp_program.cpp
+    port/ffp_glsl.cpp
+    port/ffp_state.cpp
+    port/ffp_fvf.cpp)
+  target_include_directories(rs2_ffp_smoke SYSTEM BEFORE PRIVATE
+    "${CMAKE_SOURCE_DIR}/port/stub")
+  target_include_directories(rs2_ffp_smoke PRIVATE "${CMAKE_SOURCE_DIR}/port")
+  target_compile_features(rs2_ffp_smoke PRIVATE cxx_std_17)
+  target_compile_options(rs2_ffp_smoke PRIVATE -Wall -Wextra)
+  target_compile_definitions(rs2_ffp_smoke PRIVATE
+    RS2_PORTABLE_COMPILE_FIREWALL=1
+    NOMINMAX
+    RS2_HAVE_OPENGL=1
+    RS2_HAVE_SDL2=1)
+  target_link_libraries(rs2_ffp_smoke PRIVATE OpenGL::GL SDL2::SDL2)
+endif()
 
 # CP932 <-> UTF-8 and closed _mbsicmp replacement (#75). No SDL.
 add_executable(rs2_text_test port/rs2_text_test.cpp port/rs2_text.cpp)

--- a/docs/porting/ffp-render-states.md
+++ b/docs/porting/ffp-render-states.md
@@ -333,12 +333,30 @@ GLSL uniforms declared in #88 (`u_world` / `u_view` / `u_proj` / `u_viewport` / 
 | `rs2_ffp_gl_apply_uniforms(program)` | `RS2_HAVE_OPENGL` off: false. When on: `glUniform*` the snapshot (matrices, viewport xywh, ambient, alpharef / 255, material) and bind `u_tex0` / `u_tex1`. Unbound stages use a 1x1 white texel. |
 | `rs2_ffp_gl_tex_bind(stage, w, h, rgba)` | CPU RGBA8 to `GL_TEXTURE_2D` for stage 0/1. Off / bad stage / zero size / null pixels: false. Not a file loader. |
 
-`DrawPrimitiveUP` still does not call `rs2_ffp_gl_draw`. `Present` still does not swap. `port/ffp_gl.cpp` still compiles on `check` (GL calls `#if`'d out).
+`DrawPrimitiveUP` still does not call `rs2_ffp_gl_draw` from the CPU helper. Device `DrawPrimitiveUP` tries GL after the CPU record (#120). `Present` still does not swap from this slice. `port/ffp_gl.cpp` still compiles on `check` (GL calls `#if`'d out).
 
 ctest: `rs2_ffp_state_self_test` covers transform / viewport / material shadow without GL. `rs2_ffp_gl_self_test` covers apply/bind failure without GL (no SDL window).
 
+## Device wire (port, #120)
+
+`IDirect3DDevice8` now calls the port APIs that earlier slices left unwired. `check` / CI still do not search or link SDL2 / OpenGL. GL and SDL failures are ignored; the D3D HRESULT stays the CPU result (`S_OK` for a successful UP record, and always `S_OK` for Present / Clear).
+
+| API | Role |
+|-----|------|
+| `DrawPrimitiveUP` | `rs2_ffp_draw_primitive_up` first. On `S_OK`, try `rs2_ffp_gl_apply_uniforms` + `rs2_ffp_gl_draw` (link the interned handle so uniforms have a GL program). No current GL context, or `RS2_HAVE_OPENGL` off: skip. |
+| `SetVertexShader(DWORD fvf)` | `rs2_ffp_set_fvf`. Closed FVF only; `FVF_S` / unknown still `E_FAIL`. |
+| `Present` | If `rs2_ffp_window_current()` is a live handle from `rs2_ffp_window_create`, `rs2_ffp_window_present`. Otherwise `S_OK` no-op. **Never auto-creates a window.** |
+| `Clear` | `glClear` of `TARGET` / `Z` when `RS2_HAVE_OPENGL` and `SDL_GL_GetCurrentContext` is non-null. Otherwise `S_OK` no-op. Stencil is not cleared. |
+| `rs2_ffp_window_current` | Last successful create that has not been destroyed. Null on `check`. |
+
+`rs2_ffp_window_create` remembers the handle. Destroy of that handle clears it. ctest does not create an SDL window.
+
+`rs2_ffp_smoke` is a runtime-only executable (solid `FVF_TL` UP triangle: create / Clear / DrawPrimitiveUP / Present / destroy). It is built only when `RS2_RUNTIME` and both `RS2_HAVE_SDL2` and `RS2_HAVE_OPENGL` are on. It is **not** a ctest and is not on CI.
+
+ctest: `rs2_ffp_device_self_test` (`port/ffp_device_test.cpp --self-test`). UP still records on the CPU. Present without a window is `S_OK` and does not create one.
+
 ## What #5 should implement next
 
-1. **M3 required tier (sample)** -- Wire uniforms + CPU textures through a windowed Present until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. FVF tables (#74), the state shadow (#80), GLSL source (#88), the program intern + stub draw hook (#92), GL program link (#111), UP VBO draw (#114), the SDL window + GL 3.3 context (#116), and FFP uniforms / 1x1 bind (#118) are already in `port/`. SDL2 stays off the check preset. Do not auto-wire `DrawPrimitiveUP` to `rs2_ffp_gl_draw` or `Present` to `rs2_ffp_window_present` until a later slice.
+1. **M3 required tier (sample)** -- Drive the wired device path until `Distribution/jp/RailSim2/Layout/Sample.rs2` renders without shadow, flare, or particles. Allowlist `lib/graphic.cpp` / `lib/vertex.cpp` / `lib/texture.cpp` / `lib/draw.cpp` in later slices. File textures / DXT stay later. SDL2 stays off the check preset.
 2. **Deferrable tier** -- Add stencil shadow pass, additive flare/particle blends, and `FVF_S` as separate slices after core parity.
 3. **Do not expand** -- No new render states in game code without updating this document; unknown FVF/state combos should fail in the shadow ([adr-backend.md](adr-backend.md)).

--- a/port/ffp_device_test.cpp
+++ b/port/ffp_device_test.cpp
@@ -1,0 +1,102 @@
+// Device wire self-test (#120). No SDL window: GL/Present failures are
+// ignored and HRESULT stays S_OK for CPU record / no-op Present / Clear.
+
+#include "ffp_fvf.h"
+#include "ffp_gl.h"
+#include "ffp_state.h"
+#include "ffp_window.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+using Color = std::uint32_t;
+
+struct VtxTL {
+	float x, y, z, rhw;
+	Color d;
+};
+
+bool expect(bool ok, const char *label) {
+	if (!ok) std::fprintf(stderr, "self-test: %s\n", label);
+	return ok;
+}
+
+bool set_vertex_shader_ok() {
+	rs2_ffp_up_reset();
+	IDirect3DDevice8 dev;
+	if (!expect(dev.SetVertexShader(RS2_FVF_S) != S_OK, "reject FVF_S"))
+		return false;
+	if (!expect(rs2_ffp_current_fvf() == 0, "FVF_S leaves fvf")) return false;
+	if (!expect(dev.SetVertexShader(RS2_FVF_TL) == S_OK, "set FVF_TL"))
+		return false;
+	if (!expect(rs2_ffp_current_fvf() == RS2_FVF_TL, "current FVF_TL"))
+		return false;
+	return true;
+}
+
+bool draw_up_records_without_gl() {
+	rs2_ffp_state_reset();
+	rs2_ffp_up_reset();
+	VtxTL verts[3] = {{0, 0, 0, 1, 0xFFFFFFFFu},
+	                  {10, 0, 0, 1, 0xFF00FF00u},
+	                  {5, 8, 0, 1, 0xFFFF0000u}};
+
+	IDirect3DDevice8 dev;
+	if (!expect(dev.SetVertexShader(RS2_FVF_TL) == S_OK, "fvf")) return false;
+	if (!expect(dev.DrawPrimitiveUP(D3DPT_TRIANGLELIST, 1, verts, sizeof(VtxTL)) ==
+	                S_OK,
+	            "UP HRESULT"))
+		return false;
+
+	const Rs2FfpUpRecord *rec = rs2_ffp_up_last();
+	if (!expect(rec != nullptr && rec->prim_type == D3DPT_TRIANGLELIST &&
+	                rec->prim_count == 1 && rec->vertices != nullptr &&
+	                rec->program != nullptr,
+	            "CPU record"))
+		return false;
+	if (!expect(!rs2_ffp_gl_draw(rec), "GL draw still fails")) return false;
+	return true;
+}
+
+bool present_clear_no_window() {
+	if (!expect(rs2_ffp_window_current() == nullptr, "no current window"))
+		return false;
+
+	IDirect3DDevice8 dev;
+	if (!expect(dev.Present(nullptr, nullptr, nullptr, nullptr) == S_OK,
+	            "Present no window"))
+		return false;
+	if (!expect(rs2_ffp_window_current() == nullptr, "Present did not create"))
+		return false;
+
+	if (!expect(dev.Clear(0, nullptr, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, 0, 1.0f,
+	                      0) == S_OK,
+	            "Clear no context"))
+		return false;
+	if (!expect(rs2_ffp_window_current() == nullptr, "Clear did not create"))
+		return false;
+
+	Rs2FfpWindowHandle w = reinterpret_cast<Rs2FfpWindowHandle>(0x1);
+	if (!expect(!rs2_ffp_window_create(640, 480, "check", &w) && w == nullptr,
+	            "create still fails"))
+		return false;
+	return true;
+}
+
+int self_test() {
+	if (!set_vertex_shader_ok()) return 1;
+	if (!draw_up_records_without_gl()) return 1;
+	if (!present_clear_no_window()) return 1;
+	return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--self-test") == 0) return self_test();
+	std::fprintf(stderr, "usage: %s --self-test\n", argv[0]);
+	return 2;
+}

--- a/port/ffp_gl.cpp
+++ b/port/ffp_gl.cpp
@@ -10,6 +10,13 @@
 #ifndef RS2_HAVE_OPENGL
 #define RS2_HAVE_OPENGL 0
 #endif
+#ifndef RS2_HAVE_SDL2
+#define RS2_HAVE_SDL2 0
+#endif
+
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
+#include <SDL.h>
+#endif
 
 #if RS2_HAVE_OPENGL
 #if defined(__APPLE__)
@@ -177,6 +184,14 @@ void bind_stage(unsigned stage, GLuint white) {
 	glBindTexture(GL_TEXTURE_2D, name);
 }
 #endif
+
+bool has_current_gl_context() {
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
+	return SDL_GL_GetCurrentContext() != nullptr;
+#else
+	return false;
+#endif
+}
 
 }  // namespace
 
@@ -348,5 +363,39 @@ bool rs2_ffp_gl_tex_bind(unsigned stage, unsigned width, unsigned height,
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, static_cast<GLsizei>(width),
 	             static_cast<GLsizei>(height), 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
 	return true;
+#endif
+}
+
+void rs2_ffp_gl_try_after_up() {
+	if (!has_current_gl_context()) return;
+	const Rs2FfpUpRecord *rec = rs2_ffp_up_last();
+	if (!rec) return;
+	unsigned prog = 0;
+	if (rs2_ffp_gl_link(rec->program, &prog) && prog != 0) {
+		(void)rs2_ffp_gl_apply_uniforms(prog);
+	}
+	(void)rs2_ffp_gl_draw(rec);
+}
+
+void rs2_ffp_gl_try_clear(DWORD flags, D3DCOLOR color, float z) {
+#if !RS2_HAVE_OPENGL
+	(void)flags;
+	(void)color;
+	(void)z;
+#else
+	if (!has_current_gl_context()) return;
+	GLbitfield mask = 0;
+	if (flags & D3DCLEAR_TARGET) {
+		glClearColor(static_cast<float>((color >> 16) & 0xffu) / 255.0f,
+		             static_cast<float>((color >> 8) & 0xffu) / 255.0f,
+		             static_cast<float>(color & 0xffu) / 255.0f,
+		             static_cast<float>((color >> 24) & 0xffu) / 255.0f);
+		mask |= GL_COLOR_BUFFER_BIT;
+	}
+	if (flags & D3DCLEAR_ZBUFFER) {
+		glClearDepth(static_cast<double>(z));
+		mask |= GL_DEPTH_BUFFER_BIT;
+	}
+	if (mask != 0) glClear(mask);
 #endif
 }

--- a/port/ffp_gl.h
+++ b/port/ffp_gl.h
@@ -23,8 +23,9 @@ bool rs2_ffp_gl_link(Rs2FfpProgramHandle handle, unsigned *out_program);
 // #88 locations, glDrawArrays. Caller must already have a current GL
 // context. This API does not create a window or call Present.
 //
-// IDirect3DDevice8::DrawPrimitiveUP stays a CPU record; it does not call
-// this function.
+// IDirect3DDevice8::DrawPrimitiveUP records on the CPU, then tries
+// rs2_ffp_gl_apply_uniforms + this function. GL false is ignored so
+// check/CI stay green without a context.
 bool rs2_ffp_gl_draw(const Rs2FfpUpRecord *record);
 
 // Upload the CPU FFP snapshot (matrices, viewport, ambient, alpharef,

--- a/port/ffp_smoke.cpp
+++ b/port/ffp_smoke.cpp
@@ -1,0 +1,79 @@
+// Runtime-only FFP smoke: solid UP triangle + create/draw/present/destroy.
+// Built when RS2_RUNTIME and SDL2+OpenGL were found. Not a ctest.
+
+#include "ffp_fvf.h"
+#include "ffp_window.h"
+
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+
+using Color = std::uint32_t;
+
+struct VtxTL {
+	float x, y, z, rhw;
+	Color d;
+};
+
+constexpr int kWidth = 640;
+constexpr int kHeight = 480;
+
+}  // namespace
+
+int main() {
+	Rs2FfpWindowHandle window = nullptr;
+	if (!rs2_ffp_window_create(kWidth, kHeight, "rs2_ffp_smoke", &window) ||
+	    !window) {
+		std::fprintf(stderr, "rs2_ffp_smoke: window create failed\n");
+		return 1;
+	}
+
+	IDirect3DDevice8 dev;
+	D3DVIEWPORT8 vp{};
+	vp.Width = static_cast<DWORD>(kWidth);
+	vp.Height = static_cast<DWORD>(kHeight);
+	vp.MinZ = 0.0f;
+	vp.MaxZ = 1.0f;
+	if (dev.SetViewport(&vp) != S_OK) {
+		std::fprintf(stderr, "rs2_ffp_smoke: SetViewport failed\n");
+		rs2_ffp_window_destroy(window);
+		return 1;
+	}
+	if (dev.SetRenderState(D3DRS_LIGHTING, FALSE) != S_OK ||
+	    dev.SetVertexShader(RS2_FVF_TL) != S_OK) {
+		std::fprintf(stderr, "rs2_ffp_smoke: state/FVF failed\n");
+		rs2_ffp_window_destroy(window);
+		return 1;
+	}
+
+	if (dev.Clear(0, nullptr, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, 0xFF202020u, 1.0f,
+	              0) != S_OK) {
+		std::fprintf(stderr, "rs2_ffp_smoke: Clear failed\n");
+		rs2_ffp_window_destroy(window);
+		return 1;
+	}
+
+	const VtxTL tri[3] = {
+	    {320.0f, 80.0f, 0.0f, 1.0f, 0xFF33CC66u},
+	    {120.0f, 400.0f, 0.0f, 1.0f, 0xFF33CC66u},
+	    {520.0f, 400.0f, 0.0f, 1.0f, 0xFF33CC66u},
+	};
+	if (dev.DrawPrimitiveUP(D3DPT_TRIANGLELIST, 1, tri, sizeof(VtxTL)) != S_OK) {
+		std::fprintf(stderr, "rs2_ffp_smoke: DrawPrimitiveUP failed\n");
+		rs2_ffp_window_destroy(window);
+		return 1;
+	}
+
+	if (dev.Present(nullptr, nullptr, nullptr, nullptr) != S_OK) {
+		std::fprintf(stderr, "rs2_ffp_smoke: Present failed\n");
+		rs2_ffp_window_destroy(window);
+		return 1;
+	}
+
+	if (!rs2_ffp_window_destroy(window) || rs2_ffp_window_current() != nullptr) {
+		std::fprintf(stderr, "rs2_ffp_smoke: destroy failed\n");
+		return 1;
+	}
+	return 0;
+}

--- a/port/ffp_window.cpp
+++ b/port/ffp_window.cpp
@@ -20,8 +20,10 @@ struct Rs2FfpWindow {
 #endif
 };
 
-#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
 namespace {
+Rs2FfpWindowHandle g_current = nullptr;
+
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
 int g_sdl_video_refs = 0;
 
 void teardown_video() {
@@ -32,8 +34,8 @@ void teardown_video() {
 		SDL_QuitSubSystem(SDL_INIT_VIDEO);
 	}
 }
-}  // namespace
 #endif
+}  // namespace
 
 bool rs2_ffp_window_create(int width, int height, const char *title,
                            Rs2FfpWindowHandle *out_window) {
@@ -82,9 +84,16 @@ bool rs2_ffp_window_create(int width, int height, const char *title,
 	auto *handle = new Rs2FfpWindow;
 	handle->window = win;
 	handle->context = ctx;
+	g_current = handle;
 	*out_window = handle;
 	return true;
 #endif
+}
+
+Rs2FfpWindowHandle rs2_ffp_window_current() { return g_current; }
+
+void rs2_ffp_window_try_present() {
+	if (g_current) (void)rs2_ffp_window_present(g_current);
 }
 
 bool rs2_ffp_window_present(Rs2FfpWindowHandle window) {
@@ -105,6 +114,7 @@ bool rs2_ffp_window_destroy(Rs2FfpWindowHandle window) {
 	return false;
 #else
 	if (!window) return false;
+	if (g_current == window) g_current = nullptr;
 	if (window->context) {
 		SDL_GL_DeleteContext(window->context);
 		window->context = nullptr;

--- a/port/ffp_window.h
+++ b/port/ffp_window.h
@@ -16,13 +16,17 @@ using Rs2FfpWindowHandle = Rs2FfpWindow *;
 // width/height must be > 0. Null title becomes "RailSim2". Null out_window
 // fails.
 //
-// IDirect3DDevice8::Present stays a no-op. This API does not call it, and
-// Present does not call this API.
+// A successful create is remembered as the current handle so
+// IDirect3DDevice8::Present can swap it. Present never calls create.
 bool rs2_ffp_window_create(int width, int height, const char *title,
                            Rs2FfpWindowHandle *out_window);
+
+// Last successful create that has not been destroyed. Null if none.
+Rs2FfpWindowHandle rs2_ffp_window_current();
 
 // SDL_GL_SwapWindow. Fails if handle is null or SDL/GL is off.
 bool rs2_ffp_window_present(Rs2FfpWindowHandle window);
 
 // Destroy context + window. Null handle or SDL/GL off fails (false).
+// Clears the current handle when it matches.
 bool rs2_ffp_window_destroy(Rs2FfpWindowHandle window);

--- a/port/ffp_window_test.cpp
+++ b/port/ffp_window_test.cpp
@@ -48,6 +48,8 @@ bool no_sdl_gl_present_destroy_fail() {
 		return false;
 	if (!expect(!rs2_ffp_window_destroy(w), "destroy after failed create"))
 		return false;
+	if (!expect(rs2_ffp_window_current() == nullptr, "current stays null"))
+		return false;
 
 	return true;
 }

--- a/port/stub/d3d8.h
+++ b/port/stub/d3d8.h
@@ -230,6 +230,12 @@ HRESULT rs2_ffp_set_material(const void* material);
 // CPU UP ring + program intern (#74 / #92). Bodies in port/ffp_fvf.cpp.
 HRESULT rs2_ffp_draw_primitive_up(DWORD prim_type, UINT prim_count, const void *data,
                                   UINT stride);
+HRESULT rs2_ffp_set_fvf(DWORD fvf);
+
+// Device wire (#120). GL/SDL failures are ignored; HRESULT stays the CPU result.
+void rs2_ffp_gl_try_after_up();
+void rs2_ffp_gl_try_clear(DWORD flags, D3DCOLOR color, float z);
+void rs2_ffp_window_try_present();
 
 struct IDirect3DDevice8 : IUnknown {
   HRESULT SetRenderState(D3DRENDERSTATETYPE type, DWORD value) {
@@ -247,22 +253,30 @@ struct IDirect3DDevice8 : IUnknown {
   HRESULT SetMaterial(const void* material) { return rs2_ffp_set_material(material); }
   HRESULT SetLight(DWORD, const void*) { return S_OK; }
   HRESULT LightEnable(DWORD, BOOL) { return S_OK; }
-  HRESULT Clear(DWORD, const void*, DWORD, D3DCOLOR, float, DWORD) { return S_OK; }
+  HRESULT Clear(DWORD, const void *, DWORD flags, D3DCOLOR color, float z, DWORD) {
+    rs2_ffp_gl_try_clear(flags, color, z);
+    return S_OK;
+  }
   HRESULT SetTexture(DWORD, IDirect3DTexture8*) { return S_OK; }
   HRESULT GetTexture(DWORD, IDirect3DBaseTexture8**) { return S_OK; }
   HRESULT DrawPrimitive(D3DPRIMITIVETYPE, UINT, UINT) { return S_OK; }
-  // CPU record + interned program handle. No auto GL draw (no window).
+  // CPU record, then try apply_uniforms + gl_draw. GL false is ignored.
   HRESULT DrawPrimitiveUP(D3DPRIMITIVETYPE type, UINT count, const void *data,
                           UINT stride) {
-    return rs2_ffp_draw_primitive_up(type, count, data, stride);
+    const HRESULT hr = rs2_ffp_draw_primitive_up(type, count, data, stride);
+    if (hr == S_OK) rs2_ffp_gl_try_after_up();
+    return hr;
   }
   HRESULT DrawIndexedPrimitive(D3DPRIMITIVETYPE, UINT, UINT, UINT, UINT, const void*) { return S_OK; }
   HRESULT SetStreamSource(UINT, IDirect3DVertexBuffer8*, UINT) { return S_OK; }
-  HRESULT SetVertexShader(DWORD) { return S_OK; }
+  HRESULT SetVertexShader(DWORD fvf) { return rs2_ffp_set_fvf(fvf); }
   HRESULT BeginScene() { return S_OK; }
   HRESULT EndScene() { return S_OK; }
-  // No GL/SDL swap. rs2_ffp_window_present is a separate port API (#116).
-  HRESULT Present(const RECT*, const RECT*, HWND, void*) { return S_OK; }
+  // Swap last rs2_ffp_window_create handle if any. Never auto-creates a window.
+  HRESULT Present(const RECT *, const RECT *, HWND, void *) {
+    rs2_ffp_window_try_present();
+    return S_OK;
+  }
   HRESULT GetViewport(D3DVIEWPORT8*) { return S_OK; }
   HRESULT SetViewport(const D3DVIEWPORT8* viewport) {
     return rs2_ffp_set_viewport(viewport);


### PR DESCRIPTION
## Summary
- `IDirect3DDevice8::DrawPrimitiveUP` still records on the CPU, then tries `rs2_ffp_gl_apply_uniforms` + `rs2_ffp_gl_draw`. `SetVertexShader(DWORD)` calls `rs2_ffp_set_fvf`. GL false is ignored so the HRESULT stays the CPU result.
- `Present` swaps `rs2_ffp_window_current()` when a window from `rs2_ffp_window_create` still exists; otherwise `S_OK`. It never auto-creates a window. `Clear` calls `glClear` for TARGET/Z only when OpenGL is on and a current SDL/GL context exists.
- ctest: `rs2_ffp_device_self_test` covers UP CPU records, Present/Clear without a window, and FVF_S rejection. Runtime-only `rs2_ffp_smoke` (solid UP triangle) is not on check/ctest/CI. One section on `docs/porting/ffp-render-states.md`.

Closes #120

## Test plan
- [x] `./scripts/check.sh` green (encoding-guard, check preset, 29/29 ctest including `rs2_ffp_device_self_test`)
- [x] Present without a created window is `S_OK` and does not create one
- [x] DrawPrimitiveUP still records on the CPU when GL is off
- [ ] Runtime smoke (`rs2_ffp_smoke`) needs local SDL2+OpenGL; not exercised by check/CI


Made with [Cursor](https://cursor.com)