### PR TITLE
Wire SDL2 input backend into rs2_input without pulling SDL2 into check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(railsim2_native STATIC ${RS2_NATIVE_SOURCES}
   "${CMAKE_SOURCE_DIR}/port/ffp_gl.cpp"
   "${CMAKE_SOURCE_DIR}/port/ffp_window.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_input.cpp"
+  "${CMAKE_SOURCE_DIR}/port/rs2_input_sdl.cpp"
   "${CMAKE_SOURCE_DIR}/port/wav_pcm.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_audio.cpp"
   "${CMAKE_SOURCE_DIR}/port/rs2_ime.cpp"
@@ -483,6 +484,7 @@ add_test(NAME rs2_wave_load_distribution COMMAND rs2_wave_load_test
 set_tests_properties(rs2_wave_load_distribution PROPERTIES SKIP_RETURN_CODE 77)
 
 # Stub keyboard/mouse/joy poll + ScanInputDevice merge (#82). No SDL.
+# SDL poll lives in rs2_input_sdl.cpp on railsim2_native when RS2_HAVE_SDL2.
 add_executable(rs2_input_test port/rs2_input_test.cpp port/rs2_input.cpp)
 target_include_directories(rs2_input_test SYSTEM BEFORE PRIVATE
   "${CMAKE_SOURCE_DIR}/port/stub")

--- a/docs/porting/input-seams.md
+++ b/docs/porting/input-seams.md
@@ -233,10 +233,17 @@ After `#8`, a reader should be able to answer: swap these functions and stub sym
 
 - **Issue**: [#82](https://github.com/lollipop-onl/railsim2-portable/issues/82) (parent [#8](https://github.com/lollipop-onl/railsim2-portable/issues/8))
 - **Entry**: `rs2_input_poll_once` / `rs2_input_scan_*` / `rs2_input_edge` in `port/rs2_input.h`
-- **Backend hooks**: `rs2_input_backend_*` (stub in `port/rs2_input.cpp`; SDL2 later replaces these five poll/cursor functions)
+- **Backend hooks**: `rs2_input_backend_*` (stub in `port/rs2_input.cpp`; SDL2 poll in `port/rs2_input_sdl.cpp` when `RS2_HAVE_SDL2`, see below)
 
 `lib/input.cpp` no longer calls DirectInput COM. `ScanInputDevice` still merges poll buffers, then `ScanKeyboard` / `ScanMouse` / `ScanJoyStick`. Cursor position is client coordinates from the backend (Win32 `GetCursorPos` + `ScreenToClient` later; injected in the stub). `GetKey` / `GetButton` / `GetJoy` keep `S_FREE`..`S_HOLD` via `rs2_input_edge`. `port/stub/dinput.h` now defines the inventory-missing `DIK_*` tokens (`DIK_5`..`DIK_8`, `DIK_A`/`W`/`X`/`C`/`V`/`B`, `DIK_F3`/`F5`/`F6`).
 
 The check preset links the stub only and does **not** start the original `CCrtThread` poll loop (`_beginthreadex` in `port/stub/process.h` would run it inline). `ScanInputDevice` already calls `InputPollOnce` when `g_InputPollCount==0`. Do not add SDL2 to the `check` preset. `MsgBox` / `MsgYesNo` stay sync `MessageBox` until [#12](https://github.com/lollipop-onl/railsim2-portable/issues/12).
 
 `rs2_input_self_test` covers `GetKey` edge/hold, `GetWheel` accumulation, client cursor + inside, joystick axis thresholds, and the stub-missing `DIK_*` constants.
+
+## SDL2 poll backend (`port/rs2_input_sdl.cpp`)
+
+- **Issue**: [#122](https://github.com/lollipop-onl/railsim2-portable/issues/122) (parent [#8](https://github.com/lollipop-onl/railsim2-portable/issues/8))
+- **On (`RS2_HAVE_SDL2`)**: `rs2_input_backend_poll_keys` / `_mouse` / `_get_cursor` / `_set_cursor` read SDL. Scancodes map through a closed table onto the `DIK_*` already in `port/stub/dinput.h` (M3 camera: arrows, WASD, HOME/END, PRIOR/NEXT, plus the rest of that stub set). Unknown scancodes stay 0. Mouse `DIM_LEFT` / `RIGHT` / `MIDDLE` come from `SDL_BUTTON_*`. Wheel is `SDL_MOUSEWHEEL.y * 120` (Win32 `WHEEL_DELTA`).
+- **Cursor**: if an FFP window exists, client coordinates come from that native `SDL_Window` (`SDL_GetMouseState` when it has mouse focus, else global minus window origin). `set_cursor` is `SDL_WarpMouseInWindow`. No FFP window: poll / get / set do not crash; cursor is the last `set_cursor` value. This TU never creates a window.
+- **Off (check/CI)**: existing stub in `port/rs2_input.cpp`. `rs2_input_self_test` stays on that path and does not link SDL2. Joystick stays stub. Do not add SDL2 to the `check` preset. `MsgBox` / IME / OpenAL are other issues.

--- a/lib/input.cpp
+++ b/lib/input.cpp
@@ -14,7 +14,7 @@ CRITICAL_SECTION g_InputPollCriticalSection;
 
 /*
  *	DirectInput no longer owns devices. Init wires the port backend
- *	(stub in check; SDL2 later) and keeps ScanInputDevice() as the
+ *	(stub in check; SDL2 when RS2_HAVE_SDL2) and keeps ScanInputDevice() as the
  *	per-frame merge. The Win32 poll thread is omitted here: the
  *	process.h _beginthreadex stub runs the start routine inline, and
  *	ScanInputDevice already calls InputPollOnce when the count is 0.

--- a/port/ffp_window.cpp
+++ b/port/ffp_window.cpp
@@ -92,6 +92,15 @@ bool rs2_ffp_window_create(int width, int height, const char *title,
 
 Rs2FfpWindowHandle rs2_ffp_window_current() { return g_current; }
 
+void *rs2_ffp_window_sdl_native() {
+#if RS2_HAVE_SDL2 && RS2_HAVE_OPENGL
+	if (!g_current) return nullptr;
+	return g_current->window;
+#else
+	return nullptr;
+#endif
+}
+
 void rs2_ffp_window_try_present() {
 	if (g_current) (void)rs2_ffp_window_present(g_current);
 }

--- a/port/ffp_window.h
+++ b/port/ffp_window.h
@@ -24,6 +24,11 @@ bool rs2_ffp_window_create(int width, int height, const char *title,
 // Last successful create that has not been destroyed. Null if none.
 Rs2FfpWindowHandle rs2_ffp_window_current();
 
+// Native SDL_Window* of the current FFP handle, or null. Typed as void* so
+// check TUs do not include SDL.h. Null when there is no current window or
+// when SDL/GL is off (check/CI).
+void *rs2_ffp_window_sdl_native();
+
 // SDL_GL_SwapWindow. Fails if handle is null or SDL/GL is off.
 bool rs2_ffp_window_present(Rs2FfpWindowHandle window);
 

--- a/port/ffp_window_test.cpp
+++ b/port/ffp_window_test.cpp
@@ -50,6 +50,8 @@ bool no_sdl_gl_present_destroy_fail() {
 		return false;
 	if (!expect(rs2_ffp_window_current() == nullptr, "current stays null"))
 		return false;
+	if (!expect(rs2_ffp_window_sdl_native() == nullptr, "native sdl null"))
+		return false;
 
 	return true;
 }

--- a/port/rs2_input.cpp
+++ b/port/rs2_input.cpp
@@ -2,13 +2,19 @@
 
 #include <cstring>
 
+#ifndef RS2_HAVE_SDL2
+#define RS2_HAVE_SDL2 0
+#endif
+
 namespace {
 
+#if !RS2_HAVE_SDL2
 unsigned char g_keys[RS2_INPUT_KEY_COUNT];
 unsigned char g_btn[RS2_INPUT_BTN_COUNT];
 long g_wheel_delta;
 int g_cur_x;
 int g_cur_y;
+#endif
 
 struct JoySample {
 	long lx;
@@ -22,14 +28,17 @@ JoySample g_joy[RS2_INPUT_MAX_JOY];
 }  // namespace
 
 void rs2_input_backend_reset() {
+#if !RS2_HAVE_SDL2
 	std::memset(g_keys, 0, sizeof(g_keys));
 	std::memset(g_btn, 0, sizeof(g_btn));
 	g_wheel_delta = 0;
 	g_cur_x = 0;
 	g_cur_y = 0;
+#endif
 	std::memset(g_joy, 0, sizeof(g_joy));
 }
 
+#if !RS2_HAVE_SDL2
 void rs2_input_backend_poll_keys(unsigned char out[RS2_INPUT_KEY_COUNT]) {
 	std::memcpy(out, g_keys, RS2_INPUT_KEY_COUNT);
 }
@@ -42,6 +51,7 @@ void rs2_input_backend_poll_mouse(unsigned char btn[RS2_INPUT_BTN_COUNT],
 	}
 	g_wheel_delta = 0;
 }
+#endif
 
 void rs2_input_backend_poll_joy(int n, long *lx, long *ly, long *lz,
                                 unsigned char buttons[RS2_INPUT_JOY_BTN]) {
@@ -58,6 +68,7 @@ void rs2_input_backend_poll_joy(int n, long *lx, long *ly, long *lz,
 	if (buttons) std::memcpy(buttons, g_joy[n].buttons, RS2_INPUT_JOY_BTN);
 }
 
+#if !RS2_HAVE_SDL2
 void rs2_input_backend_get_cursor(int *x, int *y) {
 	if (x) *x = g_cur_x;
 	if (y) *y = g_cur_y;
@@ -67,19 +78,34 @@ void rs2_input_backend_set_cursor(int x, int y) {
 	g_cur_x = x;
 	g_cur_y = y;
 }
+#endif
 
 void rs2_input_stub_set_key(int dik, int down) {
+#if !RS2_HAVE_SDL2
 	if (dik < 0 || dik >= RS2_INPUT_KEY_COUNT) return;
 	g_keys[dik] = down ? static_cast<unsigned char>(RS2_INPUT_DOWN) : 0;
+#else
+	(void)dik;
+	(void)down;
+#endif
 }
 
 void rs2_input_stub_set_button(int dim, int down) {
+#if !RS2_HAVE_SDL2
 	if (dim < 0 || dim >= RS2_INPUT_BTN_COUNT) return;
 	g_btn[dim] = down ? static_cast<unsigned char>(RS2_INPUT_DOWN) : 0;
+#else
+	(void)dim;
+	(void)down;
+#endif
 }
 
 void rs2_input_stub_add_wheel(long dz) {
+#if !RS2_HAVE_SDL2
 	g_wheel_delta += dz;
+#else
+	(void)dz;
+#endif
 }
 
 void rs2_input_stub_set_cursor(int x, int y) {

--- a/port/rs2_input.h
+++ b/port/rs2_input.h
@@ -1,7 +1,8 @@
-// Stub input backend + poll/scan merge (#82, parent #8).
+// Stub input backend + poll/scan merge (#82 / #122, parent #8).
 // See docs/porting/input-seams.md. Check preset links this stub only.
-// A later SDL2 TU can replace rs2_input_backend_* without changing merge
-// or GetKey / GetWheel / cursor semantics.
+// When RS2_HAVE_SDL2, port/rs2_input_sdl.cpp replaces poll_keys / poll_mouse
+// / get_cursor / set_cursor without changing merge or GetKey / GetWheel
+// / cursor semantics. Joystick stays the stub.
 
 #pragma once
 
@@ -25,7 +26,7 @@ enum {
 	RS2_INPUT_DIJ_BOTTOM = 5
 };
 
-// --- thin backend (stub here; SDL2 later) ---
+// --- thin backend (stub here; SDL2 poll_keys/mouse/cursor when RS2_HAVE_SDL2) ---
 
 void rs2_input_backend_reset();
 void rs2_input_backend_poll_keys(unsigned char out[RS2_INPUT_KEY_COUNT]);

--- a/port/rs2_input_sdl.cpp
+++ b/port/rs2_input_sdl.cpp
@@ -1,0 +1,178 @@
+// SDL2 keyboard/mouse/cursor backend (#122, parent #8).
+// check/CI leave RS2_HAVE_SDL2 off; stub poll stays in rs2_input.cpp.
+// This TU never creates an SDL window.
+
+#include "rs2_input.h"
+
+#ifndef RS2_HAVE_SDL2
+#define RS2_HAVE_SDL2 0
+#endif
+
+#if RS2_HAVE_SDL2
+
+#include "ffp_window.h"
+
+#include <dinput.h>
+#include <SDL.h>
+
+#include <cstring>
+
+namespace {
+
+int g_cur_x;
+int g_cur_y;
+unsigned char g_scan_to_dik[SDL_NUM_SCANCODES];
+bool g_map_ready;
+
+void init_scancode_map() {
+	if (g_map_ready) return;
+
+	g_scan_to_dik[SDL_SCANCODE_ESCAPE] = DIK_ESCAPE;
+	g_scan_to_dik[SDL_SCANCODE_1] = DIK_1;
+	g_scan_to_dik[SDL_SCANCODE_2] = DIK_2;
+	g_scan_to_dik[SDL_SCANCODE_3] = DIK_3;
+	g_scan_to_dik[SDL_SCANCODE_4] = DIK_4;
+	g_scan_to_dik[SDL_SCANCODE_5] = DIK_5;
+	g_scan_to_dik[SDL_SCANCODE_6] = DIK_6;
+	g_scan_to_dik[SDL_SCANCODE_7] = DIK_7;
+	g_scan_to_dik[SDL_SCANCODE_8] = DIK_8;
+	g_scan_to_dik[SDL_SCANCODE_0] = DIK_0;
+	g_scan_to_dik[SDL_SCANCODE_W] = DIK_W;
+	g_scan_to_dik[SDL_SCANCODE_Y] = DIK_Y;
+	g_scan_to_dik[SDL_SCANCODE_A] = DIK_A;
+	g_scan_to_dik[SDL_SCANCODE_BACKSPACE] = DIK_BACK;
+	g_scan_to_dik[SDL_SCANCODE_TAB] = DIK_TAB;
+	g_scan_to_dik[SDL_SCANCODE_RETURN] = DIK_RETURN;
+	g_scan_to_dik[SDL_SCANCODE_LCTRL] = DIK_LCONTROL;
+	g_scan_to_dik[SDL_SCANCODE_S] = DIK_S;
+	g_scan_to_dik[SDL_SCANCODE_D] = DIK_D;
+	g_scan_to_dik[SDL_SCANCODE_F] = DIK_F;
+	g_scan_to_dik[SDL_SCANCODE_X] = DIK_X;
+	g_scan_to_dik[SDL_SCANCODE_C] = DIK_C;
+	g_scan_to_dik[SDL_SCANCODE_V] = DIK_V;
+	g_scan_to_dik[SDL_SCANCODE_B] = DIK_B;
+	g_scan_to_dik[SDL_SCANCODE_N] = DIK_N;
+	g_scan_to_dik[SDL_SCANCODE_M] = DIK_M;
+	g_scan_to_dik[SDL_SCANCODE_Z] = DIK_Z;
+	g_scan_to_dik[SDL_SCANCODE_LSHIFT] = DIK_LSHIFT;
+	g_scan_to_dik[SDL_SCANCODE_SLASH] = DIK_SLASH;
+	g_scan_to_dik[SDL_SCANCODE_RSHIFT] = DIK_RSHIFT;
+	g_scan_to_dik[SDL_SCANCODE_LALT] = DIK_LALT;
+	g_scan_to_dik[SDL_SCANCODE_SPACE] = DIK_SPACE;
+	g_scan_to_dik[SDL_SCANCODE_F1] = DIK_F1;
+	g_scan_to_dik[SDL_SCANCODE_F2] = DIK_F2;
+	g_scan_to_dik[SDL_SCANCODE_F3] = DIK_F3;
+	g_scan_to_dik[SDL_SCANCODE_F4] = DIK_F4;
+	g_scan_to_dik[SDL_SCANCODE_F5] = DIK_F5;
+	g_scan_to_dik[SDL_SCANCODE_F6] = DIK_F6;
+	g_scan_to_dik[SDL_SCANCODE_F11] = DIK_F11;
+	g_scan_to_dik[SDL_SCANCODE_F12] = DIK_F12;
+	g_scan_to_dik[SDL_SCANCODE_HOME] = DIK_HOME;
+	g_scan_to_dik[SDL_SCANCODE_UP] = DIK_UP;
+	g_scan_to_dik[SDL_SCANCODE_PAGEUP] = DIK_PRIOR;
+	g_scan_to_dik[SDL_SCANCODE_LEFT] = DIK_LEFT;
+	g_scan_to_dik[SDL_SCANCODE_RIGHT] = DIK_RIGHT;
+	g_scan_to_dik[SDL_SCANCODE_END] = DIK_END;
+	g_scan_to_dik[SDL_SCANCODE_DOWN] = DIK_DOWN;
+	g_scan_to_dik[SDL_SCANCODE_PAGEDOWN] = DIK_NEXT;
+	g_scan_to_dik[SDL_SCANCODE_DELETE] = DIK_DELETE;
+	g_scan_to_dik[SDL_SCANCODE_RCTRL] = DIK_RCONTROL;
+	g_scan_to_dik[SDL_SCANCODE_RALT] = DIK_RALT;
+	g_scan_to_dik[SDL_SCANCODE_KP_0] = DIK_NUMPAD0;
+	g_scan_to_dik[SDL_SCANCODE_KP_1] = DIK_NUMPAD1;
+	g_scan_to_dik[SDL_SCANCODE_KP_2] = DIK_NUMPAD2;
+	g_scan_to_dik[SDL_SCANCODE_KP_3] = DIK_NUMPAD3;
+	g_scan_to_dik[SDL_SCANCODE_KP_4] = DIK_NUMPAD4;
+	g_scan_to_dik[SDL_SCANCODE_KP_ENTER] = DIK_NUMPADENTER;
+
+	g_map_ready = true;
+}
+
+SDL_Window *ffp_sdl_window() {
+	return static_cast<SDL_Window *>(rs2_ffp_window_sdl_native());
+}
+
+// Win32 WHEEL_DELTA. DIMOUSESTATE.lZ and GetWheel() callers use this scale.
+long drain_wheel() {
+	long delta = 0;
+	for (;;) {
+		SDL_Event ev[16];
+		const int n =
+		    SDL_PeepEvents(ev, 16, SDL_GETEVENT, SDL_MOUSEWHEEL, SDL_MOUSEWHEEL);
+		if (n <= 0) break;
+		for (int i = 0; i < n; ++i) {
+			long y = ev[i].wheel.y;
+			if (ev[i].wheel.direction == SDL_MOUSEWHEEL_FLIPPED) y = -y;
+			delta += y * 120;
+		}
+	}
+	return delta;
+}
+
+void read_client_cursor(SDL_Window *win, int *x, int *y) {
+	if (SDL_GetMouseFocus() == win) {
+		SDL_GetMouseState(x, y);
+		return;
+	}
+	int gx = 0;
+	int gy = 0;
+	int wx = 0;
+	int wy = 0;
+	SDL_GetGlobalMouseState(&gx, &gy);
+	SDL_GetWindowPosition(win, &wx, &wy);
+	*x = gx - wx;
+	*y = gy - wy;
+}
+
+}  // namespace
+
+void rs2_input_backend_poll_keys(unsigned char out[RS2_INPUT_KEY_COUNT]) {
+	std::memset(out, 0, RS2_INPUT_KEY_COUNT);
+	init_scancode_map();
+	SDL_PumpEvents();
+	int n = 0;
+	const Uint8 *state = SDL_GetKeyboardState(&n);
+	if (!state || n <= 0) return;
+	if (n > static_cast<int>(SDL_NUM_SCANCODES)) n = SDL_NUM_SCANCODES;
+	for (int i = 0; i < n; ++i) {
+		if (!state[i]) continue;
+		const unsigned char dik = g_scan_to_dik[i];
+		if (dik) out[dik] = static_cast<unsigned char>(RS2_INPUT_DOWN);
+	}
+}
+
+void rs2_input_backend_poll_mouse(unsigned char btn[RS2_INPUT_BTN_COUNT],
+                                  long *wheel_delta) {
+	std::memset(btn, 0, RS2_INPUT_BTN_COUNT);
+	SDL_PumpEvents();
+	const Uint32 m = SDL_GetMouseState(nullptr, nullptr);
+	if (m & SDL_BUTTON(SDL_BUTTON_LEFT)) {
+		btn[0] = static_cast<unsigned char>(RS2_INPUT_DOWN);
+	}
+	if (m & SDL_BUTTON(SDL_BUTTON_RIGHT)) {
+		btn[1] = static_cast<unsigned char>(RS2_INPUT_DOWN);
+	}
+	if (m & SDL_BUTTON(SDL_BUTTON_MIDDLE)) {
+		btn[2] = static_cast<unsigned char>(RS2_INPUT_DOWN);
+	}
+	if (wheel_delta) *wheel_delta = drain_wheel();
+}
+
+void rs2_input_backend_get_cursor(int *x, int *y) {
+	SDL_Window *win = ffp_sdl_window();
+	if (win) {
+		SDL_PumpEvents();
+		read_client_cursor(win, &g_cur_x, &g_cur_y);
+	}
+	if (x) *x = g_cur_x;
+	if (y) *y = g_cur_y;
+}
+
+void rs2_input_backend_set_cursor(int x, int y) {
+	g_cur_x = x;
+	g_cur_y = y;
+	SDL_Window *win = ffp_sdl_window();
+	if (win) SDL_WarpMouseInWindow(win, x, y);
+}
+
+#endif  // RS2_HAVE_SDL2


### PR DESCRIPTION
## Summary
- When `RS2_HAVE_SDL2` is on, `port/rs2_input_sdl.cpp` implements `rs2_input_backend_poll_keys` / `_mouse` / `_get_cursor` / `_set_cursor` from SDL (closed scancode → `DIK_*` table for M3 camera plus the rest of `port/stub/dinput.h`; unknown keys stay 0; mouse buttons + wheel × 120).
- Cursor uses the FFP `SDL_Window` when one exists (`rs2_ffp_window_sdl_native`); poll/get/set do not crash and do not create a window when none exists.
- Check/CI keep the stub backend. `rs2_input_self_test` is unchanged. Joystick stays stub. SDL2 is not added to check/apt.

Closes #122

## Test plan
- [x] `./scripts/check.sh` green (stub path, no SDL window)
- [x] `cmake --preset runtime` with SDL2 found; `railsim2_native` compiles `port/rs2_input_sdl.cpp`
- [ ] CI `check` on this PR
- [ ] Cursor auto-review


Made with [Cursor](https://cursor.com)